### PR TITLE
fix(helm): only provision oidc hmac/cookie secret in ingressNginx mode

### DIFF
--- a/deploy/helm/templates/vault-secrets.yaml
+++ b/deploy/helm/templates/vault-secrets.yaml
@@ -402,9 +402,9 @@ spec:
 {{- end }}
 
 # OIDC/SSO client credentials (optional)
-# cookie-secret is used for:
-#   - oauth2-proxy HMAC (ingress-nginx mode)
-#   - Envoy Gateway OIDC HMAC (envoyGateway mode)
+# Per ingress mode:
+#   - envoyGateway: only client-secret is needed (native OIDC SecurityPolicy)
+#   - ingressNginx: cookie-secret/hmac-secret feed oauth2-proxy's HMAC cookie
 {{- if .Values.oidc.enabled }}
 {{- if .Values.secrets.vault.paths.oidc }}
 {{- if .Values.secrets.vault.paths.oidc.path }}
@@ -432,13 +432,15 @@ spec:
         property: {{ $clientSecretProp }}
         {{- end }}
     {{- end }}
-    # hmac-secret used for OIDC state validation (both nginx oauth2-proxy and Envoy Gateway)
+    {{- /* hmac-secret + cookie-secret are only consumed by oauth2-proxy
+           (ingress-nginx mode). Envoy Gateway's OIDC SecurityPolicy only needs
+           client-secret, so don't provision an unused hmac/cookie secret there
+           (it also avoids requiring a cookieSecret vault key for gateway cells). */}}
+    {{- if eq (.Values.ingress.type | default "envoyGateway") "ingressNginx" }}
     - secretKey: hmac-secret
       remoteRef:
         key: "{{ include "nv-config-manager.vault.secretPath" (dict "root" . "secret" "oidc") }}"
         property: {{ include "nv-config-manager.vault.keyName" (dict "root" . "secret" "oidc" "key" "cookieSecret") }}
-    {{- /* cookie-secret alias for oauth2-proxy compatibility */}}
-    {{- if eq (.Values.ingress.type | default "envoyGateway") "ingressNginx" }}
     - secretKey: cookie-secret
       remoteRef:
         key: "{{ include "nv-config-manager.vault.secretPath" (dict "root" . "secret" "oidc") }}"


### PR DESCRIPTION
## Summary
- The `oidc-client-secret-eso` ExternalSecret unconditionally created an `hmac-secret` entry (from the `cookieSecret` vault key), even in `envoyGateway` mode.
- Envoy Gateway's OIDC `SecurityPolicy` only consumes `client-secret`; `hmac-secret`/`cookie-secret` are only used by `oauth2-proxy` (ingress-nginx mode — `oauth2-proxy.yaml` is fully gated to `ingressNginx`).
- This PR gates the `hmac-secret` + `cookie-secret` entries to `ingressNginx`, so gateway cells provision only `client-secret` and no longer require a `cookieSecret` vault key.

## Behavior (validated via `helm template ... --values values-ci.yaml`)
- `envoyGateway` (default): `client-secret` only
- `ingressNginx`: `hmac-secret` + `cookie-secret`

## Notes
- No change for ingress-nginx cells.
- Unblocks dropping `cookieSecret` from envoyGateway (internal-prod) values once this lands in a release.

## Test plan
- [ ] `helm template` for an envoyGateway cell shows only `client-secret` in `oidc-client-secret-eso`
- [ ] `helm template` for an ingress-nginx cell still shows `hmac-secret` + `cookie-secret`
- [ ] Confirm Envoy Gateway OIDC login still works end-to-end on a gateway cell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Secret provisioning for OIDC/SSO now conditionally creates the HMAC secret only for ingress-nginx, reducing unnecessary secrets for other ingress types.

* **Documentation**
  * Clarified ingress-mode differences: Envoy Gateway requires only a client secret; ingress-nginx/oauth2-proxy requires both cookie and HMAC secrets. Both secrets map to the same Vault cookieSecret property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->