### PR TITLE
docs: publish public docs

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -4,7 +4,7 @@ global-theme: nvidia
 
 instances:
   - url: config-manager.docs.buildwithfern.com/switch-infrastructure/config-manager
-    # custom-domain: docs.nvidia.com/switch-infrastructure/config-manager
+    custom-domain: docs.nvidia.com/switch-infrastructure/config-manager
     multi-source: true
 
 title: NVIDIA Switch Infrastructure


### PR DESCRIPTION
## Description

Publish docs to the public site. Note that this won't immediately result in the docs showing up at docs.nvidia.com — there's a backend step we need to do, and it may not happen until Friday, but it's in the queue now.

## Validation

`fern check` passes.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Configuration manager documentation is now accessible at its dedicated custom domain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/nv-config-manager/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->