### PR TITLE
address regression in auth when consolidating to shared auth library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,19 @@ version when a release tag is promoted.
 ## Unreleased
 
 - No unreleased changes have been recorded yet.
+
+## 1.2.3
+
+### Security
+
+- Fixed a regression in default authentication behavior introduced when consolidating
+  service authentication into the shared mono-repo auth library. When SSO is enabled,
+  service endpoints now require authentication by default, with health checks and
+  metrics as explicit unauthenticated exceptions.
+- Added Envoy header removal for spoofable identity headers, including
+  `ssl-client-cert` and `X-Auth-*` headers, so legacy mTLS auth paths cannot be
+  reached by forging client-supplied headers.
+
+## 1.2.2
+
+- Official OSS release.

--- a/deploy/helm/templates/client-traffic-policy.yaml
+++ b/deploy/helm/templates/client-traffic-policy.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.gateway.enabled (eq (.Values.ingress.type | default "envoyGateway") "envoyGateway") }}
+{{- $policyName := include "nv-config-manager.componentName" (dict "root" . "component" "gateway-client-traffic") }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: {{ $policyName }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "nv-config-manager.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.gateway.name }}
+  headers:
+    earlyRequestHeaders:
+      remove:
+        # Strip spoofable identity headers before auth/routing. SecurityPolicy
+        # may add trusted X-Auth-Request-* headers later from verified JWT/OIDC claims.
+        - ssl-client-cert
+        - X-Auth-Request-Email
+        - X-Auth-Request-User
+        - X-Auth-Request-Groups
+        - X-Auth-Request-Preferred-Username
+        - X-Auth-Request-Name
+        - X-Auth-Request-Roles
+        - X-Auth-Request-Subject
+        - X-Auth-Request-Access-Token
+{{- end }}

--- a/deploy/helm/templates/security-policy.yaml
+++ b/deploy/helm/templates/security-policy.yaml
@@ -89,8 +89,9 @@ spec:
     maxAge: {{ $.root.Values.gateway.cors.maxAge | quote }}
   {{- end }}
   
-  # JWT validation - validate if present, extract claims to headers
-  # NO oidc block - requests without valid JWT get 401 (no redirect)
+  # JWT validation - validate if present, extract claims to headers.
+  # NO oidc block - requests without valid JWT are left to the service's
+  # own auth middleware, avoiding browser redirects on svc-* hostnames.
   jwt:
     optional: true
     providers:

--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -99,6 +99,7 @@ from typing import Any
 import jwt as pyjwt
 from cryptography import x509
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
 from jwt.types import Options as JWTDecodeOptions
 from pydantic import BaseModel
 
@@ -112,6 +113,18 @@ SSO_EMAIL_HEADER = "X-Auth-Request-Email"
 SSO_USER_HEADER = "X-Auth-Request-User"
 SSO_GROUPS_HEADER = "X-Auth-Request-Groups"
 MTLS_CERT_HEADER = "ssl-client-cert"
+
+DEFAULT_UNAUTHENTICATED_PATHS = frozenset(
+    {
+        "/health",
+        "/healthz",
+        "/ready",
+        "/readyz",
+        "/ping",
+        "/healthcheck",
+        "/metrics",
+    }
+)
 
 
 # ── Configuration dataclasses ────────────────────────────────────────────
@@ -633,10 +646,12 @@ def extract_identity(
 
 
 def get_sso_user(request: Request) -> str:
-    """Return the short username from any auth source, or ``"unknown"``.
+    """Return the short username from any auth source.
 
     Suitable for audit trails and commit messages where a full
-    ``SSOIdentity`` is not needed.
+    ``SSOIdentity`` is not needed.  Returns ``"anonymous"`` when auth is
+    disabled and no identity is present, or ``"unknown"`` when auth is enabled
+    but identity extraction failed.
     """
     identity = extract_identity(request, include_request_headers=accept_request_headers())
     if identity:
@@ -664,6 +679,27 @@ def accept_request_headers() -> bool:
     Reads ``[auth] accept_request_headers`` from the INI.
     """
     return load_auth_config().accept_request_headers
+
+
+def _normalize_request_path(path: str) -> str:
+    """Normalize request paths for exact auth exemption checks."""
+    if path == "/":
+        return path
+    return path.rstrip("/")
+
+
+def _path_matches_prefix(path: str, prefix: str) -> bool:
+    """Return True when *path* equals or is below *prefix*."""
+    normalized_prefix = _normalize_request_path(prefix)
+    return path == normalized_prefix or path.startswith(f"{normalized_prefix}/")
+
+
+def _is_cors_preflight(request: Request) -> bool:
+    """Return True for CORS preflight requests handled by CORS middleware."""
+    return (
+        request.method == "OPTIONS"
+        and request.headers.get("access-control-request-method") is not None
+    )
 
 
 # ── FastAPI dependencies ──────────────────────────────────────────────────
@@ -793,14 +829,28 @@ class WhoamiResponse(BaseModel):
     roles: list[str]
 
 
-def install_identity_probe(app: FastAPI, *, require_auth: bool = True) -> None:
+def install_identity_probe(
+    app: FastAPI,
+    *,
+    require_auth: bool = True,
+    enforce_auth: bool = True,
+    unauthenticated_paths: frozenset[str] | set[str] | tuple[str, ...] = (
+        DEFAULT_UNAUTHENTICATED_PATHS
+    ),
+    deferred_auth_prefixes: tuple[str, ...] = (),
+) -> None:
     """Register ``normalize_auth_data`` middleware + ``GET /whoami`` on ``app``.
 
     Call this once from each FastAPI app's ``main.py``.  After installation:
 
+    - When ``enforce_auth`` is true, every request requires a trusted identity
+      unless the path is in ``unauthenticated_paths``.  This keeps healthchecks
+      as the explicit unauthenticated exception instead of requiring every route
+      author to remember an auth dependency.
     - Every request has ``request.state.user`` (str) and ``request.state.roles``
       (set[str]) populated from :func:`extract_identity`, falling back to
-      ``user="unknown"`` / ``roles={"all"}`` when no identity can be derived.
+      ``user="anonymous"`` when auth is disabled and ``user="unknown"`` when
+      auth is enabled but no identity can be derived.
     - ``GET /whoami`` returns the current caller's identity. By default this
       endpoint requires a trusted identity, matching the rest of the API
       surface; set ``require_auth=False`` only for local diagnostics.
@@ -810,6 +860,7 @@ def install_identity_probe(app: FastAPI, *, require_auth: bool = True) -> None:
     ``app.middleware`` registrations run first.  This probe does not depend on
     any other middleware so call order is not important.
     """
+    unauthenticated_path_set = frozenset(_normalize_request_path(p) for p in unauthenticated_paths)
 
     if require_auth:
 
@@ -857,9 +908,34 @@ def install_identity_probe(app: FastAPI, *, require_auth: bool = True) -> None:
         if identity is not None:
             request.state.user = identity.user
             request.state.roles = identity.groups
+        elif not auth_required():
+            request.state.user = ANONYMOUS_IDENTITY.user
+            request.state.roles = ANONYMOUS_IDENTITY.groups
         else:
             request.state.user = "unknown"
             request.state.roles = {"all"}
 
         response: Response = await call_next(request)
         return response
+
+    if enforce_auth:
+
+        @app.middleware("http")
+        async def require_auth_by_default(
+            request: Request, call_next: Callable[[Request], Any]
+        ) -> Response:
+            """Require auth on every route except explicit unauthenticated paths."""
+            path = _normalize_request_path(request.url.path)
+            if (
+                path in unauthenticated_path_set
+                or _is_cors_preflight(request)
+                or any(_path_matches_prefix(path, prefix) for prefix in deferred_auth_prefixes)
+            ):
+                return await call_next(request)
+
+            try:
+                await require_authenticated_identity(request)
+            except HTTPException as exc:
+                return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+            return await call_next(request)

--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -90,7 +90,7 @@ import json
 import os
 import threading
 import urllib.parse
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from configparser import ConfigParser
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -922,7 +922,7 @@ def install_identity_probe(
 
         @app.middleware("http")
         async def require_auth_by_default(
-            request: Request, call_next: Callable[[Request], Any]
+            request: Request, call_next: Callable[[Request], Awaitable[Response]]
         ) -> Response:
             """Require auth on every route except explicit unauthenticated paths."""
             path = _normalize_request_path(request.url.path)

--- a/src/nv_config_manager/dhcp/api.py
+++ b/src/nv_config_manager/dhcp/api.py
@@ -15,18 +15,17 @@
 """Simple HealthCheck API for DHCP Server."""
 
 import argparse
-from collections.abc import Awaitable, Callable
 from typing import Any
 
 import uvicorn
 from aiohttp import ClientResponseError
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 from prometheus_client import CONTENT_TYPE_LATEST, Gauge, generate_latest
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator import metrics as instrumentator_metrics
 
-from nv_config_manager.common.auth import install_identity_probe, require_authenticated_identity
+from nv_config_manager.common.auth import install_identity_probe
 from nv_config_manager.common.config import load_config
 from nv_config_manager.common.log import configure_logging
 from nv_config_manager.dhcp.kea import KeaClient
@@ -43,8 +42,6 @@ CACHE_LAST_REFRESH = Gauge(
     namespace="nv-config-manager",
     subsystem="dhcp",
 )
-
-UNAUTHENTICATED_PATHS = {"/healthcheck", "/metrics"}
 
 instrumentator = Instrumentator(excluded_handlers=["/healthcheck", "/metrics"])
 instrumentator.add(
@@ -71,21 +68,6 @@ def main() -> None:
         proxy_headers=True,
         log_config=None,
     )
-
-
-@app.middleware("http")
-async def authorize_request(
-    request: Request, call_next: Callable[[Request], Awaitable[Response]]
-) -> Response:
-    """Determine if the request has a trusted user or workload identity."""
-    if request.url.path in UNAUTHENTICATED_PATHS:
-        return await call_next(request)
-
-    try:
-        await require_authenticated_identity(request)
-        return await call_next(request)
-    except HTTPException as exc:
-        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
 
 def sanitize_config(config: Any) -> None:

--- a/src/nv_config_manager/temporal/api/dynamic_endpoints.py
+++ b/src/nv_config_manager/temporal/api/dynamic_endpoints.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, computed_field
 
+from nv_config_manager.common.auth import get_sso_user
 from nv_config_manager.common.log import LogCategory, get_logger
 from nv_config_manager.temporal.common.mixins.metadata import WorkflowMetadataMixin
 from nv_config_manager.temporal.hello_world.workflows import (
@@ -70,7 +71,7 @@ def create_workflow_endpoint(
             )
 
         # Auto-populate user fields from request auth data if they exist and are None
-        user = getattr(request.state, "user", "unknown")
+        user = getattr(request.state, "user", None) or get_sso_user(request)
 
         # Auto-populate common user fields if they exist in the input model and are None
         if hasattr(body, "user") and not body.user:  # type: ignore[attr-defined]

--- a/src/nv_config_manager/ztp/api/device_v1.py
+++ b/src/nv_config_manager/ztp/api/device_v1.py
@@ -106,8 +106,9 @@ async def load_configuration(
 # same DHCP boot-file-name option
 @router.get("/{device_uuid}/onie", response_class=PlainTextResponse)
 @router.get("/{device_uuid}/firmware", response_class=StreamingResponse)
-async def load_firmware(device_uuid: str) -> StreamingResponse:
+async def load_firmware(device_uuid: str, request: Request) -> StreamingResponse:
     """Load the firmware for the given device."""
+    await _authorize_request(request, device_uuid)
     try:
         nb_client = NautobotClient()
         async with nb_client:
@@ -130,8 +131,9 @@ async def load_firmware(device_uuid: str) -> StreamingResponse:
 
 
 @router.get("/{device_uuid}/firmware/checksum")
-async def load_firmware_checksum(device_uuid: str) -> ChecksumResponse:
+async def load_firmware_checksum(device_uuid: str, request: Request) -> ChecksumResponse:
     """Load the firmware checksum for the given device."""
+    await _authorize_request(request, device_uuid)
     try:
         nb_client = NautobotClient()
         async with nb_client:

--- a/src/nv_config_manager/ztp/api/main.py
+++ b/src/nv_config_manager/ztp/api/main.py
@@ -81,4 +81,4 @@ def healthcheck() -> str:
     return "OK"
 
 
-install_identity_probe(app)
+install_identity_probe(app, deferred_auth_prefixes=("/v1/device/",))

--- a/src/tests/common/test_auth.py
+++ b/src/tests/common/test_auth.py
@@ -26,7 +26,9 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
+from starlette.testclient import TestClient as StarletteClient
 
+import nv_config_manager.common.auth as auth_mod
 from nv_config_manager.common.auth import (
     SSOIdentity,
     _derive_jwks_uri,
@@ -34,6 +36,7 @@ from nv_config_manager.common.auth import (
     _spiffe_id_to_workload_name,
     extract_identity,
     identity_from_sso_headers,
+    install_identity_probe,
     load_auth_config,
     require_authenticated_identity,
     require_group,
@@ -62,8 +65,6 @@ def _make_config(**sections: dict[str, str]) -> ConfigParser:
 
 def _inject_config(config: ConfigParser):
     """Patch load_auth_config so it uses the given ConfigParser."""
-    import nv_config_manager.common.auth as auth_mod
-
     auth_mod._auth_config = None
     return patch.object(
         auth_mod, "load_auth_config", lambda cfg=None: auth_mod.load_auth_config(config)
@@ -76,8 +77,6 @@ def _inject_config(config: ConfigParser):
 @pytest.fixture(autouse=True)
 def _clear_caches():
     """Reset module-level caches between tests."""
-    import nv_config_manager.common.auth as auth_mod
-
     _jwks_clients.clear()
     auth_mod._auth_config = None
     yield
@@ -241,6 +240,64 @@ class TestConfigLoading:
         assert len(cfg.jwt_providers) == 0
 
 
+# ── install_identity_probe enforcement tests ─────────────────────────────
+
+
+class TestInstallIdentityProbe:
+    """Tests for shared identity probe auth enforcement middleware."""
+
+    def _make_app(self):
+        app = FastAPI()
+
+        @app.get("/healthcheck")
+        async def healthcheck():
+            return "OK"
+
+        @app.get("/protected")
+        async def protected():
+            return {"ok": True}
+
+        @app.get("/state-user")
+        async def state_user(request: Request):
+            return {"user": request.state.user}
+
+        install_identity_probe(app)
+        return app
+
+    def test_auth_required_by_default_except_healthchecks(self):
+        auth_mod._auth_config = load_auth_config(
+            _make_config(auth={"required": "true", "accept_request_headers": "true"})
+        )
+        client = TestClient(self._make_app())
+
+        assert client.get("/healthcheck").status_code == 200
+        assert client.get("/protected").status_code == 403
+
+        resp = client.get("/protected", headers={"X-Auth-Request-Email": "alice@example.com"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+    def test_docs_are_protected(self):
+        auth_mod._auth_config = load_auth_config(
+            _make_config(auth={"required": "true", "accept_request_headers": "true"})
+        )
+        client = TestClient(self._make_app())
+
+        assert client.get("/docs").status_code == 403
+
+    def test_auth_disabled_allows_non_healthcheck_paths(self):
+        auth_mod._auth_config = load_auth_config(_make_config(auth={"required": "false"}))
+        client = TestClient(self._make_app())
+
+        resp = client.get("/protected")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        resp = client.get("/state-user")
+        assert resp.status_code == 200
+        assert resp.json() == {"user": "anonymous"}
+
+
 # ── JWKS URI derivation tests ────────────────────────────────────────────
 
 
@@ -264,16 +321,12 @@ class TestIdentityFromJwt:
 
     def test_no_config_returns_none(self, client):
         """When no JWT providers are configured, identity_from_jwt returns None."""
-        import nv_config_manager.common.auth as auth_mod
-
         auth_mod._auth_config = load_auth_config(ConfigParser())
         resp = client.get("/whoami")
         assert resp.json() == {"identity": None}
 
     def test_no_token_returns_none(self, client):
         """When no Authorization header, returns None."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.jwt.test": {
@@ -289,8 +342,6 @@ class TestIdentityFromJwt:
 
     def test_valid_jwt_returns_identity(self, rsa_keypair, make_jwt, client):
         """A valid JWT should return an identity with extracted claims."""
-        import nv_config_manager.common.auth as auth_mod
-
         claims = {
             "iss": "https://idp.example.com",
             "aud": "my-app",
@@ -334,8 +385,6 @@ class TestIdentityFromJwt:
 
     def test_invalid_jwt_returns_none(self, client):
         """An invalid JWT should return None, not raise."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.jwt.test": {
@@ -359,8 +408,6 @@ class TestIdentityFromJwt:
 
     def test_jwt_from_cookie(self, rsa_keypair, make_jwt, client):
         """JWT can be extracted from the NVConfigManagerAccessToken cookie."""
-        import nv_config_manager.common.auth as auth_mod
-
         claims = {
             "iss": "https://idp.example.com",
             "aud": "my-app",
@@ -398,8 +445,6 @@ class TestIdentityFromJwt:
 
     def test_custom_claim_mappings(self, rsa_keypair, make_jwt, client):
         """Custom claim mappings from INI should be respected."""
-        import nv_config_manager.common.auth as auth_mod
-
         claims = {
             "iss": "https://idp.example.com",
             "aud": "my-app",
@@ -442,8 +487,6 @@ class TestIdentityFromJwt:
 
     def test_multi_issuer_first_match_wins(self, rsa_keypair, make_jwt, client):
         """With multiple providers, the first one whose issuer matches wins."""
-        import nv_config_manager.common.auth as auth_mod
-
         claims = {
             "iss": "https://ssa.example.com",
             "aud": "s:my-aud",
@@ -517,16 +560,12 @@ class TestIdentityFromSpiffe:
 
     def test_no_spiffe_config_returns_none(self, client):
         """When [auth.spiffe] is not configured, returns None."""
-        import nv_config_manager.common.auth as auth_mod
-
         auth_mod._auth_config = load_auth_config(ConfigParser())
         resp = client.get("/whoami")
         assert resp.json() == {"identity": None}
 
     def test_valid_spiffe_jwt(self, rsa_keypair, make_jwt, client):
         """A valid SPIFFE JWT-SVID should return a workload identity with mapped group."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -563,8 +602,6 @@ class TestIdentityFromSpiffe:
 
     def test_invalid_spiffe_jwt(self, client):
         """An invalid SPIFFE JWT should return None."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -585,8 +622,6 @@ class TestIdentityFromSpiffe:
 
     def test_teleport_spiffe_id_format(self, rsa_keypair, make_jwt, client):
         """Teleport-style SPIFFE IDs should be parsed correctly."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -617,8 +652,6 @@ class TestIdentityFromSpiffe:
 
     def test_group_prefix_mapping(self, rsa_keypair, make_jwt, client):
         """[auth.spiffe.groups] mapping controls the assigned group."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -684,8 +717,6 @@ class TestExtractIdentityPriority:
 
     def test_spiffe_takes_priority_over_headers(self, rsa_keypair, make_jwt, client):
         """SPIFFE identity should take priority over SSO headers."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -725,8 +756,6 @@ class TestExtractIdentityPriority:
 
     def test_sso_headers_used_as_fallback(self, client):
         """SSO headers should work when no JWT or SPIFFE is configured."""
-        import nv_config_manager.common.auth as auth_mod
-
         auth_mod._auth_config = load_auth_config(ConfigParser())
         resp = client.get(
             "/whoami",
@@ -752,8 +781,6 @@ class TestBackwardCompatibility:
 
     def test_identity_from_sso_headers_unchanged(self):
         """identity_from_sso_headers should still work as before."""
-        from starlette.testclient import TestClient as StarletteClient
-
         app = FastAPI()
 
         @app.get("/test")
@@ -770,8 +797,6 @@ class TestBackwardCompatibility:
 
     def test_require_authenticated_identity_with_auth_disabled(self):
         """require_authenticated_identity returns anonymous when auth is disabled."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(auth={"required": "false"})
         auth_mod._auth_config = load_auth_config(cp)
 
@@ -807,8 +832,6 @@ class TestAllowedGroups:
 
     def test_no_service_section_no_restriction(self):
         """Without NV_CONFIG_MANAGER_SERVICE env var, allowed_groups is empty — no restriction."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(auth={"required": "true"})
         with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("NV_CONFIG_MANAGER_SERVICE", None)
@@ -818,8 +841,6 @@ class TestAllowedGroups:
 
     def test_allowed_groups_parsed_from_service_section(self):
         """allowed_groups is read from the service's own INI section."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             auth={"required": "true"},
             render={"allowed_groups": "group-a, group-b"},
@@ -832,8 +853,6 @@ class TestAllowedGroups:
 
     def test_user_in_allowed_group_passes(self):
         """A user whose groups overlap with allowed_groups is permitted."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             auth={"required": "true", "accept_request_headers": "true"},
             render={"allowed_groups": "eng-team"},
@@ -856,8 +875,6 @@ class TestAllowedGroups:
 
     def test_user_not_in_allowed_group_denied(self):
         """A user not in any allowed group gets 403."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             auth={"required": "true", "accept_request_headers": "true"},
             render={"allowed_groups": "eng-team"},
@@ -879,8 +896,6 @@ class TestAllowedGroups:
 
     def test_spiffe_identity_bypasses_allowed_groups(self, rsa_keypair, make_jwt):
         """SPIFFE identities (source=spiffe) are not subject to allowed_groups."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth": {"required": "true"},
@@ -918,8 +933,6 @@ class TestAllowedGroups:
 
     def test_empty_allowed_groups_no_restriction(self):
         """An empty allowed_groups in the service section means no restriction."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             auth={"required": "true"},
             render={"api_service": "http://render:9000"},
@@ -969,8 +982,6 @@ class TestSpiffeGroupPrefixes:
 
     def test_no_mapping_only_all_group(self, rsa_keypair, make_jwt):
         """Without [auth.spiffe.groups], callers only get the 'all' group."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -1002,8 +1013,6 @@ class TestSpiffeGroupPrefixes:
 
     def test_matching_prefix_adds_mapped_group(self, rsa_keypair, make_jwt):
         """A SPIFFE ID matching a prefix gets the mapped group."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -1039,8 +1048,6 @@ class TestSpiffeGroupPrefixes:
 
     def test_nonmatching_prefix_no_mapped_group(self, rsa_keypair, make_jwt):
         """A SPIFFE ID not matching any prefix does not get the mapped group."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -1076,8 +1083,6 @@ class TestSpiffeGroupPrefixes:
 
     def test_multiple_prefixes_multiple_groups(self, rsa_keypair, make_jwt):
         """Multiple prefix mappings can coexist; matching ones all apply."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {
@@ -1149,8 +1154,6 @@ class TestRequireGroup:
 
     def test_user_with_matching_group_passes(self):
         """A user in a required group passes the gate."""
-        import nv_config_manager.common.auth as auth_mod
-
         auth_mod._auth_config = load_auth_config(
             _make_config(auth={"accept_request_headers": "true"})
         )
@@ -1168,8 +1171,6 @@ class TestRequireGroup:
 
     def test_user_without_required_group_denied(self):
         """A user missing all required groups gets 403."""
-        import nv_config_manager.common.auth as auth_mod
-
         auth_mod._auth_config = load_auth_config(
             _make_config(auth={"accept_request_headers": "true"})
         )
@@ -1186,8 +1187,6 @@ class TestRequireGroup:
 
     def test_any_of_multiple_groups_passes(self):
         """Having any one of the specified groups is sufficient."""
-        import nv_config_manager.common.auth as auth_mod
-
         auth_mod._auth_config = load_auth_config(
             _make_config(auth={"accept_request_headers": "true"})
         )
@@ -1204,8 +1203,6 @@ class TestRequireGroup:
 
     def test_spiffe_non_allowed_denied_by_require_group_config_manager(self, rsa_keypair, make_jwt):
         """A SPIFFE workload not matching any prefix is denied by require_group('nv-config-manager')."""
-        import nv_config_manager.common.auth as auth_mod
-
         cp = _make_config(
             **{
                 "auth.spiffe": {

--- a/src/tests/config_store/conftest.py
+++ b/src/tests/config_store/conftest.py
@@ -119,7 +119,11 @@ async def client(db_session):
     app.dependency_overrides[get_db] = override_get_db
 
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Auth-Request-Email": "test@example.com"},
+    ) as ac:
         yield ac
 
     app.dependency_overrides.clear()

--- a/src/tests/config_store/test_api.py
+++ b/src/tests/config_store/test_api.py
@@ -30,7 +30,7 @@ async def test_healthcheck(client):
 @pytest.mark.asyncio
 async def test_whoami_requires_auth(client):
     """Test authenticated identity probe endpoint."""
-    response = await client.get("/whoami")
+    response = await client.get("/whoami", headers={"X-Auth-Request-Email": ""})
     assert response.status_code == 403
 
     response = await client.get("/whoami", headers={"X-Auth-Request-Email": "admin@example.com"})

--- a/src/tests/render/api/test_main.py
+++ b/src/tests/render/api/test_main.py
@@ -52,12 +52,14 @@ def test_render(mock_execute_render):
             {"filename": "tenant.yaml", "commit": commit_2},
         ]
     }
-    mock_execute_render.assert_called_with("test", "Manual render initiated by unknown", "unknown")
+    mock_execute_render.assert_called_with(
+        "test", "Manual render initiated by anonymous", "anonymous"
+    )
 
     # Test with custom commit message
     custom_message = "Custom commit message"
     rsp = client.post("/v1/render/test/render", json={"commit_message": custom_message})
-    mock_execute_render.assert_called_with("test", custom_message, "unknown")
+    mock_execute_render.assert_called_with("test", custom_message, "anonymous")
     assert rsp.status_code == 201
 
     # Test with no changes (empty list)
@@ -95,8 +97,8 @@ def test_render_all_success(mock_get_devices, mock_queue_render_batch):
     assert mock_queue_render_batch.call_count == 1
     call = mock_queue_render_batch.call_args_list[0]
     assert call[0][0] == device_uuids  # device_uuids list
-    assert call[0][1] == "Bulk render initiated by unknown"  # commit_message
-    assert call[0][2] == "unknown"  # user
+    assert call[0][1] == "Bulk render initiated by anonymous"  # commit_message
+    assert call[0][2] == "anonymous"  # user
     # call[0][3] is timestamp - just verify it's a string
     assert isinstance(call[0][3], str)
 

--- a/src/tests/render/conftest.py
+++ b/src/tests/render/conftest.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import pytest
 
+from nv_config_manager.common.auth import AuthConfig
+
 # Check if nv_config_manager_templates is available
 try:
     import nv_config_manager_templates  # noqa: F401
@@ -62,3 +64,12 @@ def base_message() -> dict[str, Any]:
         "model": None,
         "record": {"id": None, "name": None},
     }
+
+
+@pytest.fixture(autouse=True)
+def disable_app_auth_for_render_api_unit_tests(mocker):
+    """Keep render API unit tests focused on endpoint behavior."""
+    mocker.patch(
+        "nv_config_manager.common.auth._auth_config",
+        AuthConfig(required=False, accept_request_headers=True),
+    )

--- a/src/tests/temporal/api/conftest.py
+++ b/src/tests/temporal/api/conftest.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Temporal API test configuration."""
 
 from __future__ import annotations

--- a/src/tests/temporal/api/conftest.py
+++ b/src/tests/temporal/api/conftest.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Temporal API test configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from nv_config_manager.common.auth import AuthConfig
+
+
+@pytest.fixture(autouse=True)
+def disable_app_auth_for_temporal_api_unit_tests(mocker):
+    """Keep Temporal API unit tests focused on workflow behavior."""
+    mocker.patch(
+        "nv_config_manager.common.auth._auth_config",
+        AuthConfig(required=False, accept_request_headers=True),
+    )

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -180,7 +180,7 @@ async def test_approve(mock_signal):
         ANY,
         workflow_id,
         "approve",
-        ReviewSignalInput(stage_name="prompt", user="unknown"),
+        ReviewSignalInput(stage_name="prompt", user="anonymous"),
     )
 
 
@@ -201,7 +201,7 @@ async def test_reject(mock_signal):
         ANY,
         workflow_id,
         "reject",
-        ReviewSignalInput(stage_name="prompt", user="unknown"),
+        ReviewSignalInput(stage_name="prompt", user="anonymous"),
     )
 
 

--- a/src/tests/ztp/api/test_main.py
+++ b/src/tests/ztp/api/test_main.py
@@ -31,6 +31,8 @@ from nv_config_manager.ztp.s3 import (
     S3NotFoundException,
 )
 
+SSO_HEADERS = {"X-Auth-Request-Email": "test@nvidia.com"}
+
 
 @pytest.fixture
 def client():
@@ -47,6 +49,9 @@ def test_healthcheck(client):
 def test_docs(client):
     """Verify Swagger Doc endpoint."""
     rsp = client.get("/docs")
+    assert rsp.status_code == 403
+
+    rsp = client.get("/docs", headers=SSO_HEADERS)
     assert rsp.status_code == 200
 
 
@@ -198,7 +203,7 @@ def test_device_v1_firmware(mock_device_data, mock_not_found_data, client):
         with patch(
             "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
         ):
-            rsp = client.get(f"/v1/device/{uuid4()}/firmware")
+            rsp = client.get(f"/v1/device/{uuid4()}/firmware", headers=SSO_HEADERS)
             assert rsp.status_code == 200
             assert rsp.content == mock_content
             assert rsp.headers["content-disposition"] == (
@@ -221,7 +226,7 @@ def test_device_v1_firmware(mock_device_data, mock_not_found_data, client):
         with patch(
             "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
         ):
-            rsp = client.get(f"/v1/device/{uuid4()}/onie")
+            rsp = client.get(f"/v1/device/{uuid4()}/onie", headers=SSO_HEADERS)
             assert rsp.status_code == 200
             assert rsp.content == mock_content
             assert rsp.headers["content-disposition"] == (
@@ -234,14 +239,14 @@ def test_device_v1_firmware(mock_device_data, mock_not_found_data, client):
         with patch(
             "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
         ):
-            rsp = client.get(f"/v1/device/{uuid4()}/firmware")
+            rsp = client.get(f"/v1/device/{uuid4()}/firmware", headers=SSO_HEADERS)
             assert rsp.status_code == 404
 
     with patch(
         "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
         return_value=mock_not_found_data,
     ):
-        rsp = client.get(f"/v1/device/{uuid4()}/firmware")
+        rsp = client.get(f"/v1/device/{uuid4()}/firmware", headers=SSO_HEADERS)
         assert rsp.status_code == 404
 
 
@@ -263,7 +268,7 @@ def test_device_v1_firmware_checksum(mock_device_data, mock_not_found_data, clie
         with patch(
             "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
         ):
-            rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum")
+            rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
             assert rsp.status_code == 200
             assert rsp.json() == {"checksum": "testchecksum"}
 
@@ -273,14 +278,14 @@ def test_device_v1_firmware_checksum(mock_device_data, mock_not_found_data, clie
         with patch(
             "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
         ):
-            rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum")
+            rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
             assert rsp.status_code == 404
 
     with patch(
         "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
         return_value=mock_not_found_data,
     ):
-        rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum")
+        rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 404
 
 
@@ -443,7 +448,7 @@ def test_v1_firmware(client):
     with patch(
         "nv_config_manager.ztp.api.firmware_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/firmware/arista_eos/4.29.3M")
+        rsp = client.get("/v1/firmware/arista_eos/4.29.3M", headers=SSO_HEADERS)
         assert rsp.status_code == 200
         assert rsp.content == mock_content
         assert rsp.headers["content-disposition"] == (
@@ -456,7 +461,7 @@ def test_v1_firmware(client):
     with patch(
         "nv_config_manager.ztp.api.firmware_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/firmware/arista_eos/4.29.3M")
+        rsp = client.get("/v1/firmware/arista_eos/4.29.3M", headers=SSO_HEADERS)
         assert rsp.status_code == 404
 
 
@@ -474,7 +479,7 @@ def test_v1_firmware_checksum(client):
     with patch(
         "nv_config_manager.ztp.api.firmware_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/firmware/arista_eos/4.29.3M/checksum")
+        rsp = client.get("/v1/firmware/arista_eos/4.29.3M/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 200
         assert rsp.json() == {"checksum": "testchecksum"}
 
@@ -484,7 +489,7 @@ def test_v1_firmware_checksum(client):
     with patch(
         "nv_config_manager.ztp.api.firmware_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/firmware/arista_eos/4.29.3M/checksum")
+        rsp = client.get("/v1/firmware/arista_eos/4.29.3M/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 404
 
 
@@ -514,7 +519,7 @@ def test_v1_files_get(client):
     with patch(
         "nv_config_manager.ztp.api.files_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/files/arista_eos/4.29.3M/image.bin")
+        rsp = client.get("/v1/files/arista_eos/4.29.3M/image.bin", headers=SSO_HEADERS)
         assert rsp.status_code == 200
         assert rsp.content == mock_content
         assert rsp.headers["content-disposition"] == (
@@ -527,7 +532,7 @@ def test_v1_files_get(client):
     with patch(
         "nv_config_manager.ztp.api.files_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/files/arista_eos/4.29.3M/image.bin")
+        rsp = client.get("/v1/files/arista_eos/4.29.3M/image.bin", headers=SSO_HEADERS)
         assert rsp.status_code == 404
 
 
@@ -545,7 +550,10 @@ def test_v1_files_checksum(client):
     with patch(
         "nv_config_manager.ztp.api.files_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/files/arista_eos/4.29.3M/image.bin/checksum")
+        rsp = client.get(
+            "/v1/files/arista_eos/4.29.3M/image.bin/checksum",
+            headers=SSO_HEADERS,
+        )
         assert rsp.status_code == 200
         assert rsp.json() == {"checksum": "testchecksum"}
 
@@ -555,7 +563,10 @@ def test_v1_files_checksum(client):
     with patch(
         "nv_config_manager.ztp.api.files_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/files/arista_eos/4.29.3M/image.bin/checksum")
+        rsp = client.get(
+            "/v1/files/arista_eos/4.29.3M/image.bin/checksum",
+            headers=SSO_HEADERS,
+        )
         assert rsp.status_code == 404
 
 
@@ -595,7 +606,7 @@ def test_v1_files_list(client):
     with patch(
         "nv_config_manager.ztp.api.files_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/files/arista_eos/4.29.3M")
+        rsp = client.get("/v1/files/arista_eos/4.29.3M", headers=SSO_HEADERS)
         assert rsp.json() == expected_rsp_json
 
 
@@ -715,6 +726,6 @@ def test_v1_files_list_all(client):
     with patch(
         "nv_config_manager.ztp.api.files_v1.get_storage_client", return_value=mock_s3_instance
     ):
-        rsp = client.get("/v1/files/")
+        rsp = client.get("/v1/files/", headers=SSO_HEADERS)
         assert rsp.status_code == 200
         assert rsp.json() == expected_rsp_json


### PR DESCRIPTION
## Description

A regression in default authentication behavior was introduced when consolidating to a shared auth library in the mono-repo. Additionally, due to missing header removal policies, old mTLS auth paths could be reached by forging ssl-client-cert headers.

## Validation

Deployed locally with valid SSO parameters, tested curl against svc endpoints with both forged client certs, forged headers, and no auth data at all, all 3 scenarios were properly rejected.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.
