### PR TITLE
update hooks, add dco check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,13 @@ git rebase --signoff HEAD~<number_of_commits>
    ```bash
    ./scripts/install-hooks.sh
    ```
-   This installs a pre-commit hook that auto-formats staged Python files with `ruff format` and verifies SPDX license headers are present in all source files.
+   This installs:
+
+   - `pre-commit`, which auto-formats staged Python files outside ignored/generated
+     directories with `ruff format` and verifies SPDX license headers in supported
+     source files.
+   - `commit-msg`, which rejects commit messages missing a DCO
+     `Signed-off-by: Name <email>` trailer.
 
 5. **Create a branch** for your changes:
    ```bash

--- a/README.md
+++ b/README.md
@@ -52,6 +52,29 @@ uv sync --dev
 ./scripts/install-hooks.sh
 ```
 
+### Git Hooks
+
+Install the repository hooks after cloning and whenever hook scripts change:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+Installed hooks:
+
+- `pre-commit`: formats all staged Python files outside ignored/generated
+  directories with `uv run ruff format`, re-stages those files, and checks SPDX
+  license headers for supported source files (`.py`, `.ts`, `.tsx`, `.js`,
+  `.jsx`, `.mjs`, `.cjs`, and `.go`) under `src/`, `ui/src/`, `ui/tests/`,
+  `components/`, `db/migrations/`, `scripts/`, `development/`,
+  `installer/src/`, `installer/tests/`, and `installer/scripts/`.
+- `commit-msg`: rejects commits that do not include a valid DCO
+  `Signed-off-by: Name <email>` trailer. Use `git commit -s` or
+  `git commit --amend -s` to add the trailer automatically.
+
+Local hooks can be skipped with `git commit --no-verify`, so the organization DCO
+app remains the merge-time enforcement gate in CI.
+
 For UI work:
 
 ```bash
@@ -334,8 +357,9 @@ Developer Certificate of Origin sign-off process described there.
 1. Fork the repository.
 2. Create a feature branch.
 3. Make changes.
-4. Run tests and linting with `make test lint`.
-5. Submit a pull request using the repository PR template.
+4. Install local hooks with `./scripts/install-hooks.sh`.
+5. Run tests and linting with `make test lint`.
+6. Submit a pull request using the repository PR template.
 
 Please also follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -82,6 +82,8 @@ PYTHON_DIRS = [
     "components/network-templates",
     "development/mock_topology",
     "installer/src",
+    "installer/tests",
+    "installer/scripts",
 ]
 
 JS_TS_DIRS = [
@@ -275,9 +277,9 @@ def main() -> None:
         total_modified += modified
         total_skipped += skipped
 
-    print("\nProcessing TypeScript files...")
+    print("\nProcessing TypeScript/JavaScript files...")
     for dir_path in JS_TS_DIRS:
-        for ext in (".ts", ".tsx"):
+        for ext in (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"):
             modified, skipped = process_directory(repo_root, dir_path, ext, add_header_to_js_ts)
             total_modified += modified
             total_skipped += skipped

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,96 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Commit message hook to require Developer Certificate of Origin sign-off.
+# Install with: ./scripts/install-hooks.sh
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+COMMIT_MSG_FILE="${1:-}"
+
+if [[ -z "$COMMIT_MSG_FILE" || ! -f "$COMMIT_MSG_FILE" ]]; then
+    echo -e "${RED}ERROR: commit-msg hook did not receive a commit message file.${NC}"
+    exit 1
+fi
+
+trim() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "$value"
+}
+
+trailers="$(git interpret-trailers --parse "$COMMIT_MSG_FILE")"
+valid_signoff_count=0
+invalid_signoffs=()
+git_user_name="$(git config user.name || true)"
+git_user_email="$(git config user.email || true)"
+
+while IFS= read -r line; do
+    token="$(trim "${line%%:*}")"
+    if [[ "${token,,}" != "signed-off-by" ]]; then
+        continue
+    fi
+
+    value="$(trim "${line#*:}")"
+    if [[ "$value" =~ ^[^[:space:]\<\>][^\<\>]*[[:space:]]\<[^\<\>@[:space:]]+@[^\<\>[:space:]]+\>$ ]] \
+        && [[ "${value,,}" != *"your name"* ]] \
+        && [[ "${value,,}" != *"your.email@example.com"* ]]; then
+        ((valid_signoff_count += 1))
+    else
+        invalid_signoffs+=("$value")
+    fi
+done <<< "$trailers"
+
+if [[ "$valid_signoff_count" -gt 0 ]]; then
+    echo -e "${GREEN}✓ DCO sign-off present${NC}"
+    exit 0
+fi
+
+echo -e "${RED}ERROR: commit message is missing a valid DCO sign-off.${NC}"
+echo ""
+if [[ -n "$git_user_name" && -n "$git_user_email" ]]; then
+    echo "Add a Signed-off-by trailer using your real name and email:"
+    echo ""
+    echo "  Signed-off-by: $git_user_name <$git_user_email>"
+    echo ""
+else
+    echo "Add a Signed-off-by trailer using your real name and email."
+    echo ""
+fi
+echo "Usually you can let Git add this automatically:"
+echo ""
+echo "  git commit -s"
+echo "  git commit --amend -s"
+echo ""
+
+if [[ "${#invalid_signoffs[@]}" -gt 0 ]]; then
+    echo -e "${YELLOW}Found malformed sign-off trailer(s):${NC}"
+    for signoff in "${invalid_signoffs[@]}"; do
+        echo "  Signed-off-by: $signoff"
+    done
+    echo ""
+fi
+
+echo "The organization DCO check is the final enforcement gate in CI; this hook catches"
+echo "the issue before you push."
+
+exit 1

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Pre-commit hook to verify SPDX license headers are present in source files.
+# Pre-commit hook to format staged Python files and verify SPDX license headers.
 # Install with: ./scripts/install-hooks.sh
 
 set -e
@@ -24,14 +24,31 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-EXTENSIONS=("py" "ts" "tsx" "go")
+EXTENSIONS=("py" "ts" "tsx" "js" "jsx" "mjs" "cjs" "go")
 
-CHECK_DIRS=("src/" "ui/src/" "ui/tests/" "components/" "db/migrations/" "scripts/" "development/" "installer/src/")
+CHECK_DIRS=(
+    "src/"
+    "ui/src/"
+    "ui/tests/"
+    "components/"
+    "db/migrations/"
+    "scripts/"
+    "development/"
+    "installer/src/"
+    "installer/tests/"
+    "installer/scripts/"
+)
 
 SKIP_PATTERNS=(
     "__pycache__"
     "node_modules"
     ".git"
+    ".mypy_cache"
+    ".pytest_cache"
+    ".ruff_cache"
+    ".venv"
+    "build/"
+    "dist/"
 )
 
 SPDX_IDENTIFIER="SPDX-License-Identifier: Apache-2.0"
@@ -40,7 +57,7 @@ LICENSE_TEXT="Licensed under the Apache License"
 missing_files=()
 checked_count=0
 
-staged_files=$(git diff --cached --name-only --diff-filter=ACM)
+mapfile -d '' -t staged_files < <(git diff --cached --name-only -z --diff-filter=ACM)
 
 should_skip() {
     local file="$1"
@@ -93,8 +110,12 @@ check_spdx_header() {
 
 # --- Ruff formatting ---
 staged_py_files=()
-for file in $staged_files; do
-    if [[ ( "$file" == src/* || "$file" == installer/src/* ) && "$file" == *.py ]] && [[ -f "$file" ]]; then
+for file in "${staged_files[@]}"; do
+    if should_skip "$file"; then
+        continue
+    fi
+
+    if [[ "$file" == *.py && -f "$file" ]]; then
         staged_py_files+=("$file")
     fi
 done
@@ -109,7 +130,7 @@ fi
 # --- SPDX header checks ---
 echo -e "${YELLOW}Checking SPDX license headers...${NC}"
 
-for file in $staged_files; do
+for file in "${staged_files[@]}"; do
     if ! is_in_check_dir "$file"; then
         continue
     fi
@@ -122,7 +143,7 @@ for file in $staged_files; do
         continue
     fi
 
-    ((checked_count++))
+    ((checked_count += 1))
 
     if ! check_spdx_header "$file"; then
         missing_files+=("$file")

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -27,20 +27,23 @@ echo "Installing git hooks..."
 
 mkdir -p "$HOOKS_DIR"
 
-if [[ -f "$SOURCE_HOOKS_DIR/pre-commit" ]]; then
-    cp "$SOURCE_HOOKS_DIR/pre-commit" "$HOOKS_DIR/pre-commit"
-    chmod +x "$HOOKS_DIR/pre-commit"
-    echo "  ✓ Installed pre-commit hook"
-else
-    echo "  ✗ pre-commit hook not found at $SOURCE_HOOKS_DIR/pre-commit"
-    exit 1
-fi
+for hook in pre-commit commit-msg; do
+    if [[ -f "$SOURCE_HOOKS_DIR/$hook" ]]; then
+        cp "$SOURCE_HOOKS_DIR/$hook" "$HOOKS_DIR/$hook"
+        chmod +x "$HOOKS_DIR/$hook"
+        echo "  ✓ Installed $hook hook"
+    else
+        echo "  ✗ $hook hook not found at $SOURCE_HOOKS_DIR/$hook"
+        exit 1
+    fi
+done
 
 echo ""
 echo "Git hooks installed successfully!"
 echo ""
 echo "Hooks installed:"
-echo "  - pre-commit: Auto-formats Python files with ruff, checks SPDX license headers"
+echo "  - pre-commit: Auto-formats staged Python files with ruff, checks SPDX license headers"
+echo "  - commit-msg: Requires a DCO Signed-off-by trailer"
 echo ""
-echo "To skip the pre-commit hook for a specific commit, use:"
+echo "To skip local hooks for a specific commit, use:"
 echo "  git commit --no-verify"


### PR DESCRIPTION
## Description

- Update list of dirs for format check
- Add commit-msg hook for DCO check

## Validation

```
zblevins@omni-lfn-dg82r:~/git/nv-config-manager$ git commit -s -m 'update hooks, add dco check' .
Running ruff format on staged Python files...
      Built nv-config-manager @ file:///home/zblevins/git/nv-config-manager
Uninstalled 2 packages in 95ms
Installed 2 packages in 63ms
1 file reformatted, 1 file left unchanged
✓ Formatted 2 Python file(s)
Checking SPDX license headers...
✓ All 2 checked files have valid SPDX headers
✓ DCO sign-off present
```

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contributing guidelines and setup documentation with a dedicated Git hooks section, detailing hook behaviors, installation steps, and instructions for bypassing hooks locally.

* **Chores**
  * Implemented Git hooks enforcing Python code formatting compliance and Developer Certificate of Origin (DCO) sign-off requirements on commits.
  * Updated installation scripts to support automatic setup of multiple hooks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/nv-config-manager/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->