### PR TITLE
fix(helm): render blackbox Probes into global.namespace

### DIFF
--- a/deploy/helm/templates/monitoring.yaml
+++ b/deploy/helm/templates/monitoring.yaml
@@ -57,7 +57,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ $renderName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: render-service
@@ -85,7 +85,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ $ztpName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: network-ztp
@@ -113,7 +113,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ $dhcpName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: network-dhcp
@@ -141,7 +141,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ $configStoreName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: config-store
@@ -197,7 +197,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ $temporalName }}-api
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: temporal-api
@@ -225,7 +225,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ $temporalName }}-ui
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: temporal-ui
@@ -253,7 +253,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ $uiName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: ui
@@ -281,7 +281,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
   name: {{ $nautobotName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: nautobot


### PR DESCRIPTION
## Summary
The `Probe` templates in `deploy/helm/templates/monitoring.yaml` set `namespace: {{ .Values.namespace }}`, but that key is unset — the namespace lives at `.Values.global.namespace`. As a result every blackbox `Probe` CR rendered with an **empty `metadata.namespace`**, relying on the apply-time namespace fallback (helm `-n` / ArgoCD destination) to place it.

The `PodMonitor` templates in the same file already use the local `$namespace` alias (`{{- $namespace := .Values.global.namespace }}`). This change aligns the 8 Probe blocks with that, so Probes render into the chart namespace explicitly and consistently with PodMonitors.

This affects every env with `monitoring.probes.enabled: true` (e.g. pdx01, and the in-flight sjc4 migration).

## Why it matters
- Removes reliance on implicit apply-time namespace defaulting for namespaced CRs.
- Makes Probe placement deterministic and identical to PodMonitors (both `global.namespace`).
- Keeps the `OBSERVABILITY=true` integration test (`test_probe_labels.py`, which looks for Probe CRs in `config_manager_namespace`) robust.

## Test plan
- [x] `helm template ... --values values-ci.yaml --values values-observability.yaml` → all 8 Probes render with `namespace: nv-config-manager-ci` (was empty) and retain `staticConfig.labels.include_in_slo`.
- [x] No remaining `.Values.namespace` references in `monitoring.yaml`.
- [ ] kind integration job with `observability` enabled (CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed monitoring probe configuration so all Prometheus Blackbox Exporter Probe resources consistently use the chart’s computed namespace setting, ensuring correct deployment and monitoring across all components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->