### PR TITLE
add longer pytest timeout for test_kea_config_valid

### DIFF
--- a/src/tests/dhcp/test_kea_dhcp_confgen.py
+++ b/src/tests/dhcp/test_kea_dhcp_confgen.py
@@ -181,6 +181,7 @@ async def test_subnet_id_preservation():
     assert 2 in subnet_ids.values()
 
 
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_kea_config_valid():
     """Validate that KEA accepts our generated configuration."""


### PR DESCRIPTION
## Description

Adding a 120-second timeout to `test_kea_config_valid()` to see if we can stop the test runs from failing.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution reliability with timeout configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/nv-config-manager/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->