### PR TITLE
feat(installer): stamp provenance labels on installer-managed resources

### DIFF
--- a/installer/src/nv_config_manager_installer/deployer.py
+++ b/installer/src/nv_config_manager_installer/deployer.py
@@ -48,6 +48,7 @@ from nv_config_manager_installer.k8s import (
     K8sClient,
     ServiceProxy,
     kubectl_current_context,
+    nv_config_manager_helm_common_labels,
     pin_kubeconfig_to_current_context,
 )
 from nv_config_manager_installer.operator_versions import load_operator_versions
@@ -1081,7 +1082,7 @@ class Deployer:
             step.output.append(f"{tool}: found")
 
         try:
-            self._k8s = K8sClient()
+            self._k8s = K8sClient(release_name=self.config.cluster.release_name)
         except Exception as exc:
             raise RuntimeError(f"Cannot load kubeconfig: {exc}") from exc
         if not self._k8s.check_connectivity():
@@ -1477,6 +1478,37 @@ class Deployer:
             raise RuntimeError(f"Airgapped deployment requested but {description} was not found")
         return artifact
 
+    @staticmethod
+    def _helm_common_labels_args(prefix: str = "commonLabels") -> list[str]:
+        """Build ``--set-string`` args that stamp installer labels on every
+        resource a chart renders.
+
+        ``prefix`` is the values-file key path: ``commonLabels`` for most
+        charts (Envoy Gateway, CNPG, prometheus-operator) and
+        ``global.commonLabels`` for cert-manager. Helm's ``--set`` parser
+        treats unescaped dots as nested-key separators, so dots inside the
+        *label key* (e.g. ``nv-config-manager.nvidia.com/installer``) are
+        escaped with a backslash — the prefix itself never contains a label
+        key so it stays as-is.
+        """
+        args: list[str] = []
+        for key, value in nv_config_manager_helm_common_labels().items():
+            escaped_key = key.replace(".", "\\.")
+            args.extend(["--set-string", f"{prefix}.{escaped_key}={value}"])
+        return args
+
+    def _ensure_operator_namespace(self, name: str) -> None:
+        """Pre-create an operator namespace so it carries installer provenance labels.
+
+        Helm's ``--create-namespace`` flag would otherwise lazily create an
+        unlabelled namespace, which leaves no breadcrumb for cleanup. Calling
+        ``ensure_namespace`` first stamps the installer labels (via
+        ``_object_meta``) and turns ``--create-namespace`` into a no-op.
+        """
+        assert self._k8s is not None
+        if self._k8s.ensure_namespace(name):
+            self.callback.on_log(f"Created namespace: {name}")
+
     def _install_crds(self) -> None:
         opts = self.options
         observability_on = self.config.infrastructure.monitoring.observability_enabled
@@ -1494,6 +1526,8 @@ class Deployer:
         step = self._start_step("install-crds")
         versions = load_operator_versions(Path(opts.chart_dir))
         bundle_root = self._operator_bundle_root()
+        common_labels_args = self._helm_common_labels_args()
+        cert_manager_label_args = self._helm_common_labels_args("global.commonLabels")
 
         if opts.install_envoy_gateway:
             # The Envoy Gateway Helm chart carries the matching Gateway API and
@@ -1514,6 +1548,7 @@ class Deployer:
                 if envoy_chart is not None
                 else "oci://docker.io/envoyproxy/gateway-helm"
             )
+            self._ensure_operator_namespace("envoy-gateway-system")
             envoy_args = [
                 "helm",
                 "upgrade",
@@ -1526,6 +1561,7 @@ class Deployer:
                 "--wait",
                 "--timeout",
                 "120s",
+                *common_labels_args,
             ]
             if envoy_chart is not None:
                 self.callback.on_log(f"Using local chart: {envoy_chart}")
@@ -1582,6 +1618,7 @@ class Deployer:
                 if cert_manager_chart is not None
                 else "jetstack/cert-manager"
             )
+            self._ensure_operator_namespace("cert-manager")
             cert_manager_args = [
                 "helm",
                 "upgrade",
@@ -1594,6 +1631,7 @@ class Deployer:
                 "--wait",
                 "--timeout",
                 "120s",
+                *cert_manager_label_args,
             ]
             if cert_manager_chart is not None:
                 self.callback.on_log(f"Using local chart: {cert_manager_chart}")
@@ -1680,6 +1718,11 @@ class Deployer:
                 f"CNPG operator chart {versions.cnpg_operator_version}",
             )
             cnpg_chart_ref = str(cnpg_chart) if cnpg_chart is not None else "cnpg/cloudnative-pg"
+            self._ensure_operator_namespace("cnpg-system")
+            # cloudnative-pg ≤0.28 has no chart-wide commonLabels value, so we
+            # only get installer labels on the namespace + on the operator pod
+            # via podLabels. Namespace-level cleanup still works.
+            cnpg_pod_label_args = self._helm_common_labels_args("podLabels")
             cnpg_args = [
                 "helm",
                 "upgrade",
@@ -1692,6 +1735,7 @@ class Deployer:
                 "--wait",
                 "--timeout",
                 "120s",
+                *cnpg_pod_label_args,
             ]
             if cnpg_chart is not None:
                 self.callback.on_log(f"Using local chart: {cnpg_chart}")
@@ -1746,6 +1790,11 @@ class Deployer:
                 if prom_crds_chart is not None
                 else "prometheus-community/prometheus-operator-crds"
             )
+            self._ensure_operator_namespace("nv-config-manager-monitoring")
+            # The prometheus-operator-crds chart only exposes ``crds.annotations``
+            # (not labels) — CRDs are cluster-scoped so namespace-deletion can't
+            # reach them anyway. Tag them with our installer annotation so they
+            # show up in audits.
             prom_crds_args = [
                 "helm",
                 "upgrade",
@@ -1758,6 +1807,8 @@ class Deployer:
                 "--wait",
                 "--timeout",
                 "120s",
+                "--set-string",
+                "crds.annotations.nv-config-manager\\.nvidia\\.com/installer=nv-config-manager-installer",
             ]
             if prom_crds_chart is not None:
                 self.callback.on_log(f"Using local chart: {prom_crds_chart}")

--- a/installer/src/nv_config_manager_installer/deployer.py
+++ b/installer/src/nv_config_manager_installer/deployer.py
@@ -1526,7 +1526,6 @@ class Deployer:
         step = self._start_step("install-crds")
         versions = load_operator_versions(Path(opts.chart_dir))
         bundle_root = self._operator_bundle_root()
-        common_labels_args = self._helm_common_labels_args()
         cert_manager_label_args = self._helm_common_labels_args("global.commonLabels")
 
         if opts.install_envoy_gateway:
@@ -1548,6 +1547,10 @@ class Deployer:
                 if envoy_chart is not None
                 else "oci://docker.io/envoyproxy/gateway-helm"
             )
+            # gateway-helm has no chart-wide ``commonLabels`` value, so passing
+            # one would be a silent no-op. The pre-created namespace above
+            # carries the installer labels instead, which is what cleanup
+            # selectors key off of.
             self._ensure_operator_namespace("envoy-gateway-system")
             envoy_args = [
                 "helm",
@@ -1561,7 +1564,6 @@ class Deployer:
                 "--wait",
                 "--timeout",
                 "120s",
-                *common_labels_args,
             ]
             if envoy_chart is not None:
                 self.callback.on_log(f"Using local chart: {envoy_chart}")

--- a/installer/src/nv_config_manager_installer/k8s.py
+++ b/installer/src/nv_config_manager_installer/k8s.py
@@ -47,7 +47,45 @@ from kubernetes import client, config, watch
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream as k8s_stream
 
+from nv_config_manager_installer import __version__ as _INSTALLER_VERSION
+
 LOADER_POD_IMAGE = "docker.io/library/busybox:1.36"
+
+# Provenance metadata stamped onto every resource the installer creates
+# directly via the Kubernetes API (i.e. outside of any Helm release).
+# These mirror the Kubernetes "recommended labels" so cleanup commands like
+# ``kubectl delete -l app.kubernetes.io/managed-by=nv-config-manager-installer`` work.
+LABEL_MANAGED_BY = "app.kubernetes.io/managed-by"
+LABEL_PART_OF = "app.kubernetes.io/part-of"
+LABEL_INSTANCE = "app.kubernetes.io/instance"
+MANAGED_BY_VALUE = "nv-config-manager-installer"
+PART_OF_VALUE = "nv-config-manager"
+ANNOTATION_INSTALLER_VERSION = "nv-config-manager.nvidia.com/installer-version"
+
+# Cross-cutting label stamped on *both* direct-API resources AND on Helm
+# releases the installer drives (via each chart's commonLabels value). This
+# gives a single selector — ``nv-config-manager.nvidia.com/installer=nv-config-manager-installer`` —
+# that lights up every resource the installer brought into the cluster,
+# regardless of who actually created the K8s object (us, Helm, or an
+# operator that propagates commonLabels). Helm itself owns the
+# ``app.kubernetes.io/managed-by`` key on chart-rendered resources, so we
+# can't reuse that for chart resources — hence this installer-namespaced label.
+LABEL_INSTALLER = "nv-config-manager.nvidia.com/installer"
+INSTALLER_VALUE = "nv-config-manager-installer"
+
+
+def nv_config_manager_helm_common_labels() -> dict[str, str]:
+    """Return the label set the installer wants on every Helm release it drives.
+
+    Callers feed this to ``--set-string commonLabels.<key>=<value>`` (or
+    ``global.commonLabels.<key>=<value>`` for charts like cert-manager that
+    nest it under ``global``). Helm's set-string parser treats unescaped dots
+    as nested-key separators, so callers must escape dots in keys with ``\\.``.
+    """
+    return {
+        LABEL_INSTALLER: INSTALLER_VALUE,
+        LABEL_PART_OF: PART_OF_VALUE,
+    }
 
 
 def kubectl_current_context() -> str | None:
@@ -128,7 +166,13 @@ def pin_kubeconfig_to_current_context() -> tuple[Path, str] | None:
 class K8sClient:
     """High-level wrapper around the ``kubernetes`` Python client."""
 
-    def __init__(self, context: str | None = None) -> None:
+    def __init__(
+        self,
+        context: str | None = None,
+        *,
+        release_name: str | None = None,
+        installer_version: str = _INSTALLER_VERSION,
+    ) -> None:
         # The Python kubernetes client and kubectl/helm disagree on which
         # context is "current" when KUBECONFIG merges multiple files that each
         # set their own current-context: kubectl picks the FIRST file's value,
@@ -155,6 +199,37 @@ class K8sClient:
             self.api_server: str | None = self.v1.api_client.configuration.host
         except Exception:
             self.api_server = None
+        self._release_name = release_name
+        self._installer_version = installer_version
+
+    # -- Provenance metadata --------------------------------------------------
+
+    def _object_meta(
+        self,
+        name: str,
+        namespace: str | None = None,
+    ) -> client.V1ObjectMeta:
+        """Build a V1ObjectMeta stamped with installer provenance labels.
+
+        Used for every resource the installer creates directly via the
+        Kubernetes API (i.e. not via Helm). Lets users find and clean up
+        installer-created objects with selectors like
+        ``app.kubernetes.io/managed-by=nv-config-manager-installer``.
+        """
+        labels = {
+            LABEL_MANAGED_BY: MANAGED_BY_VALUE,
+            LABEL_PART_OF: PART_OF_VALUE,
+            LABEL_INSTALLER: INSTALLER_VALUE,
+        }
+        if self._release_name:
+            labels[LABEL_INSTANCE] = self._release_name
+        annotations = {ANNOTATION_INSTALLER_VERSION: self._installer_version}
+        return client.V1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            labels=labels,
+            annotations=annotations,
+        )
 
     # -- Cluster connectivity -------------------------------------------------
 
@@ -187,7 +262,7 @@ class K8sClient:
         return getattr(ns.status, "phase", None) if ns.status else None
 
     def create_namespace(self, name: str) -> None:
-        body = client.V1Namespace(metadata=client.V1ObjectMeta(name=name))
+        body = client.V1Namespace(metadata=self._object_meta(name))
         self.v1.create_namespace(body)
 
     def ensure_namespace(self, name: str) -> bool:
@@ -239,7 +314,7 @@ class K8sClient:
     ) -> None:
         """Create or replace a secret with plaintext string data."""
         body = client.V1Secret(
-            metadata=client.V1ObjectMeta(name=name, namespace=namespace),
+            metadata=self._object_meta(name, namespace),
             string_data=string_data,
             type=secret_type,
         )
@@ -265,7 +340,7 @@ class K8sClient:
             {"auths": {server: {"username": username, "password": password, "auth": auth}}}
         )
         body = client.V1Secret(
-            metadata=client.V1ObjectMeta(name=name, namespace=namespace),
+            metadata=self._object_meta(name, namespace),
             data={".dockerconfigjson": base64.b64encode(docker_config.encode()).decode()},
             type="kubernetes.io/dockerconfigjson",
         )
@@ -286,7 +361,7 @@ class K8sClient:
         """Create or replace a secret with binary file data (e.g. from-file)."""
         encoded = {k: base64.b64encode(v).decode() for k, v in file_data.items()}
         body = client.V1Secret(
-            metadata=client.V1ObjectMeta(name=name, namespace=namespace),
+            metadata=self._object_meta(name, namespace),
             data=encoded,
             type="Opaque",
         )
@@ -419,7 +494,7 @@ class K8sClient:
             spec.storage_class_name = storage_class
 
         body = client.V1PersistentVolumeClaim(
-            metadata=client.V1ObjectMeta(name=name, namespace=namespace),
+            metadata=self._object_meta(name, namespace),
             spec=spec,
         )
         self.v1.create_namespaced_persistent_volume_claim(namespace, body)
@@ -487,7 +562,7 @@ class K8sClient:
     ) -> None:
         """Create a short-lived pod that mounts a PVC for content loading."""
         body = client.V1Pod(
-            metadata=client.V1ObjectMeta(name=name, namespace=namespace),
+            metadata=self._object_meta(name, namespace),
             spec=client.V1PodSpec(
                 restart_policy="Never",
                 containers=[

--- a/installer/tests/test_deployer.py
+++ b/installer/tests/test_deployer.py
@@ -289,6 +289,7 @@ class TestInstallCrds:
             DeployOptions(chart_dir=str(tmp_path / "helm"), install_cert_manager=True),
             RecordingCallback(),
         )
+        deployer._k8s = _mock_k8s()
         deployer._install_crds()
 
         assert any("charts.jetstack.io" in " ".join(cmd) for cmd in run_commands)
@@ -346,6 +347,7 @@ class TestInstallCrds:
             ),
             RecordingCallback(),
         )
+        deployer._k8s = _mock_k8s()
         deployer._install_crds()
 
         rendered_commands = [" ".join(cmd) for cmd in logged_commands]
@@ -416,6 +418,171 @@ class TestInstallCrds:
         assert str(charts_dir / "prometheus-operator-crds-28.0.1.tgz") in prom_crds_cmd
         assert run_commands == []
         assert not any("github.com/cert-manager" in cmd for cmd in rendered_commands)
+
+
+class TestInstallCrdsProvenance:
+    """Verify operator namespaces get pre-created with installer labels and that
+    chart-aware ``commonLabels`` args reach the helm CLI so installer-managed
+    resources are discoverable for cleanup.
+    """
+
+    @staticmethod
+    def _run_install_crds(tmp_path, monkeypatch, *, options: DeployOptions):
+        (tmp_path / "operator-versions.env").write_text(_OPERATOR_VERSIONS)
+        run_commands: list[list[str]] = []
+        logged_commands: list[list[str]] = []
+        monkeypatch.setattr(
+            "nv_config_manager_installer.deployer._run",
+            lambda cmd, **kw: (run_commands.append(cmd), MagicMock(returncode=0))[1],
+        )
+        monkeypatch.setattr(
+            "nv_config_manager_installer.deployer._run_logged",
+            lambda cmd, step, callback, **kw: (
+                logged_commands.append(cmd),
+                MagicMock(returncode=0),
+            )[1],
+        )
+
+        deployer = Deployer(_make_config(), options, RecordingCallback())
+        deployer._k8s = _mock_k8s()
+        deployer._install_crds()
+        return deployer, logged_commands
+
+    def test_envoy_namespace_pre_created_with_installer_labels(self, tmp_path, monkeypatch):
+        deployer, _ = self._run_install_crds(
+            tmp_path,
+            monkeypatch,
+            options=DeployOptions(chart_dir=str(tmp_path), install_envoy_gateway=True),
+        )
+        assert ("envoy-gateway-system",) in {
+            (c.args[0],) for c in deployer._k8s.ensure_namespace.call_args_list
+        }
+
+    def test_cert_manager_namespace_pre_created(self, tmp_path, monkeypatch):
+        deployer, _ = self._run_install_crds(
+            tmp_path,
+            monkeypatch,
+            options=DeployOptions(chart_dir=str(tmp_path), install_cert_manager=True),
+        )
+        assert ("cert-manager",) in {
+            (c.args[0],) for c in deployer._k8s.ensure_namespace.call_args_list
+        }
+
+    def test_cnpg_namespace_pre_created(self, tmp_path, monkeypatch):
+        deployer, _ = self._run_install_crds(
+            tmp_path,
+            monkeypatch,
+            options=DeployOptions(chart_dir=str(tmp_path), install_cnpg_operator=True),
+        )
+        assert ("cnpg-system",) in {
+            (c.args[0],) for c in deployer._k8s.ensure_namespace.call_args_list
+        }
+
+    def test_observability_namespace_pre_created(self, tmp_path, monkeypatch):
+        config = _make_config()
+        config.infrastructure.monitoring.observability_enabled = True
+        (tmp_path / "operator-versions.env").write_text(_OPERATOR_VERSIONS)
+        run_commands: list[list[str]] = []
+        logged_commands: list[list[str]] = []
+        monkeypatch.setattr(
+            "nv_config_manager_installer.deployer._run",
+            lambda cmd, **kw: (run_commands.append(cmd), MagicMock(returncode=0))[1],
+        )
+        monkeypatch.setattr(
+            "nv_config_manager_installer.deployer._run_logged",
+            lambda cmd, step, callback, **kw: (
+                logged_commands.append(cmd),
+                MagicMock(returncode=0),
+            )[1],
+        )
+
+        deployer = Deployer(config, DeployOptions(chart_dir=str(tmp_path)), RecordingCallback())
+        deployer._k8s = _mock_k8s()
+        deployer._install_crds()
+
+        assert ("nv-config-manager-monitoring",) in {
+            (c.args[0],) for c in deployer._k8s.ensure_namespace.call_args_list
+        }
+
+    def test_envoy_helm_args_include_common_labels(self, tmp_path, monkeypatch):
+        _, logged = self._run_install_crds(
+            tmp_path,
+            monkeypatch,
+            options=DeployOptions(chart_dir=str(tmp_path), install_envoy_gateway=True),
+        )
+        envoy_cmd = next(cmd for cmd in logged if cmd[:4] == ["helm", "upgrade", "--install", "eg"])
+        # Dotted label keys must be backslash-escaped to survive helm's --set parser.
+        assert (
+            "commonLabels.nv-config-manager\\.nvidia\\.com/installer=nv-config-manager-installer"
+            in envoy_cmd
+        )
+        assert "commonLabels.app\\.kubernetes\\.io/part-of=nv-config-manager" in envoy_cmd
+
+    def test_cert_manager_helm_args_use_global_common_labels(self, tmp_path, monkeypatch):
+        # cert-manager nests commonLabels under ``global`` — getting the prefix
+        # wrong means the labels silently land nowhere.
+        _, logged = self._run_install_crds(
+            tmp_path,
+            monkeypatch,
+            options=DeployOptions(chart_dir=str(tmp_path), install_cert_manager=True),
+        )
+        cert_cmd = next(
+            cmd for cmd in logged if cmd[:4] == ["helm", "upgrade", "--install", "cert-manager"]
+        )
+        assert (
+            "global.commonLabels.nv-config-manager\\.nvidia\\.com/installer="
+            "nv-config-manager-installer" in cert_cmd
+        )
+        assert "global.commonLabels.app\\.kubernetes\\.io/part-of=nv-config-manager" in cert_cmd
+
+    def test_cnpg_helm_args_use_pod_labels_fallback(self, tmp_path, monkeypatch):
+        # cloudnative-pg has no chart-wide commonLabels value, so the best we
+        # can do is stamp the operator pod via podLabels. Anything else is
+        # covered by namespace-level cleanup.
+        _, logged = self._run_install_crds(
+            tmp_path,
+            monkeypatch,
+            options=DeployOptions(chart_dir=str(tmp_path), install_cnpg_operator=True),
+        )
+        cnpg_cmd = next(
+            cmd for cmd in logged if cmd[:4] == ["helm", "upgrade", "--install", "cnpg"]
+        )
+        assert (
+            "podLabels.nv-config-manager\\.nvidia\\.com/installer=nv-config-manager-installer"
+            in cnpg_cmd
+        )
+
+    def test_prom_crds_helm_args_use_crd_annotations(self, tmp_path, monkeypatch):
+        # prometheus-operator-crds only exposes crds.annotations — labels
+        # aren't an option, so we annotate the CRDs for audit visibility.
+        config = _make_config()
+        config.infrastructure.monitoring.observability_enabled = True
+        (tmp_path / "operator-versions.env").write_text(_OPERATOR_VERSIONS)
+        logged_commands: list[list[str]] = []
+        monkeypatch.setattr(
+            "nv_config_manager_installer.deployer._run",
+            lambda cmd, **kw: MagicMock(returncode=0),
+        )
+        monkeypatch.setattr(
+            "nv_config_manager_installer.deployer._run_logged",
+            lambda cmd, step, callback, **kw: (
+                logged_commands.append(cmd),
+                MagicMock(returncode=0),
+            )[1],
+        )
+        deployer = Deployer(config, DeployOptions(chart_dir=str(tmp_path)), RecordingCallback())
+        deployer._k8s = _mock_k8s()
+        deployer._install_crds()
+
+        prom_cmd = next(
+            cmd
+            for cmd in logged_commands
+            if cmd[:4] == ["helm", "upgrade", "--install", "nv-config-manager-prom-crds"]
+        )
+        assert (
+            "crds.annotations.nv-config-manager\\.nvidia\\.com/installer="
+            "nv-config-manager-installer" in prom_cmd
+        )
 
 
 class TestDeployOptions:

--- a/installer/tests/test_deployer.py
+++ b/installer/tests/test_deployer.py
@@ -504,19 +504,17 @@ class TestInstallCrdsProvenance:
             (c.args[0],) for c in deployer._k8s.ensure_namespace.call_args_list
         }
 
-    def test_envoy_helm_args_include_common_labels(self, tmp_path, monkeypatch):
+    def test_envoy_helm_args_omit_common_labels(self, tmp_path, monkeypatch):
+        # gateway-helm has no chart-wide commonLabels value, so we must NOT
+        # pass one (it would be a silent no-op). Envoy provenance comes from
+        # the pre-created namespace label instead.
         _, logged = self._run_install_crds(
             tmp_path,
             monkeypatch,
             options=DeployOptions(chart_dir=str(tmp_path), install_envoy_gateway=True),
         )
         envoy_cmd = next(cmd for cmd in logged if cmd[:4] == ["helm", "upgrade", "--install", "eg"])
-        # Dotted label keys must be backslash-escaped to survive helm's --set parser.
-        assert (
-            "commonLabels.nv-config-manager\\.nvidia\\.com/installer=nv-config-manager-installer"
-            in envoy_cmd
-        )
-        assert "commonLabels.app\\.kubernetes\\.io/part-of=nv-config-manager" in envoy_cmd
+        assert not any(arg.startswith("commonLabels.") for arg in envoy_cmd)
 
     def test_cert_manager_helm_args_use_global_common_labels(self, tmp_path, monkeypatch):
         # cert-manager nests commonLabels under ``global`` — getting the prefix

--- a/installer/tests/test_k8s_metadata.py
+++ b/installer/tests/test_k8s_metadata.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for installer provenance metadata stamped onto direct-API resources.
+
+Every Kubernetes object the installer creates outside of Helm should carry a
+consistent set of ``app.kubernetes.io/*`` labels and a
+``nv-config-manager.nvidia.com/installer-version`` annotation so users can find
+and clean up installer-managed resources with simple label selectors.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes.client.rest import ApiException
+
+from nv_config_manager_installer import __version__
+from nv_config_manager_installer.k8s import (
+    ANNOTATION_INSTALLER_VERSION,
+    INSTALLER_VALUE,
+    LABEL_INSTALLER,
+    LABEL_INSTANCE,
+    LABEL_MANAGED_BY,
+    LABEL_PART_OF,
+    MANAGED_BY_VALUE,
+    PART_OF_VALUE,
+    K8sClient,
+    nv_config_manager_helm_common_labels,
+)
+
+
+def _make_client(release_name: str | None = "nv-config-manager") -> K8sClient:
+    """Construct a K8sClient without touching kubeconfig or the API."""
+    obj = K8sClient.__new__(K8sClient)
+    obj.v1 = MagicMock()
+    obj.apps_v1 = MagicMock()
+    obj.active_context = "test-context"
+    obj.api_server = "https://test.example.com"
+    obj._release_name = release_name
+    obj._installer_version = __version__
+    return obj
+
+
+def _assert_installer_metadata(
+    meta, *, name: str, namespace: str | None, instance: str | None
+) -> None:
+    assert meta.name == name
+    assert meta.namespace == namespace
+    assert meta.labels[LABEL_MANAGED_BY] == MANAGED_BY_VALUE
+    assert meta.labels[LABEL_PART_OF] == PART_OF_VALUE
+    assert meta.labels[LABEL_INSTALLER] == INSTALLER_VALUE
+    if instance is None:
+        assert LABEL_INSTANCE not in meta.labels
+    else:
+        assert meta.labels[LABEL_INSTANCE] == instance
+    assert meta.annotations[ANNOTATION_INSTALLER_VERSION] == __version__
+
+
+class TestObjectMeta:
+    def test_includes_managed_by_and_part_of_labels(self):
+        client = _make_client(release_name=None)
+        meta = client._object_meta("foo")
+
+        _assert_installer_metadata(meta, name="foo", namespace=None, instance=None)
+
+    def test_includes_instance_label_when_release_known(self):
+        client = _make_client(release_name="my-release")
+        meta = client._object_meta("foo", "nvcm")
+
+        _assert_installer_metadata(meta, name="foo", namespace="nvcm", instance="my-release")
+
+    def test_omits_instance_label_when_release_blank(self):
+        client = _make_client(release_name="")
+        meta = client._object_meta("foo")
+
+        assert LABEL_INSTANCE not in meta.labels
+
+
+class TestNamespaceMetadata:
+    def test_create_namespace_stamps_installer_labels(self):
+        client = _make_client()
+        client.create_namespace("nvcm")
+
+        body = client.v1.create_namespace.call_args.args[0]
+        _assert_installer_metadata(
+            body.metadata, name="nvcm", namespace=None, instance="nv-config-manager"
+        )
+
+
+class TestSecretMetadata:
+    def test_apply_secret_stamps_installer_labels(self):
+        client = _make_client()
+        client.apply_secret("creds", "nvcm", {"key": "value"})
+
+        body = client.v1.create_namespaced_secret.call_args.args[1]
+        _assert_installer_metadata(
+            body.metadata, name="creds", namespace="nvcm", instance="nv-config-manager"
+        )
+
+    def test_apply_secret_replace_path_stamps_installer_labels(self):
+        # On 409 the client falls back to replace_namespaced_secret and the
+        # body it sends must still carry installer provenance.
+        client = _make_client()
+        client.v1.create_namespaced_secret.side_effect = ApiException(status=409)
+
+        client.apply_secret("creds", "nvcm", {"key": "value"})
+
+        body = client.v1.replace_namespaced_secret.call_args.args[2]
+        _assert_installer_metadata(
+            body.metadata, name="creds", namespace="nvcm", instance="nv-config-manager"
+        )
+
+    def test_apply_docker_registry_secret_stamps_installer_labels(self):
+        client = _make_client()
+        client.apply_docker_registry_secret(
+            "regcred", "nvcm", "registry.example.com", "user", "pass"
+        )
+
+        body = client.v1.create_namespaced_secret.call_args.args[1]
+        _assert_installer_metadata(
+            body.metadata, name="regcred", namespace="nvcm", instance="nv-config-manager"
+        )
+
+    def test_apply_file_secret_stamps_installer_labels(self):
+        client = _make_client()
+        client.apply_file_secret("certs", "nvcm", {"ca.crt": b"---PEM---"})
+
+        body = client.v1.create_namespaced_secret.call_args.args[1]
+        _assert_installer_metadata(
+            body.metadata, name="certs", namespace="nvcm", instance="nv-config-manager"
+        )
+
+
+class TestPVCMetadata:
+    def test_ensure_pvc_stamps_installer_labels_on_create(self):
+        client = _make_client()
+        client.v1.read_namespaced_persistent_volume_claim.side_effect = ApiException(status=404)
+
+        created = client.ensure_pvc("data", "nvcm", size="1Gi")
+
+        assert created is True
+        body = client.v1.create_namespaced_persistent_volume_claim.call_args.args[1]
+        _assert_installer_metadata(
+            body.metadata, name="data", namespace="nvcm", instance="nv-config-manager"
+        )
+
+
+class TestLoaderPodMetadata:
+    def test_create_loader_pod_stamps_installer_labels(self):
+        client = _make_client()
+        client.create_loader_pod("loader", "nvcm", "data-pvc", "/data")
+
+        body = client.v1.create_namespaced_pod.call_args.args[1]
+        _assert_installer_metadata(
+            body.metadata, name="loader", namespace="nvcm", instance="nv-config-manager"
+        )
+
+
+class TestVersionAnnotation:
+    def test_default_installer_version_matches_package(self):
+        client = _make_client()
+        meta = client._object_meta("foo")
+        assert meta.annotations[ANNOTATION_INSTALLER_VERSION] == __version__
+
+    def test_explicit_installer_version_override(self):
+        obj = _make_client()
+        obj._installer_version = "9.9.9-test"
+        meta = obj._object_meta("foo")
+        assert meta.annotations[ANNOTATION_INSTALLER_VERSION] == "9.9.9-test"
+
+
+class TestHelmCommonLabels:
+    def test_returns_installer_marker(self):
+        labels = nv_config_manager_helm_common_labels()
+        assert labels[LABEL_INSTALLER] == INSTALLER_VALUE
+        assert labels[LABEL_PART_OF] == PART_OF_VALUE
+
+    def test_excludes_managed_by_to_avoid_helm_conflict(self):
+        # Helm itself owns ``app.kubernetes.io/managed-by`` on chart-rendered
+        # resources (sets it to "Helm"). Including it in commonLabels would
+        # either be overridden or cause a conflict, so it must be omitted.
+        labels = nv_config_manager_helm_common_labels()
+        assert LABEL_MANAGED_BY not in labels
+
+
+@pytest.mark.parametrize(
+    "label",
+    [LABEL_MANAGED_BY, LABEL_PART_OF, LABEL_INSTALLER],
+)
+def test_required_labels_present_on_every_create_method(label):
+    """Smoke test: every direct-API create method must stamp the core labels.
+
+    Guards against regressions where a new ``V1ObjectMeta(...)`` call site
+    forgets to route through ``_object_meta``.
+    """
+    client = _make_client()
+    client.v1.read_namespaced_persistent_volume_claim.side_effect = ApiException(status=404)
+
+    client.create_namespace("ns")
+    client.apply_secret("s1", "ns", {"k": "v"})
+    client.apply_docker_registry_secret("s2", "ns", "r.io", "u", "p")
+    client.apply_file_secret("s3", "ns", {"f": b"x"})
+    client.ensure_pvc("pvc1", "ns")
+    client.create_loader_pod("pod1", "ns", "pvc1", "/m")
+
+    bodies = [
+        client.v1.create_namespace.call_args.args[0],
+        client.v1.create_namespaced_secret.call_args_list[0].args[1],
+        client.v1.create_namespaced_secret.call_args_list[1].args[1],
+        client.v1.create_namespaced_secret.call_args_list[2].args[1],
+        client.v1.create_namespaced_persistent_volume_claim.call_args.args[1],
+        client.v1.create_namespaced_pod.call_args.args[1],
+    ]
+    for body in bodies:
+        assert label in body.metadata.labels, f"{label} missing on {body}"


### PR DESCRIPTION
Stamp a consistent set of app.kubernetes.io/* labels plus a nv-config-manager.nvidia.com/installer-version annotation onto every resource the installer creates directly via the Kubernetes API (namespaces, secrets, PVCs, loader pods), and push the same installer marker onto operator Helm releases via each chart's commonLabels value. Operator namespaces are pre-created so they carry the labels instead of being lazily created unlabelled by --create-namespace. This makes installer-managed objects discoverable for cleanup with simple label selectors.

## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now tags created Kubernetes resources with consistent provenance labels and an installer-version annotation.
  * Operator namespaces are pre-created and carry installer provenance labels for consistent ownership.
  * Helm-based installs now propagate installer provenance to charts and CRDs using chart-appropriate mechanisms (chart labels, pod labels, or CRD annotations) so installed components show installer metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->