### PR TITLE
resolve missed header attachement in non-spiffe environments

### DIFF
--- a/src/nv_config_manager/ztp/device.py
+++ b/src/nv_config_manager/ztp/device.py
@@ -24,7 +24,7 @@ from nv_config_manager.common.client import (
     ConfigStoreClient,
     ConfigStoreFileNotFound,
 )
-from nv_config_manager.common.config import load_config
+from nv_config_manager.common.config import get_internal_auth_headers, load_config
 
 
 @dataclass
@@ -60,6 +60,7 @@ class DeviceData:  # pylint: disable=too-many-instance-attributes
                 ui_url,
                 verify=False,
                 client_certificate=None,
+                headers=get_internal_auth_headers,
             )
         else:
             # External mTLS communication

--- a/src/tests/ztp/test_device.py
+++ b/src/tests/ztp/test_device.py
@@ -16,6 +16,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from nv_config_manager.common.config import get_internal_auth_headers
 from nv_config_manager.ztp.device import DeviceData
 
 
@@ -48,6 +49,7 @@ def test_config_store_client():
         assert call_args[0][1] == "intended"
         assert call_args[1]["verify"] is False  # No SSL verification for internal HTTP
         assert call_args[1]["client_certificate"] is None  # No mTLS for internal communication
+        assert call_args[1]["headers"] is get_internal_auth_headers
         assert client == mock_client_instance
 
 


### PR DESCRIPTION
## Description

With the previous fix to authentication, a gap was discovered where ZTP was not attaching the internal headers in non-SPIFFE environments.


## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.
