### PR TITLE
add GitHub links to front page and start-here, and docs links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ NVIDIA Config Manager is an open-source network automation and configuration man
 
 | Service | Description |
 | :------ | :---------- |
-| **[ZTP](docs/network-ztp/index.mdx)** | Zero Touch Provisioning, boot scripts, OS image delivery, and provisioning status updates |
-| **[DHCP](docs/dhcp/index.mdx)** | Kea DHCP configuration generation from Nautobot data |
-| **[Temporal](docs/temporal/index.mdx)** | Long-running network operations and approval workflows |
-| **[Render](docs/render/index.mdx)** | Template rendering and event processing from Nautobot and workflow events |
-| **[Config Store](docs/config-store/index.mdx)** | PostgreSQL-backed rendered, intended, and backup configuration storage |
-| **[UI](docs/getting-started/interfaces.mdx)** | React/Next.js interface for workflows and configuration browsing |
-| **[Nautobot](docs/nautobot/index.mdx)** | Network source of truth, custom jobs, and event publication |
+| **[ZTP](https://docs.nvidia.com/switch-infrastructure/config-manager/services/network-ztp/overview)** | Zero Touch Provisioning, boot scripts, OS image delivery, and provisioning status updates |
+| **[DHCP](https://docs.nvidia.com/switch-infrastructure/config-manager/services/dhcp/overview)** | Kea DHCP configuration generation from Nautobot data |
+| **[Temporal](https://docs.nvidia.com/switch-infrastructure/config-manager/services/temporal/overview)** | Long-running network operations and approval workflows |
+| **[Render](https://docs.nvidia.com/switch-infrastructure/config-manager/services/render/overview)** | Template rendering and event processing from Nautobot and workflow events |
+| **[Config Store](https://docs.nvidia.com/switch-infrastructure/config-manager/services/config-store/overview)** | PostgreSQL-backed rendered, intended, and backup configuration storage |
+| **[UI](https://docs.nvidia.com/switch-infrastructure/config-manager/getting-started/which-interface-should-i-use)** | React/Next.js interface for workflows and configuration browsing |
+| **[Nautobot](https://docs.nvidia.com/switch-infrastructure/config-manager/config-manager/nautobot)** | Network source of truth, custom jobs, and event publication |
 
 ## Installer
 

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -13,6 +13,8 @@ Use Config Manager when you need to:
 - Review and approve Day-2 configuration changes before they reach devices.
 - Run operational workflows such as backup, deploy, cable validation, password rotation, OS upgrades, and reprovisioning.
 
+The project's GitHub repository is [https://github.com/nvidia/nv-config-manager](https://github.com/nvidia/nv-config-manager).
+
 ## Primary Personas
 
 | Persona | Primary work |

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,6 +8,8 @@ NVIDIA Config Manager is a platform for bootstrapping and managing NVIDIA AI-fac
 
 Read the [Start Here guide](getting-started/index.mdx) or learn fundamental concepts through the [Config Manager overview](overview/index.mdx). Then use the [deployment guide](install/index.mdx) and [user guides](user-guides/new-site-deployment/index.mdx) to install Config Manager, model network intent, render device configuration, run approved workflows, and troubleshoot day-0 and day-2 operations.
 
+The project's GitHub repository is [https://github.com/nvidia/nv-config-manager](https://github.com/nvidia/nv-config-manager).
+
 ## Start here
 
 - [Start Here](getting-started/index.mdx) explains the product, personas, and recommended first path.


### PR DESCRIPTION
## Description

Add GitHub links to the front page of the docs site, as well as to /getting-started/start-here.

Add docs links to README.

## Validation

Clicked all the links to make sure they work.

Ran `make docs-lint docs-lint fern`.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated service reference links in the overview table to point to official NVIDIA Config Manager documentation pages.
  * Added GitHub repository links to getting started and main documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->