### PR TITLE
fix(auth): match SPIFFE prefixes on path-segment boundaries

### DIFF
--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -44,7 +44,7 @@ INI sections::
     audiences = spiffe://trust-domain
 
     ; Map SPIFFE ID prefixes to group names.  Matching callers get the
-    ; mapped group (plus spiffe:<workload_name> for tracking).
+    ; mapped group.
     [auth.spiffe.groups]
     spiffe://trust-domain/ns/nv-config-manager = nv-config-manager
     spiffe://trust-domain/ns/dgxc = dgxc
@@ -159,7 +159,7 @@ class SpiffeConfig:
 
     ``group_prefixes`` maps SPIFFE ID *path-segment* prefixes to group names.
     When a caller's SPIFFE ID matches a prefix the mapped group is added to
-    its identity (in addition to ``spiffe:<workload_name>``).
+    its identity.
 
     Match semantics: the prefix matches a SPIFFE ID iff either
     (a) the SPIFFE ID equals the prefix exactly, or

--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -157,9 +157,20 @@ class JwtProviderConfig:
 class SpiffeConfig:
     """Configuration for SPIFFE JWT-SVID validation via PyJWT + JWKS.
 
-    ``group_prefixes`` maps SPIFFE ID prefixes to group names.
-    When a caller's SPIFFE ID matches a prefix, the mapped group is added
-    to its identity (in addition to ``spiffe:<workload_name>``).
+    ``group_prefixes`` maps SPIFFE ID *path-segment* prefixes to group names.
+    When a caller's SPIFFE ID matches a prefix the mapped group is added to
+    its identity (in addition to ``spiffe:<workload_name>``).
+
+    Match semantics: the prefix matches a SPIFFE ID iff either
+    (a) the SPIFFE ID equals the prefix exactly, or
+    (b) the SPIFFE ID starts with the prefix followed by ``/``.
+
+    This is the standard hierarchical-path matching used elsewhere in SPIFFE
+    tooling. It deliberately does **not** match across path-segment boundaries
+    so that a sibling identity such as
+    ``spiffe://td/ns/nv-config-manager-admin`` is not accidentally granted the
+    role mapped to the ``spiffe://td/ns/nv-config-manager`` prefix. Use a
+    longer/exact prefix to scope a role to a single identity.
 
     Configured via ``[auth.spiffe.groups]``::
 
@@ -545,8 +556,16 @@ def identity_from_spiffe(request: Request) -> SSOIdentity | None:
 
         groups: set[str] = {"all"}
 
+        # Match prefixes on path-segment boundaries: either the SPIFFE ID is
+        # exactly the prefix, or the prefix is followed by '/'. A naive
+        # ``startswith`` would also match sibling identities — e.g. the
+        # configured prefix ``spiffe://td/ns/nv-config-manager`` would
+        # otherwise match ``spiffe://td/ns/nv-config-manager-admin`` and
+        # silently grant it the ``nv-config-manager`` role. SPIFFE IDs are
+        # hierarchical paths, so the boundary must be a ``/`` (or
+        # end-of-string).
         for prefix, group in cfg.spiffe.group_prefixes:
-            if spiffe_id.startswith(prefix):
+            if spiffe_id == prefix or spiffe_id.startswith(prefix + "/"):
                 groups.add(group)
 
         return SSOIdentity(

--- a/src/tests/common/test_auth.py
+++ b/src/tests/common/test_auth.py
@@ -1228,13 +1228,13 @@ class TestSpiffeGroupPrefixes:
     def test_layered_prefixes_add_both_roles(self, rsa_keypair, make_jwt):
         """Per-service narrow prefix layers on top of a coarser one.
 
-        A SPIFFE ID under ``…/nv-config-manager/render`` must pick up BOTH the
-        broad ``nv-config-manager`` role (from the ``…/nv-config-manager``
-        prefix, matched via path-segment boundary) and the narrow
-        ``nv-config-manager-render`` role (from the exact
-        ``…/nv-config-manager/render`` prefix). This is what enables
-        progressive scoping: keep coarse roles working while introducing
-        tighter per-service roles to gate sensitive endpoints.
+        A SPIFFE ID *below* ``…/nv-config-manager/render`` must pick up BOTH
+        the broad ``nv-config-manager`` role and the narrow
+        ``nv-config-manager-render`` role -- both matched via the
+        ``prefix + "/"`` path-segment boundary (a descendant SVID, not an
+        exact prefix match). This is what enables progressive scoping: keep
+        coarse roles working while introducing tighter per-service roles to
+        gate sensitive endpoints.
         """
         cp = _make_config(
             **{
@@ -1250,10 +1250,14 @@ class TestSpiffeGroupPrefixes:
         )
         auth_mod._auth_config = load_auth_config(cp)
 
+        # SVID sits a segment below the narrow prefix so that BOTH mapped
+        # prefixes are hit via the descendant (``prefix + "/"``) branch, not an
+        # exact match -- proving layered roles still accumulate for sub-workload
+        # identities.
         token, mock_jwk = self._mock_spiffe_request(
             rsa_keypair,
             make_jwt,
-            sub="spiffe://cluster.local/ns/nv-config-manager/render",
+            sub="spiffe://cluster.local/ns/nv-config-manager/render/sa/api",
             aud="spiffe://cluster.local",
         )
 

--- a/src/tests/common/test_auth.py
+++ b/src/tests/common/test_auth.py
@@ -1145,6 +1145,130 @@ class TestSpiffeGroupPrefixes:
         assert "dgxc" in data["groups"]
         assert "nv-config-manager" not in data["groups"]
 
+    def test_sibling_identity_not_granted_role(self, rsa_keypair, make_jwt):
+        """A sibling identity sharing a common prefix must NOT inherit the role.
+
+        Regression test for the prefix-matching footgun:
+        ``spiffe://cluster.local/ns/nv-config-manager`` configured as the
+        prefix for the ``nv-config-manager`` role must not match a sibling
+        SPIFFE ID like ``spiffe://cluster.local/ns/nv-config-manager-admin``.
+        Path matching is on segment boundaries, so ``nv-config-manager-admin``
+        falls outside the ``ns/nv-config-manager`` path and gets only the
+        baseline ``all`` group.
+        """
+        cp = _make_config(
+            **{
+                "auth.spiffe": {
+                    "jwks_uri": "https://spire-server:8443/keys",
+                    "audiences": "spiffe://cluster.local",
+                },
+                "auth.spiffe.groups": {
+                    "spiffe://cluster.local/ns/nv-config-manager": "nv-config-manager",
+                },
+            }
+        )
+        auth_mod._auth_config = load_auth_config(cp)
+
+        token, mock_jwk = self._mock_spiffe_request(
+            rsa_keypair,
+            make_jwt,
+            sub="spiffe://cluster.local/ns/nv-config-manager-admin/sa/attacker",
+            aud="spiffe://cluster.local",
+        )
+
+        app = self._make_app()
+        client = TestClient(app)
+        with patch("nv_config_manager.common.auth._get_jwks_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.get_signing_key_from_jwt.return_value = mock_jwk
+            mock_get_client.return_value = mock_client
+            resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+
+        data = resp.json()
+        assert "nv-config-manager" not in data["groups"], (
+            f"sibling identity must not inherit the 'nv-config-manager' role; "
+            f"got groups={data['groups']!r}"
+        )
+        assert data["groups"] == ["all"]
+
+    def test_exact_match_grants_role(self, rsa_keypair, make_jwt):
+        """An SVID equal to the prefix (no trailing path) still gets the role."""
+        cp = _make_config(
+            **{
+                "auth.spiffe": {
+                    "jwks_uri": "https://spire-server:8443/keys",
+                    "audiences": "spiffe://cluster.local",
+                },
+                "auth.spiffe.groups": {
+                    "spiffe://cluster.local/ns/nv-config-manager": "nv-config-manager",
+                },
+            }
+        )
+        auth_mod._auth_config = load_auth_config(cp)
+
+        token, mock_jwk = self._mock_spiffe_request(
+            rsa_keypair,
+            make_jwt,
+            sub="spiffe://cluster.local/ns/nv-config-manager",
+            aud="spiffe://cluster.local",
+        )
+
+        app = self._make_app()
+        client = TestClient(app)
+        with patch("nv_config_manager.common.auth._get_jwks_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.get_signing_key_from_jwt.return_value = mock_jwk
+            mock_get_client.return_value = mock_client
+            resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+
+        data = resp.json()
+        assert "nv-config-manager" in data["groups"]
+        assert "all" in data["groups"]
+
+    def test_layered_prefixes_add_both_roles(self, rsa_keypair, make_jwt):
+        """Per-service narrow prefix layers on top of a coarser one.
+
+        A SPIFFE ID under ``…/nv-config-manager/render`` must pick up BOTH the
+        broad ``nv-config-manager`` role (from the ``…/nv-config-manager``
+        prefix, matched via path-segment boundary) and the narrow
+        ``nv-config-manager-render`` role (from the exact
+        ``…/nv-config-manager/render`` prefix). This is what enables
+        progressive scoping: keep coarse roles working while introducing
+        tighter per-service roles to gate sensitive endpoints.
+        """
+        cp = _make_config(
+            **{
+                "auth.spiffe": {
+                    "jwks_uri": "https://spire-server:8443/keys",
+                    "audiences": "spiffe://cluster.local",
+                },
+                "auth.spiffe.groups": {
+                    "spiffe://cluster.local/ns/nv-config-manager": "nv-config-manager",
+                    "spiffe://cluster.local/ns/nv-config-manager/render": "nv-config-manager-render",
+                },
+            }
+        )
+        auth_mod._auth_config = load_auth_config(cp)
+
+        token, mock_jwk = self._mock_spiffe_request(
+            rsa_keypair,
+            make_jwt,
+            sub="spiffe://cluster.local/ns/nv-config-manager/render",
+            aud="spiffe://cluster.local",
+        )
+
+        app = self._make_app()
+        client = TestClient(app)
+        with patch("nv_config_manager.common.auth._get_jwks_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.get_signing_key_from_jwt.return_value = mock_jwk
+            mock_get_client.return_value = mock_client
+            resp = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+
+        data = resp.json()
+        assert "nv-config-manager" in data["groups"]
+        assert "nv-config-manager-render" in data["groups"]
+
     def test_group_prefixes_parsed(self):
         """[auth.spiffe.groups] section is parsed into group_prefixes."""
         cp = _make_config(


### PR DESCRIPTION
A naive startswith() match let a sibling identity (e.g. spiffe://td/ns/nv-config-manager-admin) inherit the role mapped to a shorter prefix (spiffe://td/ns/nv-config-manager). Match now requires an exact prefix or a '/' boundary, so roles only apply along hierarchical SPIFFE path segments. Adds sibling/exact/layered regression tests.

## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->

- Enforce boundary-aware SPIFFE group-prefix matching (exact or `/`-delimited), preventing sibling identities from inheriting a shorter prefix's role.
- Align the `SpiffeConfig` docstring and INI example with the implementation: removed the unimplemented `spiffe:<workload_name>` tracking-group claim, since `identity_from_spiffe()` only adds `"all"` plus configured mapped groups.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/28549893053

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SPIFFE group-prefix matching now enforces boundary-aware semantics: a configured prefix grants roles only on exact match or when the ID continues with a path segment, preventing sibling identities from unintentionally receiving mapped roles.

* **Tests**
  * Added regression tests covering boundary-aware prefix matching, exact-prefix grants, and cumulative behavior when multiple overlapping prefixes apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
