### PR TITLE
Use universally cluster-local FQDNs for temporal-setup container

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -706,7 +706,7 @@ Usage: {{ include "nv-config-manager.waitForTemporalNamespace" . | nindent 6 }}
     - /bin/bash
     - -c
     - |
-      TEMPORAL_ADDR="{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}"
+      TEMPORAL_ADDR="{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}"
 
       echo "Waiting for Temporal default namespace..."
       until tctl --address "$TEMPORAL_ADDR" --namespace default namespace describe >/dev/null 2>&1; do

--- a/deploy/helm/templates/_vault-agent.tpl
+++ b/deploy/helm/templates/_vault-agent.tpl
@@ -354,7 +354,7 @@ nv-config-manager.ini body (consul-template): must stay in sync with vault-secre
           # -----------------------------------------------------------------
           [temporal]
           # Internal: Temporal gRPC frontend (for workers, SDK clients)
-          grpc_service = {{ $temporalName }}-frontend-service.{{ $root.Values.global.namespace }}.svc:{{ $root.Values.temporal.services.frontend.port }}
+          grpc_service = {{ $temporalName }}-frontend-service.{{ $root.Values.global.namespace }}.svc.cluster.local:{{ $root.Values.temporal.services.frontend.port }}
           # Internal: NVIDIA Config Manager Temporal API (for internal service calls)
           # Uses sidecar port when auth sidecars are enabled for header injection
           api_service = http://{{ $temporalName }}-api:{{ $internalPort }}

--- a/deploy/helm/templates/kubernetes-secrets.yaml
+++ b/deploy/helm/templates/kubernetes-secrets.yaml
@@ -186,7 +186,7 @@ spec:
               # -----------------------------------------------------------------
               [temporal]
               # Internal: Temporal gRPC frontend (for workers, SDK clients)
-              grpc_service = {{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}
+              grpc_service = {{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}
               # Internal: NVIDIA Config Manager Temporal API (for internal service calls)
               # Uses sidecar port when auth sidecars are enabled for header injection
               api_service = http://{{ $temporalName }}-api:{{ $internalPort }}

--- a/deploy/helm/templates/temporal.yaml
+++ b/deploy/helm/templates/temporal.yaml
@@ -139,7 +139,7 @@ spec:
       # Non-frontend services wait for frontend to be ready (which implies schema is set up)
       - name: wait-for-frontend
         image: "{{ $.Values.global.images.busybox.repository }}:{{ $.Values.global.images.busybox.tag }}"
-        command: ['sh', '-c', 'until nc -z {{ $temporalName }}-frontend-service {{ (index $.Values.temporal.services "frontend").port }}; do echo "waiting for {{ $temporalName }}-frontend-service"; sleep 2; done; echo "frontend is ready"']
+        command: ['sh', '-c', 'until nc -z {{ $temporalName }}-frontend-service.{{ $.Values.global.namespace }}.svc.cluster.local {{ (index $.Values.temporal.services "frontend").port }}; do echo "waiting for {{ $temporalName }}-frontend-service.{{ $.Values.global.namespace }}.svc.cluster.local"; sleep 2; done; echo "frontend is ready"']
       {{- end }}
       containers:
       - name: temporal-{{ $service }}
@@ -302,12 +302,12 @@ spec:
         - -c
         - |
           set -e
-          TEMPORAL_ADDR="{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}"
+          TEMPORAL_ADDR="{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}"
           MAX_RETRIES=30
           RETRY_DELAY=5
 
           echo "Waiting for temporal frontend..."
-          until nc -z {{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc {{ .Values.temporal.services.frontend.port }}; do
+          until nc -z {{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local {{ .Values.temporal.services.frontend.port }}; do
             echo "waiting for {{ $temporalName }}-frontend-service..."
             sleep 2
           done
@@ -375,7 +375,7 @@ spec:
           value: {{ .Values.global.environment }}
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         - name: TEMPORAL_ADDRESS
-          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}"
+          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}"
         {{- if .Values.secrets.vault.configSecrets.enabled }}
         - name: NV_CONFIG_MANAGER_CONFIG_SECRET_PATH
           value: {{ include "nv-config-manager.vaultAgent.configSecretsFilePath" (dict "root" . "path" .Values.temporal.configManagerWorker.configSecrets.path) | quote }}
@@ -464,7 +464,7 @@ spec:
           value: {{ .Values.global.environment }}
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         - name: TEMPORAL_ADDRESS
-          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}"
+          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}"
         ports:
         - containerPort: 9000
           name: http
@@ -579,7 +579,7 @@ spec:
         - name: ENVIRONMENT
           value: {{ .Values.global.environment }}
         - name: TEMPORAL_ADDRESS
-          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}"
+          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}"
         resources:
           {{- toYaml .Values.temporal.scheduler.resources | nindent 10 }}
         volumeMounts:
@@ -653,7 +653,7 @@ spec:
         - name: TEMPORAL_API_HOST
           value: {{ tpl .Values.temporal.gateway.api.hostname . | quote }}
         - name: TEMPORAL_ADDRESS
-          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}"
+          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}"
         volumeMounts:
         {{- include "nv-config-manager.vaultAgent.configManagerIniVolumeMount" . | nindent 8 }}
         {{- /* SPIFFE volume mount for outbound mTLS */ -}}
@@ -698,7 +698,7 @@ spec:
         imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
         env:
         - name: TEMPORAL_ADDRESS
-          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}"
+          value: "{{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}"
         {{- $codecEndpoint := .Values.temporal.devUi.codecEndpoint }}
         {{- if $codecEndpoint }}
         - name: TEMPORAL_CODEC_ENDPOINT

--- a/deploy/helm/templates/vault-secrets.yaml
+++ b/deploy/helm/templates/vault-secrets.yaml
@@ -850,7 +850,7 @@ spec:
           # -----------------------------------------------------------------
           [temporal]
           # Internal: Temporal gRPC frontend (for workers, SDK clients)
-          grpc_service = {{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc:{{ .Values.temporal.services.frontend.port }}
+          grpc_service = {{ $temporalName }}-frontend-service.{{ .Values.global.namespace }}.svc.cluster.local:{{ .Values.temporal.services.frontend.port }}
           # Internal: NVIDIA Config Manager Temporal API (for internal service calls)
           # Uses sidecar port when auth sidecars are enabled for header injection
           api_service = http://{{ $temporalName }}-api:{{ $internalPort }}


### PR DESCRIPTION
## Description

### Summary
Updates all Temporal frontend addresses in the Helm chart from short-form Kubernetes service DNS (<service>.<namespace>.svc) to fully-qualified cluster-local names (<service>.<namespace>.svc.cluster.local).

### Problem
Several Temporal components were configured to reach the frontend using the abbreviated .svc hostname. While that often resolves inside a cluster, some environments and tooling expect the full cluster-local FQDN. The temporal-setup init container was especially sensitive to this — it uses nc to wait for the frontend and TEMPORAL_ADDR for namespace/bootstrap commands, so unreliable DNS resolution can block pod startup.

### Changes
In deploy/helm/templates/temporal.yaml, append .cluster.local to every Temporal frontend reference:

temporal-setup init container — TEMPORAL_ADDR and the nc -z readiness loop
config-manager-worker — TEMPORAL_ADDRESS
Workflow worker — TEMPORAL_ADDRESS
Scheduler — TEMPORAL_ADDRESS
Gateway — TEMPORAL_ADDRESS
Dev UI — TEMPORAL_ADDRESS


## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized in-cluster service addressing to use fully-qualified domain names (.svc.cluster.local) across Temporal components.
  * Updated deployments, init containers, and generated configs so connectivity checks, readiness probes, and runtime addresses consistently target the frontend FQDN with the configured port.
  * Improved internal DNS resolution consistency and startup reliability for Temporal services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Local Kind output:

```
➜  nv-config-manager git:(jp/fix-temporal-setup) make test-integration-local
🧪 Running integration tests against local Envoy Gateway...
   Using namespace: nv-config-manager
uv run pytest src/tests/integration/ -v --nv-config-manager-namespace nv-config-manager --timeout=900
============================================================================================================= test session starts =============================================================================================================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0 -- /Users/jpack/repos/nv-config-manager/.venv/bin/python
cachedir: .cache/pytest_cache
metadata: {'Python': '3.13.7', 'Platform': 'macOS-26.5-arm64-arm-64bit-Mach-O', 'Packages': {'pytest': '9.0.3', 'pluggy': '1.6.0'}, 'Plugins': {'mock': '3.15.1', 'cov': '7.1.0', 'aioresponses': '0.3.0', 'xdist': '3.8.0', 'timeout': '2.4.0', 'metadata': '3.1.1', 'html': '4.2.0', 'asyncio': '1.3.0', 'anyio': '4.13.0'}}
rootdir: /Users/jpack/repos/nv-config-manager
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, aioresponses-0.3.0, xdist-3.8.0, timeout-2.4.0, metadata-3.1.1, html-4.2.0, asyncio-1.3.0, anyio-4.13.0
timeout: 900.0s
timeout method: signal
timeout func_only: False
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 85 items                                                                                                                                                                                                                            

src/tests/integration/test_dhcp.py::TestDHCPAPI::test_dhcp_healthcheck PASSED                                                                                                                                                           [  1%]
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_dhcp_config_accessible PASSED                                                                                                                                                     [  2%]
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_dhcp_config_has_subnets PASSED                                                                                                                                                    [  3%]
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_dhcp_config_has_reservations PASSED                                                                                                                                               [  4%]
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_ztp_devices_have_dhcp_reservations PASSED                                                                                                                                         [  5%]
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_smn_devices_have_dhcp_pools SKIPPED (No SMN uplink subnets found)                                                                                                                 [  7%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_starts SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                                   [  8%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_reaches_complete SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                         [  9%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_stages_all_complete SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                      [ 10%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_result_has_attachment_url SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                [ 11%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_comment_posted SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                           [ 12%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_with_tech_support SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                        [ 14%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_invalid_ticket_fails SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                     [ 15%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_command_normalization SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                    [ 16%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_unknown_commands_ignored SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                 [ 17%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_multiple_devices SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                         [ 18%]
src/tests/integration/test_diagnostics.py::test_diagnostics_workflow_search_attribute SKIPPED (JIRA_ISSUE_KEY not set — Jira unreachable in CI)                                                                                         [ 20%]
src/tests/integration/test_diagnostics_ticketless.py::test_ticketless_workflow_starts PASSED                                                                                                                                            [ 21%]
src/tests/integration/test_diagnostics_ticketless.py::test_ticketless_workflow_completes PASSED                                                                                                                                         [ 22%]
src/tests/integration/test_diagnostics_ticketless.py::test_ticketless_jira_stages_unreachable PASSED                                                                                                                                    [ 23%]
src/tests/integration/test_diagnostics_ticketless.py::test_ticketless_result_has_diagnostics_content PASSED                                                                                                                             [ 24%]
src/tests/integration/test_diagnostics_ticketless.py::test_ticketless_result_no_jira_fields PASSED                                                                                                                                      [ 25%]
src/tests/integration/test_diagnostics_ticketless.py::test_ticketless_diagnostics_content_has_device_output PASSED                                                                                                                      [ 27%]
src/tests/integration/test_diagnostics_ticketless.py::test_ticketless_multiple_devices PASSED                                                                                                                                           [ 28%]
src/tests/integration/test_diagnostics_ticketless.py::test_ticketless_with_tech_support PASSED                                                                                                                                          [ 29%]
src/tests/integration/test_nautobot.py::TestNautobotGitTokens::test_git_token_env_var SKIPPED (CI-only test (pass --ci or set CI env var to run))                                                                                       [ 30%]
src/tests/integration/test_nautobot.py::TestNautobotGitTokens::test_git_username_env_var SKIPPED (CI-only test (pass --ci or set CI env var to run))                                                                                    [ 31%]
src/tests/integration/test_render.py::TestRenderPipeline::test_render_queues_drain PASSED                                                                                                                                               [ 32%]
src/tests/integration/test_render.py::TestRenderPipeline::test_all_devices_have_rendered_config PASSED                                                                                                                                  [ 34%]
src/tests/integration/test_render.py::TestRenderPipeline::test_rendered_configs_have_commit_ids PASSED                                                                                                                                  [ 35%]
src/tests/integration/test_spiffe.py::TestSpiffeHelperWritesArtifacts::test_jwt_svid_file_is_populated SKIPPED (SPIFFE tests require --spiffe)                                                                                          [ 36%]
src/tests/integration/test_spiffe.py::TestSpiffeHelperWritesArtifacts::test_jwt_svid_claims_are_spiffe_shaped SKIPPED (SPIFFE tests require --spiffe)                                                                                   [ 37%]
src/tests/integration/test_spiffe.py::TestSpiffeHelperWritesArtifacts::test_trust_bundle_is_valid_json_with_keys SKIPPED (SPIFFE tests require --spiffe)                                                                                [ 38%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_valid_jwt_yields_spiffe_identity[temporal] SKIPPED (SPIFFE tests require --spiffe)                                                                             [ 40%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_valid_jwt_yields_spiffe_identity[render] SKIPPED (SPIFFE tests require --spiffe)                                                                               [ 41%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_valid_jwt_yields_spiffe_identity[ztp] SKIPPED (SPIFFE tests require --spiffe)                                                                                  [ 42%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_valid_jwt_yields_spiffe_identity[dhcp] SKIPPED (SPIFFE tests require --spiffe)                                                                                 [ 43%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_valid_jwt_yields_spiffe_identity[config-store] SKIPPED (SPIFFE tests require --spiffe)                                                                         [ 44%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_no_token_is_rejected[temporal] SKIPPED (SPIFFE tests require --spiffe)                                                                                         [ 45%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_no_token_is_rejected[render] SKIPPED (SPIFFE tests require --spiffe)                                                                                           [ 47%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_no_token_is_rejected[ztp] SKIPPED (SPIFFE tests require --spiffe)                                                                                              [ 48%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_no_token_is_rejected[dhcp] SKIPPED (SPIFFE tests require --spiffe)                                                                                             [ 49%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_no_token_is_rejected[config-store] SKIPPED (SPIFFE tests require --spiffe)                                                                                     [ 50%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[temporal-bad-signature] SKIPPED (SPIFFE tests require --spiffe)                                                                        [ 51%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[temporal-tampered-payload] SKIPPED (SPIFFE tests require --spiffe)                                                                     [ 52%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[temporal-wrong-audience] SKIPPED (SPIFFE tests require --spiffe)                                                                       [ 54%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[temporal-garbage] SKIPPED (SPIFFE tests require --spiffe)                                                                              [ 55%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[render-bad-signature] SKIPPED (SPIFFE tests require --spiffe)                                                                          [ 56%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[render-tampered-payload] SKIPPED (SPIFFE tests require --spiffe)                                                                       [ 57%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[render-wrong-audience] SKIPPED (SPIFFE tests require --spiffe)                                                                         [ 58%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[render-garbage] SKIPPED (SPIFFE tests require --spiffe)                                                                                [ 60%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[ztp-bad-signature] SKIPPED (SPIFFE tests require --spiffe)                                                                             [ 61%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[ztp-tampered-payload] SKIPPED (SPIFFE tests require --spiffe)                                                                          [ 62%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[ztp-wrong-audience] SKIPPED (SPIFFE tests require --spiffe)                                                                            [ 63%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[ztp-garbage] SKIPPED (SPIFFE tests require --spiffe)                                                                                   [ 64%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[dhcp-bad-signature] SKIPPED (SPIFFE tests require --spiffe)                                                                            [ 65%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[dhcp-tampered-payload] SKIPPED (SPIFFE tests require --spiffe)                                                                         [ 67%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[dhcp-wrong-audience] SKIPPED (SPIFFE tests require --spiffe)                                                                           [ 68%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[dhcp-garbage] SKIPPED (SPIFFE tests require --spiffe)                                                                                  [ 69%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[config-store-bad-signature] SKIPPED (SPIFFE tests require --spiffe)                                                                    [ 70%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[config-store-tampered-payload] SKIPPED (SPIFFE tests require --spiffe)                                                                 [ 71%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[config-store-wrong-audience] SKIPPED (SPIFFE tests require --spiffe)                                                                   [ 72%]
src/tests/integration/test_spiffe.py::TestSpiffeAuthEnforcedAtApis::test_invalid_jwt_is_rejected[config-store-garbage] SKIPPED (SPIFFE tests require --spiffe)                                                                          [ 74%]
src/tests/integration/test_spiffe.py::TestSpiffePrefixRoleMapping::test_valid_jwt_gets_expected_role SKIPPED (SPIFFE tests require --spiffe)                                                                                            [ 75%]
src/tests/integration/test_spiffe.py::TestSpiffePrefixRoleMapping::test_forged_jwt_does_not_get_expected_role SKIPPED (SPIFFE tests require --spiffe)                                                                                   [ 76%]
src/tests/integration/test_spiffe.py::TestClientInjectsSpiffeJwt::test_client_injects_spiffe_jwt[temporal] SKIPPED (SPIFFE tests require --spiffe)                                                                                      [ 77%]
src/tests/integration/test_spiffe.py::TestClientInjectsSpiffeJwt::test_client_injects_spiffe_jwt[ztp] SKIPPED (SPIFFE tests require --spiffe)                                                                                           [ 78%]
src/tests/integration/test_spiffe.py::TestClientInjectsSpiffeJwt::test_client_injects_spiffe_jwt[render] SKIPPED (SPIFFE tests require --spiffe)                                                                                        [ 80%]
src/tests/integration/test_spiffe.py::TestClientInjectsSpiffeJwt::test_client_injects_spiffe_jwt[config-store] SKIPPED (SPIFFE tests require --spiffe)                                                                                  [ 81%]
src/tests/integration/test_spiffe.py::TestClientInjectsSpiffeJwt::test_client_without_headers_is_rejected[temporal] SKIPPED (SPIFFE tests require --spiffe)                                                                             [ 82%]
src/tests/integration/test_spiffe.py::TestClientInjectsSpiffeJwt::test_client_without_headers_is_rejected[ztp] SKIPPED (SPIFFE tests require --spiffe)                                                                                  [ 83%]
src/tests/integration/test_spiffe.py::TestClientInjectsSpiffeJwt::test_client_without_headers_is_rejected[render] SKIPPED (SPIFFE tests require --spiffe)                                                                               [ 84%]
src/tests/integration/test_spiffe.py::TestClientInjectsSpiffeJwt::test_client_without_headers_is_rejected[config-store] SKIPPED (SPIFFE tests require --spiffe)                                                                         [ 85%]
src/tests/integration/test_temporal.py::TestTemporalAPI::test_temporal_healthcheck PASSED                                                                                                                                               [ 87%]
src/tests/integration/test_temporal.py::TestTemporalAPI::test_workflow_types_endpoint PASSED                                                                                                                                            [ 88%]
src/tests/integration/test_temporal.py::TestTemporalAPI::test_hello_world_workflow_succeeds PASSED                                                                                                                                      [ 89%]
src/tests/integration/test_temporal.py::TestTemporalAPI::test_workflow_list_endpoint PASSED                                                                                                                                             [ 90%]
src/tests/integration/test_temporal.py::TestTemporalAPI::test_backup_workflow_has_no_failed_stages_and_backup_configs_exist PASSED                                                                                                      [ 91%]
src/tests/integration/test_temporal.py::TestTemporalAPI::test_rbac_config_status PASSED                                                                                                                                                 [ 92%]
src/tests/integration/test_ztp.py::TestZTPAPI::test_ztp_devices_can_fetch_config PASSED                                                                                                                                                 [ 94%]
src/tests/integration/test_ztp.py::TestZTPAPI::test_provisioned_endpoint_updates_status PASSED                                                                                                                                          [ 95%]
src/tests/integration/test_ztp.py::TestZTPAPI::test_ztp_devices_exist PASSED                                                                                                                                                            [ 96%]
src/tests/integration/test_ztp.py::TestZTPSFTP::test_sftp_fetch_config PASSED                                                                                                                                                           [ 97%]
src/tests/integration/test_ztp.py::TestZTPSFTP::test_sftp_healthcheck PASSED                                                                                                                                                            [ 98%]
src/tests/integration/test_ztp.py::TestZTPSFTP::test_sftp_connection PASSED                                                                                                                                                             [100%]

============================================================================================================== warnings summary ===============================================================================================================
.venv/lib/python3.13/site-packages/pythonjsonlogger/jsonlogger.py:11
  /Users/jpack/repos/nv-config-manager/.venv/lib/python3.13/site-packages/pythonjsonlogger/jsonlogger.py:11: DeprecationWarning: pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json
    warnings.warn(

src/tests/integration/test_dhcp.py::TestDHCPAPI::test_dhcp_healthcheck
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_dhcp_config_accessible
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_dhcp_config_has_subnets
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_dhcp_config_has_reservations
src/tests/integration/test_dhcp.py::TestDHCPAPI::test_ztp_devices_have_dhcp_reservations
  /Users/jpack/repos/nv-config-manager/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py:1110: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp.config-manager.local'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    warnings.warn(

src/tests/integration/test_dhcp.py: 2 warnings
src/tests/integration/test_diagnostics_ticketless.py: 1 warning
src/tests/integration/test_render.py: 2 warnings
src/tests/integration/test_temporal.py: 1 warning
src/tests/integration/test_ztp.py: 4 warnings
  /Users/jpack/repos/nv-config-manager/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py:1110: InsecureRequestWarning: Unverified HTTPS request is being made to host 'nautobot.config-manager.local'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    warnings.warn(

src/tests/integration/test_diagnostics_ticketless.py: 4 warnings
src/tests/integration/test_temporal.py: 6 warnings
  /Users/jpack/repos/nv-config-manager/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py:1110: InsecureRequestWarning: Unverified HTTPS request is being made to host 'workflow.config-manager.local'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    warnings.warn(

src/tests/integration/test_render.py::TestRenderPipeline::test_render_queues_drain
  /Users/jpack/repos/nv-config-manager/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py:1110: InsecureRequestWarning: Unverified HTTPS request is being made to host 'render.config-manager.local'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    warnings.warn(

src/tests/integration/test_ztp.py::TestZTPAPI::test_ztp_devices_can_fetch_config
src/tests/integration/test_ztp.py::TestZTPAPI::test_provisioned_endpoint_updates_status
  /Users/jpack/repos/nv-config-manager/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py:1110: InsecureRequestWarning: Unverified HTTPS request is being made to host 'ztp.config-manager.local'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================ 28 passed, 57 skipped, 29 warnings in 36.09s =================================================================================================
```