### PR TITLE
Fix for helm tag issue

### DIFF
--- a/installer/src/nv_config_manager_installer/deployer.py
+++ b/installer/src/nv_config_manager_installer/deployer.py
@@ -198,9 +198,7 @@ def _hash_content_dir(
 def _get_image_digest_tag(image: str) -> str:
     """Extract a short content-addressed tag from a local Docker image.
 
-    Runs ``docker inspect`` to get the image ID (sha256 digest) and
-    returns the first 12 hex characters.  Returns an empty string if
-    the inspect fails (e.g. Docker not available).
+    Returns the first 12 hex characters of the image ID. Returns an empty string if the inspect fails or the image ID is empty.
     """
     try:
         result = subprocess.run(
@@ -211,9 +209,10 @@ def _get_image_digest_tag(image: str) -> str:
             timeout=30,
         )
         image_id = result.stdout.strip()
-        # image_id looks like "sha256:a1b2c3d4..."
         hex_part = image_id.split(":")[-1]
-        return hex_part[:12]
+        if not hex_part:
+            return ""
+        return f"sha-{hex_part[:12]}"
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
         return ""
 

--- a/installer/tests/test_deployer.py
+++ b/installer/tests/test_deployer.py
@@ -827,7 +827,7 @@ class TestContentAddressedTags:
             returncode=0, stdout="sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6\n"
         )
         tag = _get_image_digest_tag("nv-config-manager:local")
-        assert tag == "a1b2c3d4e5f6"
+        assert tag == "sha-a1b2c3d4e5f6"
         mock_run.assert_called_once()
 
     @patch("nv_config_manager_installer.deployer.subprocess.run")
@@ -839,6 +839,12 @@ class TestContentAddressedTags:
     @patch("nv_config_manager_installer.deployer.subprocess.run")
     def test_get_image_digest_tag_no_docker(self, mock_run):
         mock_run.side_effect = FileNotFoundError("docker not found")
+        tag = _get_image_digest_tag("nv-config-manager:local")
+        assert tag == ""
+
+    @patch("nv_config_manager_installer.deployer.subprocess.run")
+    def test_get_image_digest_tag_empty_id(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="\n")
         tag = _get_image_digest_tag("nv-config-manager:local")
         assert tag == ""
 


### PR DESCRIPTION
## Description

Prefix image digest tags with sha- so YAML doesn't change them to scientific notation.

## Validation

```
============================================================== test session starts ===============================================================                                                                                             

tests/test_deployer.py::TestContentAddressedTags::test_get_image_digest_tag PASSED                                                         [ 25%]
tests/test_deployer.py::TestContentAddressedTags::test_get_image_digest_tag_failure PASSED                                                 [ 50%]
tests/test_deployer.py::TestContentAddressedTags::test_get_image_digest_tag_no_docker PASSED                                               [ 75%]
tests/test_deployer.py::TestContentAddressedTags::test_get_image_digest_tag_empty_id PASSED                                                [100%]

======================================================== 4 passed, 41 deselected in 2.77s ========================================================
```
## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved image tag generation with validation to handle missing identifiers
- Standardized image digest tag naming format for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/nv-config-manager/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->