### PR TITLE
Implement MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ The local SuperPOD profile uses `config-manager.local` as the base hostname. Add
 127.0.0.1 workflow.config-manager.local
 127.0.0.1 config-store.config-manager.local
 127.0.0.1 temporal.config-manager.local
+127.0.0.1 mcp.config-manager.local
+127.0.0.1 svc-mcp.config-manager.local
 127.0.0.1 svc-workflow.config-manager.local
 127.0.0.1 svc-config-store.config-manager.local
 127.0.0.1 svc-render.config-manager.local
@@ -155,6 +157,7 @@ Local endpoints:
 - Nautobot: <https://nautobot.config-manager.local>
 - Workflow API: <https://workflow.config-manager.local>
 - Config Store API: <https://config-store.config-manager.local>
+- MCP endpoint: <https://mcp.config-manager.local/mcp>
 
 For the local SuperPOD profile, Nautobot login is `admin` / `admin`. For generated credentials:
 
@@ -334,6 +337,7 @@ The `svc-*` hostnames, such as `svc-workflow.<base-hostname>`, accept bearer tok
 - [Temporal](docs/temporal/index.mdx)
 - [Render](docs/render/index.mdx)
 - [Config Store](docs/config-store/index.mdx)
+- [Remote MCP](docs/overview/mcp.mdx)
 - [UI and API interfaces](docs/getting-started/interfaces.mdx)
 - [Nautobot](docs/nautobot/index.mdx)
 - [Device Authentication](docs/overview/device-authentication.mdx)

--- a/deploy/configs/local-sec.yaml
+++ b/deploy/configs/local-sec.yaml
@@ -62,6 +62,7 @@ sso:
   internal_issuer: http://keycloak.keycloak.svc.cluster.local:80/realms/nv-config-manager
   jwks_uri: http://keycloak.keycloak.svc.cluster.local:80/realms/nv-config-manager/protocol/openid-connect/certs
   client_id: nv-config-manager
+  cli_client_id: nv-config-manager-cli
   client_secret: nvcm-local-client-secret
   scopes: openid,email,profile
   audiences: account,nv-config-manager

--- a/deploy/helm/sample-eso-config.yaml
+++ b/deploy/helm/sample-eso-config.yaml
@@ -15,6 +15,7 @@
 #           path: "prod/nautobot"  # Full path within the secrets engine
 #           keys:
 #             token: "token"
+#             readOnlyToken: "read_only_token"
 # =============================================================================
 
 # =============================================================================
@@ -65,6 +66,7 @@ secrets:
         path: "prod/nautobot"  # Full path within secretsPath
         keys:
           token: "token"
+          readOnlyToken: "read_only_token"
           natsPassword: "nats_password"
       
       # Redis credentials

--- a/deploy/helm/sample-nv-config-manager.ini
+++ b/deploy/helm/sample-nv-config-manager.ini
@@ -194,8 +194,10 @@ use_internal_endpoint = false
 # caller's Bearer token and does not fall back to service-to-service auth.
 use_internal_endpoints = true
 max_response_bytes = 100000
-# auto: bundled/local Nautobot uses user JWT; external Nautobot uses [nautobot] token.
-# token: use [nautobot] token; configure it as read-only for external Nautobot envs.
+# Optional separate read-only Nautobot token used only by MCP token auth mode.
+nautobot_read_only_token = <secret>
+# auto: bundled/local Nautobot uses user JWT; external Nautobot uses the MCP read-only token.
+# token: use the MCP read-only Nautobot token.
 # jwt: forward the caller's Bearer token to Nautobot when auth is enabled.
 nautobot_auth_mode = auto
 nautobot_token_fallback_enabled = false

--- a/deploy/helm/sample-nv-config-manager.ini
+++ b/deploy/helm/sample-nv-config-manager.ini
@@ -184,3 +184,18 @@ api_url = https://ztp.config-manager.example.com
 # User domain for workflow context
 user_domain = prod.config-manager.example.com
 use_internal_endpoint = false
+
+# =============================================================================
+# MCP SERVICE
+# =============================================================================
+
+[mcp]
+# MCP uses internal service endpoints. When auth is enabled, it forwards the
+# caller's Bearer token and does not fall back to service-to-service auth.
+use_internal_endpoints = true
+max_response_bytes = 100000
+# auto: bundled/local Nautobot uses user JWT; external Nautobot uses [nautobot] token.
+# token: use [nautobot] token; configure it as read-only for external Nautobot envs.
+# jwt: forward the caller's Bearer token to Nautobot when auth is enabled.
+nautobot_auth_mode = auto
+nautobot_token_fallback_enabled = false

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -46,8 +46,11 @@ Pass root and, optionally, strategy. Global strategy wins when set so local
 overrides can switch every Deployment to Recreate in one place.
 */}}
 {{- define "nv-config-manager.deploymentStrategy" -}}
-{{- $globalStrategy := .root.Values.global.deploymentStrategy | default dict -}}
-{{- $strategy := $globalStrategy | default .strategy | default dict -}}
+{{- $strategy := .strategy | default dict -}}
+{{- if .root.Values.global.deploymentStrategy -}}
+{{- $strategy = .root.Values.global.deploymentStrategy -}}
+{{- end -}}
+{{- if $strategy }}
 {{- $type := $strategy.type | default "RollingUpdate" -}}
 strategy:
   type: {{ $type }}
@@ -56,6 +59,7 @@ strategy:
   rollingUpdate:
     maxSurge: {{ $rollingUpdate.maxSurge | default "25%" }}
     maxUnavailable: {{ $rollingUpdate.maxUnavailable | default 0 }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/deploy/helm/templates/_vault-agent.tpl
+++ b/deploy/helm/templates/_vault-agent.tpl
@@ -481,6 +481,21 @@ nv-config-manager.ini body (consul-template): must stay in sync with vault-secre
 
           {{- end }}
 
+          {{- if $root.Values.mcp.enabled }}
+          # -----------------------------------------------------------------
+          # MCP Service Configuration
+          # -----------------------------------------------------------------
+          [mcp]
+          # When auth is enabled, MCP forwards the caller's inbound Bearer token
+          # to Config Manager APIs. It does not fall back to service-to-service auth.
+          use_internal_endpoints = {{ $root.Values.mcp.client.useInternalEndpoints | default true }}
+          max_response_bytes = {{ $root.Values.mcp.client.maxResponseBytes | default 100000 }}
+          # auto resolves to jwt for bundled/local Nautobot and token for external Nautobot.
+          nautobot_auth_mode = {{ $root.Values.mcp.nautobot.authMode | default "auto" }}
+          nautobot_token_fallback_enabled = {{ $root.Values.mcp.nautobot.tokenFallbackEnabled | default false }}
+
+          {{- end }}
+
           {{- if and $root.Values.temporal.enabled (index $root.Values.secrets.vault.paths "jira") }}
           # -----------------------------------------------------------------
           # Jira Configuration (for DiagnosticsWorkflow)

--- a/deploy/helm/templates/_vault-agent.tpl
+++ b/deploy/helm/templates/_vault-agent.tpl
@@ -196,6 +196,13 @@ Usage: ctKv2Key emits a full consul-template action (including outer braces). In
 {{- printf "{{if $%s}}{{if $%s.Data}}{{index (or (index $%s.Data \"data\") (index $%s.Data \"Data\")) %q}}{{end}}{{end}}" $vn $vn $vn $vn $vk -}}
 {{- end -}}
 
+{{- define "nv-config-manager.vaultAgent.ctKv2OptionalIniLine" -}}
+{{- $vn := required "var is required" .var -}}
+{{- $vk := .key | toString -}}
+{{- $name := required "name is required" .name -}}
+{{- printf "{{with $%s}}{{with $%s.Data}}{{with index (or (index $%s.Data \"data\") (index $%s.Data \"Data\")) %q}}%s = {{.}}{{end}}{{end}}{{end}}" $vn $vn $vn $vn $vk $name -}}
+{{- end -}}
+
 {{/*
 Consul-template prelude: declare $secret vars for nv-config-manager.ini (same KV paths as ESO unified ExternalSecret)
 */}}
@@ -356,6 +363,7 @@ nv-config-manager.ini body (consul-template): must stay in sync with vault-secre
           api_service = http://{{ $temporalName }}-api:{{ $internalPort }}
           # External: Gateway URLs for user-facing links
           api_url = https://{{ tpl $root.Values.temporal.gateway.api.hostname $root }}
+          temporal_ui_url = https://{{ tpl $root.Values.temporal.gateway.devUi.hostname $root }}
           ui_url = https://{{ $root.Values.gateway.baseHostname }}
           # Set to true for internal cluster communication (uses api_service)
           # Set to false for external mTLS communication (uses api_url)
@@ -490,7 +498,8 @@ nv-config-manager.ini body (consul-template): must stay in sync with vault-secre
           # to Config Manager APIs. It does not fall back to service-to-service auth.
           use_internal_endpoints = {{ $root.Values.mcp.client.useInternalEndpoints | default true }}
           max_response_bytes = {{ $root.Values.mcp.client.maxResponseBytes | default 100000 }}
-          # auto resolves to jwt for bundled/local Nautobot and token for external Nautobot.
+          {{ include "nv-config-manager.vaultAgent.ctKv2OptionalIniLine" (dict "var" "nautobot" "key" (include "nv-config-manager.vault.keyName" (dict "root" $root "secret" "nautobot" "key" "readOnlyToken")) "name" "nautobot_read_only_token") }}
+          # auto resolves to jwt for bundled/local Nautobot and the MCP read-only token for external Nautobot.
           nautobot_auth_mode = {{ $root.Values.mcp.nautobot.authMode | default "auto" }}
           nautobot_token_fallback_enabled = {{ $root.Values.mcp.nautobot.tokenFallbackEnabled | default false }}
 

--- a/deploy/helm/templates/dhcp.yaml
+++ b/deploy/helm/templates/dhcp.yaml
@@ -130,12 +130,7 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
         resources:
-          requests:
-            memory: "128Mi"
-            cpu: 200m
-          limits:
-            memory: "128Mi"
-            cpu: 200m
+          {{- toYaml .Values.networkDhcp.resources.healthcheck | nindent 10 }}
         volumeMounts:
         {{- include "nv-config-manager.vaultAgent.configManagerSecretsDirEtcVault" . | nindent 8 }}
       # API container
@@ -173,12 +168,7 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
         resources:
-          requests:
-            memory: "128Mi"
-            cpu: 200m
-          limits:
-            memory: "128Mi"
-            cpu: 200m
+          {{- toYaml .Values.networkDhcp.resources.api | nindent 10 }}
         volumeMounts:
         {{- include "nv-config-manager.vaultAgent.configManagerSecretsDirEtcVault" . | nindent 8 }}
         {{- include "nv-config-manager.authVolumeMounts" . | nindent 8 }}

--- a/deploy/helm/templates/envoy-proxy.yaml
+++ b/deploy/helm/templates/envoy-proxy.yaml
@@ -1,9 +1,9 @@
 {{- if eq (.Values.ingress.type | default "envoyGateway") "envoyGateway" }}
 {{- $envoyImage := dig "envoyProxy" "image" "" .Values.gateway }}
-{{- $createOwnProxy := or .Values.gateway.hostNetwork.enabled .Values.gateway.hostPorts.enabled (dig "nodePort" "enabled" false .Values.gateway) .Values.gateway.nlb (dig "envoyProxy" "enabled" false .Values.gateway) $envoyImage }}
+{{- $envoyResources := dig "envoyProxy" "resources" nil .Values.gateway }}
+{{- $createOwnProxy := or .Values.gateway.hostNetwork.enabled .Values.gateway.hostPorts.enabled (dig "nodePort" "enabled" false .Values.gateway) .Values.gateway.nlb (dig "envoyProxy" "enabled" false .Values.gateway) $envoyImage $envoyResources }}
 {{- $proxyName := .Values.gateway.envoyProxy.name | default (printf "%s-proxy" .Values.gateway.name) }}
 {{- $needsPortPatch := or .Values.gateway.hostNetwork.enabled .Values.gateway.hostPorts.enabled (dig "nodePort" "enabled" false .Values.gateway) }}
-{{- $envoyResources := dig "envoyProxy" "resources" nil .Values.gateway }}
 {{- $needsContainerPatch := or $envoyImage $envoyResources (and (not .Values.gateway.hostNetwork.enabled) (or .Values.gateway.hostPorts.enabled (dig "nodePort" "enabled" false .Values.gateway))) }}
 {{- if $createOwnProxy }}
 apiVersion: gateway.envoyproxy.io/v1alpha1

--- a/deploy/helm/templates/httproutes.yaml
+++ b/deploy/helm/templates/httproutes.yaml
@@ -99,6 +99,7 @@ spec:
 {{- $uiName := include "nv-config-manager.componentName" (dict "root" . "component" "ui") }}
 {{- $nautobotName := include "nv-config-manager.componentName" (dict "root" . "component" "nautobot") }}
 {{- $configStoreName := include "nv-config-manager.componentName" (dict "root" . "component" "config-store") }}
+{{- $mcpName := include "nv-config-manager.componentName" (dict "root" . "component" "mcp") }}
 
 {{- if and .Values.gateway.enabled (eq (.Values.ingress.type | default "envoyGateway") "envoyGateway") }}
 
@@ -456,6 +457,52 @@ spec:
         value: /
     backendRefs:
     - name: {{ $configStoreName }}-api
+      port: 9000
+{{- end }}
+
+# MCP svc-* HTTPRoute (JWT-only)
+{{- if .Values.mcp.enabled }}
+{{- include "nv-config-manager.svcHTTPRoute" (dict
+    "root" .
+    "routeName" $mcpName
+    "svcHostname" (tpl (.Values.mcp.gateway.svcHostname | default "") .)
+    "backendName" $mcpName
+    "backendPort" 9000
+) }}
+{{- end }}
+
+# MCP HTTPRoute
+{{- if .Values.mcp.enabled }}
+{{- if .Values.mcp.gateway.authBypass }}
+{{- include "nv-config-manager.authBypassHTTPRoute" (dict
+    "root" .
+    "routeName" $mcpName
+    "enabled" (.Values.mcp.gateway.authBypass.enabled | default false)
+    "paths" (.Values.mcp.gateway.authBypass.paths | default list)
+    "hostname" (tpl .Values.mcp.gateway.hostname .)
+    "backendName" $mcpName
+    "backendPort" 9000
+) }}
+{{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $mcpName }}
+  namespace: {{ .Values.global.namespace }}
+spec:
+  parentRefs:
+  - name: {{ .Values.gateway.name }}
+    namespace: {{ .Values.global.namespace }}
+  hostnames:
+  - {{ tpl .Values.mcp.gateway.hostname . | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: {{ $mcpName }}
       port: 9000
 {{- end }}
 

--- a/deploy/helm/templates/httproutes.yaml
+++ b/deploy/helm/templates/httproutes.yaml
@@ -311,14 +311,14 @@ spec:
 ---
 # Unified UI HTTPRoute (at base hostname) - OIDC-only, direct to app port
 {{- if .Values.ui.enabled }}
-{{- if .Values.oidc.enabled }}
+{{- if and .Values.oidc.enabled .Values.oidc.authUtility.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ $uiName }}-auth-logout
+  name: {{ $uiName }}-auth-utility
   namespace: {{ .Values.global.namespace }}
   annotations:
-    # Allows the UI to clear stale local OIDC cookies before Envoy logout.
+    # Allows unauthenticated access to public auth utility endpoints.
     nv-config-manager.nvidia.com/no-auth: "true"
 spec:
   parentRefs:
@@ -331,6 +331,9 @@ spec:
     - path:
         type: PathPrefix
         value: /auth/logout
+    - path:
+        type: PathPrefix
+        value: /auth/discovery
     backendRefs:
     - name: {{ $uiName }}
       port: 3000

--- a/deploy/helm/templates/kubernetes-secrets.yaml
+++ b/deploy/helm/templates/kubernetes-secrets.yaml
@@ -189,6 +189,7 @@ spec:
               api_service = http://{{ $temporalName }}-api:{{ $internalPort }}
               # External: Gateway URLs for user-facing links
               api_url = https://{{ tpl .Values.temporal.gateway.api.hostname . }}
+              temporal_ui_url = https://{{ tpl .Values.temporal.gateway.devUi.hostname . }}
               ui_url = https://{{ .Values.gateway.baseHostname }}
               # Set to true for internal cluster communication (uses api_service)
               # Set to false for external mTLS communication (uses api_url)
@@ -325,7 +326,8 @@ spec:
               # to Config Manager APIs. It does not fall back to service-to-service auth.
               use_internal_endpoints = {{ .Values.mcp.client.useInternalEndpoints | default true }}
               max_response_bytes = {{ .Values.mcp.client.maxResponseBytes | default 100000 }}
-              # auto resolves to jwt for bundled/local Nautobot and token for external Nautobot.
+              nautobot_read_only_token = $(cat /secrets/nautobot-token/read-only-token)
+              # auto resolves to jwt for bundled/local Nautobot and the MCP read-only token for external Nautobot.
               nautobot_auth_mode = {{ .Values.mcp.nautobot.authMode | default "auto" }}
               nautobot_token_fallback_enabled = {{ .Values.mcp.nautobot.tokenFallbackEnabled | default false }}
 
@@ -352,6 +354,9 @@ spec:
                   sed -i "s|\$(cat ${secret_file})|${value}|g" /tmp/nv-config-manager-final.ini
                 fi
               done
+              if [ ! -f /secrets/nautobot-token/read-only-token ]; then
+                sed -i 's|^[[:space:]]*nautobot_read_only_token = $(cat /secrets/nautobot-token/read-only-token)$|nautobot_read_only_token = |' /tmp/nv-config-manager-final.ini
+              fi
               
               # Create or update the ini secret
               kubectl create secret generic {{ include "nv-config-manager.iniSecretName" . }} \

--- a/deploy/helm/templates/kubernetes-secrets.yaml
+++ b/deploy/helm/templates/kubernetes-secrets.yaml
@@ -316,6 +316,21 @@ spec:
 
               {{- end }}
 
+              {{- if .Values.mcp.enabled }}
+              # -----------------------------------------------------------------
+              # MCP Service Configuration
+              # -----------------------------------------------------------------
+              [mcp]
+              # When auth is enabled, MCP forwards the caller's inbound Bearer token
+              # to Config Manager APIs. It does not fall back to service-to-service auth.
+              use_internal_endpoints = {{ .Values.mcp.client.useInternalEndpoints | default true }}
+              max_response_bytes = {{ .Values.mcp.client.maxResponseBytes | default 100000 }}
+              # auto resolves to jwt for bundled/local Nautobot and token for external Nautobot.
+              nautobot_auth_mode = {{ .Values.mcp.nautobot.authMode | default "auto" }}
+              nautobot_token_fallback_enabled = {{ .Values.mcp.nautobot.tokenFallbackEnabled | default false }}
+
+              {{- end }}
+
               {{- if and .Values.temporal.enabled .Values.externalServices.jira.enabled }}
               # -----------------------------------------------------------------
               # Jira Configuration (local dev — credentials from jira-creds secret)

--- a/deploy/helm/templates/kubernetes-secrets.yaml
+++ b/deploy/helm/templates/kubernetes-secrets.yaml
@@ -355,7 +355,7 @@ spec:
                 fi
               done
               if [ ! -f /secrets/nautobot-token/read-only-token ]; then
-                sed -i 's|^[[:space:]]*nautobot_read_only_token = $(cat /secrets/nautobot-token/read-only-token)$|nautobot_read_only_token = |' /tmp/nv-config-manager-final.ini
+                sed -i '/^[[:space:]]*nautobot_read_only_token = $(cat \/secrets\/nautobot-token\/read-only-token)$/d' /tmp/nv-config-manager-final.ini
               fi
               
               # Create or update the ini secret

--- a/deploy/helm/templates/mcp.yaml
+++ b/deploy/helm/templates/mcp.yaml
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+{{- if .Values.mcp.enabled }}
+{{- $mcpName := include "nv-config-manager.componentName" (dict "root" . "component" "mcp") }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $mcpName }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: {{ $mcpName }}
+    component: api
+    app.kubernetes.io/name: nv-config-manager
+    app.kubernetes.io/component: mcp
+spec:
+  replicas: {{ .Values.mcp.api.replicas }}
+  selector:
+    matchLabels:
+      app: {{ $mcpName }}
+      component: api
+  {{- include "nv-config-manager.deploymentStrategy" (dict "root" .) | nindent 2 }}
+  template:
+    metadata:
+      labels:
+        app: {{ $mcpName }}
+        component: api
+        {{- include "nv-config-manager.customPodLabels" . | nindent 8 }}
+      annotations:
+        {{- include "nv-config-manager.authIniChecksum" . | nindent 8 }}
+        {{- if eq .Values.secrets.method "vault-agent" }}
+        {{- include "nv-config-manager.vaultAgent.injectorAnnotations" . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "nv-config-manager.serviceAccountName" . }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- include "nv-config-manager.scheduling" .Values.mcp.api | nindent 6 }}
+      {{- include "nv-config-manager.podSecurityContext" . | nindent 6 }}
+      containers:
+      - name: api
+        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ .Values.global.images.nvConfigManager.tag }}"
+        imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
+        {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
+        command: ["nvidia-config-manager-mcp"]
+        args: []
+        env:
+        - name: LOG_LEVEL
+          value: "INFO"
+        - name: ENVIRONMENT
+          value: {{ .Values.global.environment }}
+        {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
+        - name: NV_CONFIG_MANAGER_INI
+          value: {{ include "nv-config-manager.vaultAgent.configManagerIniPathApp" . | quote }}
+        - name: NV_CONFIG_MANAGER_SERVICE
+          value: "mcp"
+        ports:
+        - containerPort: 9000
+          name: http
+        resources:
+          {{- toYaml .Values.mcp.api.resources | nindent 10 }}
+        volumeMounts:
+        {{- include "nv-config-manager.vaultAgent.configManagerIniVolumeMount" . | nindent 8 }}
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 9000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 9000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+      volumes:
+      {{- include "nv-config-manager.vaultAgent.projectedSATokenVolume" . | nindent 6 }}
+      {{- include "nv-config-manager.vaultAgent.configManagerIniVolume" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $mcpName }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: {{ $mcpName }}
+    component: api
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9000
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ $mcpName }}
+    component: api
+{{- end }}

--- a/deploy/helm/templates/mcp.yaml
+++ b/deploy/helm/templates/mcp.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+{{- include "nv-config-manager.validateSecrets" . -}}
 {{- if .Values.mcp.enabled }}
 {{- $mcpName := include "nv-config-manager.componentName" (dict "root" . "component" "mcp") }}
 ---

--- a/deploy/helm/templates/monitoring.yaml
+++ b/deploy/helm/templates/monitoring.yaml
@@ -30,6 +30,7 @@
 {{- $ztpName := include "nv-config-manager.componentName" (dict "root" . "component" "ztp") }}
 {{- $dhcpName := include "nv-config-manager.componentName" (dict "root" . "component" "dhcp") }}
 {{- $configStoreName := include "nv-config-manager.componentName" (dict "root" . "component" "config-store") }}
+{{- $mcpName := include "nv-config-manager.componentName" (dict "root" . "component" "mcp") }}
 {{- $temporalName := include "nv-config-manager.componentName" (dict "root" . "component" "temporal") }}
 {{- $nautobotName := include "nv-config-manager.componentName" (dict "root" . "component" "nautobot") }}
 {{- $uiName := include "nv-config-manager.componentName" (dict "root" . "component" "ui") }}
@@ -159,6 +160,34 @@ spec:
       {{- include "nv-config-manager.probeStaticConfigLabels" . | nindent 6 }}
       static:
       - {{ $probeScheme }}://{{ tpl .Values.configStore.gateway.api.hostname . }}/healthcheck
+{{- end }}
+
+{{- /* MCP Probe */}}
+{{- if and .Values.monitoring.probes.enabled .Values.mcp.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: {{ $mcpName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "nv-config-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp
+    {{- with $monitoringCRLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  interval: 30s
+  module: http_2xx
+  jobName: {{ $probeJobPrefix }}{{ $mcpName }}-probe
+  prober:
+    scheme: {{ $probeScheme }}
+    url: {{ .Values.monitoring.probes.blackboxExporterUrl }}
+  targets:
+    staticConfig:
+      {{- include "nv-config-manager.probeStaticConfigLabels" . | nindent 6 }}
+      static:
+      - {{ $probeScheme }}://{{ tpl .Values.mcp.gateway.hostname . }}/healthcheck
 {{- end }}
 
 {{- /* Temporal API Probe */}}
@@ -413,6 +442,40 @@ spec:
   selector:
     matchLabels:
       app: {{ $configStoreName }}
+      component: api
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics
+      interval: {{ $scrapeInterval }}
+      scrapeTimeout: {{ $scrapeTimeout }}
+      {{- if .Values.global.customLabels }}
+      metricRelabelings:
+        {{- include "nv-config-manager.podMonitorMetricRelabelings" . | nindent 8 }}
+      {{- end }}
+{{- end }}
+
+{{- /* MCP PodMonitor */}}
+{{- if and .Values.monitoring.podMonitors.enabled .Values.mcp.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ $mcpName }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "nv-config-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp
+    {{- with $monitoringCRLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- include "nv-config-manager.podTargetLabels" . | nindent 2 }}
+  namespaceSelector:
+    matchNames:
+      - {{ $namespace }}
+  selector:
+    matchLabels:
+      app: {{ $mcpName }}
       component: api
   podMetricsEndpoints:
     - port: http

--- a/deploy/helm/templates/nautobot.yaml
+++ b/deploy/helm/templates/nautobot.yaml
@@ -580,10 +580,10 @@ spec:
               mountPath: /opt/nautobot/jobs
               readOnly: true
             {{- end }}
-          {{- with .Values.nautobot.server.migrations.resources }}
+          {{- $defaultMigrationResources := dict "requests" (dict "cpu" "250m" "memory" "512Mi") "limits" (dict "memory" "2Gi") }}
+          {{- $migrationResources := dig "server" "migrations" "resources" $defaultMigrationResources .Values.nautobot }}
           resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- toYaml $migrationResources | nindent 12 }}
       containers:
         - name: nautobot
           image: {{ .Values.global.images.nautobot.repository }}:{{ .Values.global.images.nautobot.tag }}

--- a/deploy/helm/templates/security-policy.yaml
+++ b/deploy/helm/templates/security-policy.yaml
@@ -539,6 +539,19 @@ spec:
 {{- end }}
 {{- end }}
 
+# MCP Auth Bypass SecurityPolicy
+{{- if .Values.mcp.enabled }}
+{{- if .Values.mcp.gateway.authBypass }}
+{{- $mcpName := include "nv-config-manager.componentName" (dict "root" . "component" "mcp") }}
+{{- include "nv-config-manager.authBypassSecurityPolicy" (dict
+    "root" .
+    "routeName" $mcpName
+    "enabled" (.Values.mcp.gateway.authBypass.enabled | default false)
+    "paths" (.Values.mcp.gateway.authBypass.paths | default list)
+) }}
+{{- end }}
+{{- end }}
+
 # =============================================================================
 # Service (svc-*) SecurityPolicies
 # =============================================================================
@@ -609,6 +622,16 @@ spec:
     "root" .
     "routeName" (printf "%s-api" $configStoreName)
     "svcHostname" (tpl (.Values.configStore.gateway.api.svcHostname | default "") .)
+) }}
+{{- end }}
+
+# MCP svc-* SecurityPolicy
+{{- if .Values.mcp.enabled }}
+{{- $mcpName := include "nv-config-manager.componentName" (dict "root" . "component" "mcp") }}
+{{- include "nv-config-manager.svcSecurityPolicy" (dict
+    "root" .
+    "routeName" $mcpName
+    "svcHostname" (tpl (.Values.mcp.gateway.svcHostname | default "") .)
 ) }}
 {{- end }}
 

--- a/deploy/helm/templates/security-policy.yaml
+++ b/deploy/helm/templates/security-policy.yaml
@@ -236,8 +236,10 @@ spec:
           headers:
             - name: Authorization
               valuePrefix: "Bearer "
+          {{- if $.root.Values.oidc.disableTokenEncryption }}
           cookies:
             - {{ $.root.Values.oidc.cookieName | default "NVConfigManagerAccessToken" | quote }}
+          {{- end }}
         {{- if $.root.Values.oidc.claimToHeaders }}
         claimToHeaders:
         {{- range $.root.Values.oidc.claimToHeaders }}

--- a/deploy/helm/templates/security-policy.yaml
+++ b/deploy/helm/templates/security-policy.yaml
@@ -154,10 +154,8 @@ spec:
 # Auth Bypass SecurityPolicy Helper Template
 # =============================================================================
 # Creates a SecurityPolicy with jwt.optional=true but NO oidc.
-# This allows requests without JWT to pass through while still extracting
-# claims from Authorization bearer tokens. Browser cookies are left to the
-# backend on these bypass paths so stale local OIDC cookies do not poison
-# health checks or native-token APIs.
+# This allows requests without JWT to pass through while still
+# extracting claims if a valid JWT is present.
 # =============================================================================
 {{- define "nv-config-manager.authBypassSecurityPolicy" }}
 {{- if and $.root.Values.oidc.enabled $.root.Values.gateway.authBypass.enabled $.enabled (or (gt (len $.paths) 0) $.pathRegex) }}
@@ -238,6 +236,8 @@ spec:
           headers:
             - name: Authorization
               valuePrefix: "Bearer "
+          cookies:
+            - {{ $.root.Values.oidc.cookieName | default "NVConfigManagerAccessToken" | quote }}
         {{- if $.root.Values.oidc.claimToHeaders }}
         claimToHeaders:
         {{- range $.root.Values.oidc.claimToHeaders }}
@@ -403,21 +403,21 @@ spec:
       idToken: {{ .Values.oidc.idTokenCookieName | default "NVConfigManagerIdToken" | quote }}
   {{- end }}
 
-{{- if and .Values.oidc.enabled .Values.ui.enabled }}
+{{- if and .Values.oidc.enabled .Values.oidc.authUtility.enabled .Values.ui.enabled }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: {{ $uiName }}-auth-logout
+  name: {{ $uiName }}-auth-utility
   namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}
 spec:
-  # Override the gateway-level OIDC/JWT policy so stale JWT cookies can be cleared.
+  # Override the gateway-level OIDC/JWT policy for public auth utility routes.
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
-    name: {{ $uiName }}-auth-logout
+    name: {{ $uiName }}-auth-utility
   cors:
     allowOrigins:
     {{- if .Values.gateway.cors.allowOrigins }}

--- a/deploy/helm/templates/ui.yaml
+++ b/deploy/helm/templates/ui.yaml
@@ -51,9 +51,35 @@ spec:
         # Application version (matches image tag - git tag/semver)
         - name: APP_VERSION
           value: "{{ .Values.global.images.nvConfigManagerUi.tag }}"
+        {{- if .Values.oidc.authUtility.enabled }}
+        # Public auth discovery metadata for native clients
+        - name: OIDC_ENABLED
+          value: {{ .Values.oidc.enabled | quote }}
+        - name: OIDC_ISSUER_URL
+          value: {{ .Values.oidc.issuerUrl | default "" | quote }}
+        - name: OIDC_CLIENT_ID
+          value: {{ .Values.oidc.clientId | default "" | quote }}
+        - name: OIDC_CLI_CLIENT_ID
+          value: {{ (.Values.oidc.cliClientId | default .Values.oidc.clientId | default "") | quote }}
+        - name: OIDC_SCOPES
+          value: {{ toJson (.Values.oidc.scopes | default (list)) | quote }}
         # Workflow API URL
         - name: WORKFLOW_API_URL
           value: "https://{{ tpl .Values.temporal.gateway.api.hostname . }}"
+        - name: SVC_WORKFLOW_API_URL
+          value: "https://{{ tpl .Values.temporal.gateway.api.svcHostname . }}/v1/workflow"
+        {{- if .Values.mcp.enabled }}
+        # MCP API URL
+        - name: MCP_URL
+          value: "https://{{ tpl .Values.mcp.gateway.hostname . }}/mcp"
+        - name: SVC_MCP_URL
+          value: "https://{{ tpl .Values.mcp.gateway.svcHostname . }}/mcp"
+        {{- end }}
+        {{- else }}
+        # Workflow API URL
+        - name: WORKFLOW_API_URL
+          value: "https://{{ tpl .Values.temporal.gateway.api.hostname . }}"
+        {{- end }}
         # Config Store API URL
         - name: CONFIG_STORE_API_URL
           value: "https://{{ tpl .Values.configStore.gateway.api.hostname . }}"

--- a/deploy/helm/templates/vault-secrets.yaml
+++ b/deploy/helm/templates/vault-secrets.yaml
@@ -957,6 +957,21 @@ spec:
 
           {{- end }}
 
+          {{- if .Values.mcp.enabled }}
+          # -----------------------------------------------------------------
+          # MCP Service Configuration
+          # -----------------------------------------------------------------
+          [mcp]
+          # When auth is enabled, MCP forwards the caller's inbound Bearer token
+          # to Config Manager APIs. It does not fall back to service-to-service auth.
+          use_internal_endpoints = {{ .Values.mcp.client.useInternalEndpoints | default true }}
+          max_response_bytes = {{ .Values.mcp.client.maxResponseBytes | default 100000 }}
+          # auto resolves to jwt for bundled/local Nautobot and token for external Nautobot.
+          nautobot_auth_mode = {{ .Values.mcp.nautobot.authMode | default "auto" }}
+          nautobot_token_fallback_enabled = {{ .Values.mcp.nautobot.tokenFallbackEnabled | default false }}
+
+          {{- end }}
+
           {{- if and .Values.temporal.enabled (index .Values.secrets.vault.paths "jira") }}
           # -----------------------------------------------------------------
           # Jira Configuration (for DiagnosticsWorkflow)

--- a/deploy/helm/templates/vault-secrets.yaml
+++ b/deploy/helm/templates/vault-secrets.yaml
@@ -832,6 +832,7 @@ spec:
           api_service = http://{{ $temporalName }}-api:{{ $internalPort }}
           # External: Gateway URLs for user-facing links
           api_url = https://{{ tpl .Values.temporal.gateway.api.hostname . }}
+          temporal_ui_url = https://{{ tpl .Values.temporal.gateway.devUi.hostname . }}
           ui_url = https://{{ .Values.gateway.baseHostname }}
           # Set to true for internal cluster communication (uses api_service)
           # Set to false for external mTLS communication (uses api_url)
@@ -966,7 +967,10 @@ spec:
           # to Config Manager APIs. It does not fall back to service-to-service auth.
           use_internal_endpoints = {{ .Values.mcp.client.useInternalEndpoints | default true }}
           max_response_bytes = {{ .Values.mcp.client.maxResponseBytes | default 100000 }}
-          # auto resolves to jwt for bundled/local Nautobot and token for external Nautobot.
+          {{ "{{- with index (fromJson .nautobot_data) \"" }}{{ include "nv-config-manager.vault.keyName" (dict "root" . "secret" "nautobot" "key" "readOnlyToken") }}{{ "\" }}" }}
+          nautobot_read_only_token = {{ "{{ . }}" }}
+          {{ "{{- end }}" }}
+          # auto resolves to jwt for bundled/local Nautobot and the MCP read-only token for external Nautobot.
           nautobot_auth_mode = {{ .Values.mcp.nautobot.authMode | default "auto" }}
           nautobot_token_fallback_enabled = {{ .Values.mcp.nautobot.tokenFallbackEnabled | default false }}
 

--- a/deploy/helm/values-ci.yaml
+++ b/deploy/helm/values-ci.yaml
@@ -77,3 +77,6 @@ monitoring:
   probes:
     enabled: true
     blackboxExporterUrl: "blackbox:9115"
+
+mcp:
+  enabled: true

--- a/deploy/helm/values-local-small.yaml
+++ b/deploy/helm/values-local-small.yaml
@@ -453,6 +453,7 @@ cnpg:
 # MCP Service - Clear node scheduling
 # -----------------------------------------------------------------------------
 mcp:
+  enabled: true
   api:
     replicas: 1
     resources:

--- a/deploy/helm/values-local-small.yaml
+++ b/deploy/helm/values-local-small.yaml
@@ -160,10 +160,10 @@ networkDhcp:
   resources:
     dhcp:
       requests:
-        cpu: 1
+        cpu: "1"
         memory: 256Mi
       limits:
-        cpu: 1
+        cpu: "1"
         memory: 256Mi
     confgen:
       requests:
@@ -449,6 +449,20 @@ cnpg:
     affinity:
       nodeSelector: null
       enablePodAntiAffinity: false
+# -----------------------------------------------------------------------------
+# MCP Service - Clear node scheduling
+# -----------------------------------------------------------------------------
+mcp:
+  api:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+    nodeSelector: null
+    affinity: null
 
 gateway:
   envoyProxy:

--- a/deploy/helm/values-local.yaml
+++ b/deploy/helm/values-local.yaml
@@ -96,6 +96,9 @@ configStore:
   cacheRefresh:
     replicas: 1
 
+mcp:
+  enabled: true
+
 # Local infrastructure - single replicas
 redis:
   enabled: true

--- a/deploy/helm/values-sample-keycloak.yaml
+++ b/deploy/helm/values-sample-keycloak.yaml
@@ -56,7 +56,8 @@ oidc:
   # Public/native client used by CLI PKCE auth discovery
   cliClientId: "nv-config-manager-cli"
   authUtility:
-    enabled: true
+    # Keep disabled unless the UI image tag includes /auth/discovery and /auth/logout.
+    enabled: false
   
   # Name of K8s secret containing client-secret key
   # Create with: kubectl create secret generic oidc-client-secret --from-literal=client-secret=nv-config-manager-client-secret -n nv-config-manager
@@ -135,7 +136,8 @@ gateway:
           header: X-Forwarded-User
 
 mcp:
-  enabled: true
+  # Keep disabled unless the nv-config-manager image tag includes the MCP entrypoint.
+  enabled: false
 
 # =============================================================================
 # Note: Browser Access Setup

--- a/deploy/helm/values-sample-keycloak.yaml
+++ b/deploy/helm/values-sample-keycloak.yaml
@@ -52,6 +52,11 @@ oidc:
   
   # NVIDIA Config Manager client (created by setup-vm-prereqs.sh)
   clientId: "nv-config-manager"
+
+  # Public/native client used by CLI PKCE auth discovery
+  cliClientId: "nv-config-manager-cli"
+  authUtility:
+    enabled: true
   
   # Name of K8s secret containing client-secret key
   # Create with: kubectl create secret generic oidc-client-secret --from-literal=client-secret=nv-config-manager-client-secret -n nv-config-manager
@@ -128,6 +133,9 @@ gateway:
           header: X-Forwarded-Preferred-Username
         - claim: sub
           header: X-Forwarded-User
+
+mcp:
+  enabled: true
 
 # =============================================================================
 # Note: Browser Access Setup

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -336,6 +336,7 @@ secrets:
         path: "" # Required: e.g., "my-org/nv-config-manager/dev/nautobot"
         keys:
           token: "token"
+          readOnlyToken: "read_only_token"
           natsPassword: "nats_password"
           natsSysPassword: "nats_sys_password"
           natsNautobotPassword: "nats_nautobot_password"
@@ -920,6 +921,14 @@ oidc:
   issuerUrl: ""
   # OAuth2 client ID
   clientId: ""
+  # Optional public/native client ID for CLI PKCE auth discovery.
+  # Defaults to clientId when unset.
+  cliClientId: ""
+  # Public UI-backed auth utility endpoints for native clients.
+  # Keep disabled by default so current chart main remains compatible with
+  # pre-1.3.0 UI images that do not serve /auth/discovery or /auth/logout.
+  authUtility:
+    enabled: false
   # Name of K8s secret containing client-secret key
   # Secret must have key 'client-secret'
   clientSecretName: "oidc-client-secret"
@@ -1864,7 +1873,10 @@ configStore:
 # Service: MCP
 # =============================================================================
 mcp:
-  enabled: true
+  # Keep disabled by default so current chart main remains compatible with
+  # pre-1.3.0 environment values that pin nv-config-manager images to 1.2.x.
+  # Enable explicitly in values once the image contains the MCP entrypoint.
+  enabled: false
   # Gateway routing - Streamable HTTP MCP endpoint
   gateway:
     # Hostname: mcp.<baseHostname> (OIDC+JWT, browser access)
@@ -1894,9 +1906,9 @@ mcp:
     useInternalEndpoints: true
     maxResponseBytes: 100000
   nautobot:
-    # auto: bundled/local Nautobot uses user JWT, external Nautobot uses token
+    # auto: bundled/local Nautobot uses user JWT, external Nautobot uses the MCP read-only token
     # jwt: always forward the user's Bearer token to Nautobot
-    # token: always use [nautobot] token; set it to a read-only token per env
+    # token: always use [mcp] nautobot_read_only_token
     authMode: auto
     # Optional escape hatch for dev-only environments. Keep false in production.
     tokenFallbackEnabled: false

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1511,6 +1511,20 @@ networkDhcp:
         memory: 1Gi
       limits:
         memory: 2Gi
+    healthcheck:
+      requests:
+        cpu: 200m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+    api:
+      requests:
+        cpu: 200m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
     confgen:
       requests:
         cpu: 100m
@@ -1846,6 +1860,46 @@ configStore:
     useInternalEndpoint: false
     # SSL verification: true, false, or path to CA cert file
     verify: true
+# =============================================================================
+# Service: MCP
+# =============================================================================
+mcp:
+  enabled: true
+  # Gateway routing - Streamable HTTP MCP endpoint
+  gateway:
+    # Hostname: mcp.<baseHostname> (OIDC+JWT, browser access)
+    hostname: "mcp.{{ .Values.gateway.baseHostname }}"
+    # Hostname: svc-mcp.<baseHostname> (JWT-only, machine access)
+    svcHostname: "svc-mcp.{{ .Values.gateway.baseHostname }}"
+    # Auth bypass - healthcheck and metrics must be accessible without OIDC/JWT
+    authBypass:
+      enabled: true
+      paths:
+        - /healthcheck
+        - /metrics
+  api:
+    replicas: 2
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    nodeSelector: null
+    affinity: null
+  client:
+    # MCP always calls Config Manager APIs through internal service endpoints
+    # and forwards the caller's inbound Bearer token. It never falls back to
+    # service-to-service auth for these APIs.
+    useInternalEndpoints: true
+    maxResponseBytes: 100000
+  nautobot:
+    # auto: bundled/local Nautobot uses user JWT, external Nautobot uses token
+    # jwt: always forward the user's Bearer token to Nautobot
+    # token: always use [nautobot] token; set it to a read-only token per env
+    authMode: auto
+    # Optional escape hatch for dev-only environments. Keep false in production.
+    tokenFallbackEnabled: false
 # =============================================================================
 # SPIFFE Configuration (Service-to-Service Authentication)
 # =============================================================================

--- a/deploy/scripts/setup-vm-prereqs.sh
+++ b/deploy/scripts/setup-vm-prereqs.sh
@@ -1133,6 +1133,34 @@ spec:
               }'
             echo "Client created"
           fi
+
+          # Check if public CLI client exists
+          if curl -sf -H "Authorization: Bearer \$TOKEN" "http://keycloak:80/admin/realms/nv-config-manager/clients?clientId=nv-config-manager-cli" | grep -q "nv-config-manager-cli"; then
+            echo "Client nv-config-manager-cli already exists, skipping creation"
+          else
+            echo "Creating nv-config-manager-cli public client..."
+            curl -sf -X POST "http://keycloak:80/admin/realms/nv-config-manager/clients" \
+              -H "Authorization: Bearer \$TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "clientId": "nv-config-manager-cli",
+                "name": "NVIDIA Config Manager CLI",
+                "enabled": true,
+                "publicClient": true,
+                "directAccessGrantsEnabled": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "serviceAccountsEnabled": false,
+                "protocol": "openid-connect",
+                "redirectUris": ["http://localhost:*", "http://127.0.0.1:*"],
+                "webOrigins": ["*"],
+                "attributes": {
+                  "access.token.lifespan": "3600",
+                  "pkce.code.challenge.method": "S256"
+                }
+              }'
+            echo "CLI client created"
+          fi
           
           # Check if demo user exists
           if curl -sf -H "Authorization: Bearer \$TOKEN" "http://keycloak:80/admin/realms/nv-config-manager/users?username=demo" | grep -q "demo"; then

--- a/deploy/scripts/setup-vm-prereqs.sh
+++ b/deploy/scripts/setup-vm-prereqs.sh
@@ -1153,7 +1153,7 @@ spec:
                 "serviceAccountsEnabled": false,
                 "protocol": "openid-connect",
                 "redirectUris": ["http://localhost:*", "http://127.0.0.1:*"],
-                "webOrigins": ["*"],
+                "webOrigins": ["http://localhost:*", "http://127.0.0.1:*"],
                 "attributes": {
                   "access.token.lifespan": "3600",
                   "pkce.code.challenge.method": "S256"

--- a/docs/getting-started/local-development-quick-start.mdx
+++ b/docs/getting-started/local-development-quick-start.mdx
@@ -73,6 +73,7 @@ Add local hostnames for the Envoy Gateway.
 127.0.0.1 workflow.config-manager.local
 127.0.0.1 config-store.config-manager.local
 127.0.0.1 temporal.config-manager.local
+127.0.0.1 mcp.config-manager.local
 ```
 
 Then open:
@@ -83,6 +84,7 @@ Then open:
 | Nautobot | `https://nautobot.config-manager.local` |
 | Workflow API | `https://workflow.config-manager.local` |
 | Config Store API | `https://config-store.config-manager.local` |
+| MCP endpoint | `https://mcp.config-manager.local/mcp` |
 
 For the local profile, Nautobot login is `admin` / `admin`.
 

--- a/docs/install/tui-wizard-reference.mdx
+++ b/docs/install/tui-wizard-reference.mdx
@@ -231,6 +231,7 @@ Configure OIDC Single Sign-On for Config Manager services.
 | Provider | OIDC provider. The bundled sample uses `keycloak`; any compatible OIDC provider can be substituted. |
 | Issuer URL | OIDC issuer URL |
 | Client ID | OIDC client identifier |
+| CLI Client ID | Optional public/native client identifier for CLI PKCE auth. Defaults to Client ID when unset. |
 | Client Secret | OIDC client secret |
 | JWKS URI | Override for JWKS endpoint |
 | Audiences | Comma-separated audience list |

--- a/docs/overview/index.mdx
+++ b/docs/overview/index.mdx
@@ -18,6 +18,7 @@ Running on [Nautobot](../nautobot/index.mdx), Config Manager provides a comprehe
 | **[Config Store](../config-store/index.mdx)** | PostgreSQL-backed configuration storage and versioning |
 | **[ZTP Service](../network-ztp/index.mdx)** | Zero Touch Provisioning for device bootstrapping and firmware distribution |
 | **[DHCP Service](../dhcp/index.mdx)** | Dynamic configuration generation for ISC Kea DHCP server |
+| **[Remote MCP](mcp.mdx)** | Streamable HTTP MCP endpoint for authenticated tool access |
 
 ## Design Principles
 

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -4,105 +4,142 @@ sidebar-title: Remote MCP
 position: 95
 ---
 
-NVIDIA Config Manager exposes a remote Model Context Protocol (MCP) endpoint for MCP-capable clients. The endpoint is a Streamable HTTP service that runs in the Config Manager deployment; users do not need to run a local MCP server process.
+NVIDIA Config Manager includes a remote Model Context Protocol (MCP) server for
+MCP-capable clients. The MCP server runs inside the Config Manager deployment.
+You do not need to run a local MCP server.
 
-## Connection Model
+Use MCP when you want an assistant or other MCP-capable client to answer
+operational questions from Config Manager data, such as Nautobot inventory,
+DHCP reservations, stored device configs, workflow history, and selected safe
+workflow actions.
 
-When SSO is enabled, use the JWT-only service hostname for MCP client connections:
+## Quick Setup
+
+There are two supported ways to discover the MCP connection details.
+
+### Use the helper CLI
+
+The `nvcm-mcp-cli` helper discovers the MCP endpoint, handles OIDC login when
+SSO is enabled, and prints generic Streamable HTTP connection details.
+
+```sh
+nvcm-mcp-cli config -H config-manager.example.com
+```
+
+For SSO-enabled environments, sign in first:
+
+```sh
+nvcm-mcp-cli login -H config-manager.example.com
+```
+
+The helper opens a browser when a fresh OIDC login is required. If the browser
+does not open automatically, it prints the login URL. After login, the helper
+caches the user token locally.
+
+You can also print just the endpoint or token:
+
+```sh
+nvcm-mcp-cli endpoint -H config-manager.example.com
+nvcm-mcp-cli token -H config-manager.example.com
+```
+
+For local development environments that use a self-signed certificate, add
+`-k`.
+
+### Use discovery directly
+
+You can also tell an MCP-capable assistant or client to discover the server
+details from:
 
 ```text
-https://svc-mcp.<base-hostname>/mcp
+https://config-manager.example.com/auth/discovery
 ```
 
-The client sends a bearer token for the signed-in user:
+For example:
 
 ```text
-Authorization: Bearer <user-token>
+Connect to the NVIDIA Config Manager MCP server. Discover the MCP endpoint and
+auth details from https://config-manager.example.com/auth/discovery. Do not
+start a local MCP server.
 ```
 
-When SSO is not enabled, use the regular MCP hostname and omit the Authorization header:
+The discovery response tells the client which remote MCP endpoint to use and
+whether bearer authentication is required. In SSO-enabled environments, the MCP
+tools act with the signed-in user's bearer token. They do not switch to broader
+service credentials for Config Manager APIs.
 
-```text
-https://mcp.<base-hostname>/mcp
-```
+## Client Settings
 
-Config Manager MCP tools use the caller's bearer token when SSO is enabled. The tools do not switch to broader service credentials for user-authorized APIs.
-
-## CLI Helper
-
-The `nvcm-mcp-cli` command handles OIDC login, token retrieval, endpoint resolution, and generic connection output.
-
-Authenticate to an environment:
-
-```sh
-uv run nvcm-mcp-cli login -H <base-hostname>
-```
-
-Print the remote MCP endpoint:
-
-```sh
-uv run nvcm-mcp-cli endpoint -H <base-hostname>
-```
-
-In SSO-enabled environments, export a bearer token for an MCP-capable client:
-
-```sh
-export NVCM_MCP_BEARER_TOKEN="$(uv run nvcm-mcp-cli token -H <base-hostname>)"
-```
-
-Print generic Streamable HTTP connection details:
-
-```sh
-uv run nvcm-mcp-cli config -H <base-hostname>
-```
-
-Check token availability and service health:
-
-```sh
-uv run nvcm-mcp-cli check -H <base-hostname>
-```
-
-## Client Configuration
-
-Configure the MCP-capable client for Streamable HTTP using:
+Use these settings when configuring a client manually:
 
 | Setting | Value |
 | :------ | :---- |
 | Transport | Streamable HTTP |
-| URL | Use `nvcm-mcp-cli endpoint -H <base-hostname>` |
-| Authentication | Use bearer authentication when `nvcm-mcp-cli config` reports it; otherwise omit Authorization |
+| URL | Use `nvcm-mcp-cli endpoint -H <hostname>` or the endpoint from `/auth/discovery` |
+| Authentication | Use bearer authentication only when discovery or the helper says it is required |
 
-When bearer authentication is required, prefer passing the token through an environment variable rather than writing token values into static configuration files.
+When bearer authentication is required, prefer an environment variable or the
+client's secret storage instead of writing tokens into static configuration
+files.
 
-## Custom Endpoints
+## What You Can Ask
 
-If the deployment uses a custom MCP URL, pass it explicitly:
+The available tools are discoverable at runtime, so exact tool names may vary by
+deployment. In general, the operational Config Manager MCP server can answer
+questions like these:
 
-```sh
-uv run nvcm-mcp-cli endpoint --mcp-url https://svc-mcp.example.com/mcp
-uv run nvcm-mcp-cli token --mcp-url https://svc-mcp.example.com/mcp
+- "Find device `leaf1.example.com` and summarize its role, site, serial number,
+  platform, and Nautobot ID."
+- "How many DHCP reservations do we have, split by pool reservations and static
+  reservations?"
+- "Show the DHCP reservation details for `leaf1.example.com`."
+- "List the intended config files for `leaf1.example.com`."
+- "Show the latest stored running config for this device, with secrets
+  redacted."
+- "Compare two stored config versions for this device and summarize the
+  differences."
+- "List recent failed workflows for this site and include the Config Manager
+  workflow links."
+- "Run a backup for `leaf1.example.com` and give me the workflow URL."
+- "Run cable validation for this site and summarize the result."
+- "Check the InfiniBand fabric for unhealthy ports."
+
+MCP clients can also inspect the Nautobot GraphQL schema through the server. If
+you are asking a broad inventory question, it is usually best to let the client
+explore the schema and then issue targeted read-only queries.
+
+## Public Documentation MCP
+
+NVIDIA also publishes a public documentation MCP server for Config Manager:
+
+```text
+https://docs.nvidia.com/switch-infrastructure/config-manager/_mcp/server
 ```
 
-OIDC discovery normally uses the OIDC-enabled `mcp.<base-hostname>` endpoint. If discovery is served from a different URL, provide it separately:
+Connect to this as a separate MCP server when you want product documentation,
+usage guidance, or conceptual reference. It does not require authentication.
 
-```sh
-uv run nvcm-mcp-cli token \
-  --mcp-url https://svc-mcp.example.com/mcp \
-  --discovery-url https://mcp.example.com/mcp
-```
+The operational Config Manager MCP server includes a
+`list_related_mcp_servers` tool that returns the public docs MCP URL for clients
+that support discovering related servers.
 
-If automatic discovery is not available, provide the OIDC issuer and client ID:
+Examples of documentation-focused questions:
 
-```sh
-uv run nvcm-mcp-cli token \
-  --mcp-url https://svc-mcp.example.com/mcp \
-  --issuer https://issuer.example.com \
-  --client-id <client-id>
-```
+- "Find the Config Manager documentation for MCP setup."
+- "Explain how Config Manager handles workflow approvals."
+- "What does the backup workflow do?"
+- "Find the installation guidance for SSO-enabled deployments."
+- "Which documented workflow should I use to validate cabling?"
+
+For the best results, connect both MCP servers: use the deployment MCP server
+for live operational data, and use the public documentation MCP server for
+product guidance.
 
 ## Security Notes
 
-- The token represents the signed-in user.
-- In SSO-enabled environments, MCP tools call Config Manager APIs with the user's bearer token.
-- The CLI does not create service credentials or elevate access.
-- Token values should be treated as secrets and kept out of committed configuration.
+- The bearer token represents the signed-in user.
+- MCP tools use the caller's access for Config Manager APIs.
+- External Nautobot deployments may use a configured read-only Nautobot token
+  for MCP Nautobot queries.
+- Token values should be treated as secrets and kept out of documentation,
+  logs, and committed configuration.

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -4,14 +4,9 @@ sidebar-title: Remote MCP
 position: 95
 ---
 
-NVIDIA Config Manager includes a remote Model Context Protocol (MCP) server for
-MCP-capable clients. The MCP server runs inside the Config Manager deployment.
-You do not need to run a local MCP server.
+NVIDIA Config Manager includes a remote Model Context Protocol (MCP) server for MCP-capable clients. The MCP server runs inside the Config Manager deployment. You do not need to run a local MCP server.
 
-Use MCP when you want an assistant or other MCP-capable client to answer
-operational questions from Config Manager data, such as Nautobot inventory,
-DHCP reservations, stored device configs, workflow history, and selected safe
-workflow actions.
+Use MCP when you want an assistant or other MCP-capable client to answer operational questions from Config Manager data, such as Nautobot inventory, DHCP reservations, stored device configs, workflow history, and selected safe workflow actions.
 
 ## Quick Setup
 
@@ -19,8 +14,7 @@ There are two supported ways to discover the MCP connection details.
 
 ### Use the helper CLI
 
-The `nvcm-mcp-cli` helper discovers the MCP endpoint, handles OIDC login when
-SSO is enabled, and prints generic Streamable HTTP connection details.
+The `nvcm-mcp-cli` helper discovers the MCP endpoint, handles OIDC login when SSO is enabled, and prints generic Streamable HTTP connection details.
 
 ```sh
 nvcm-mcp-cli config -H config-manager.example.com
@@ -32,9 +26,7 @@ For SSO-enabled environments, sign in first:
 nvcm-mcp-cli login -H config-manager.example.com
 ```
 
-The helper opens a browser when a fresh OIDC login is required. If the browser
-does not open automatically, it prints the login URL. After login, the helper
-caches the user token locally.
+The helper opens a browser when a fresh OIDC login is required. If the browser does not open automatically, it prints the login URL. After login, the helper caches the user token locally.
 
 You can also print just the endpoint or token:
 
@@ -43,13 +35,11 @@ nvcm-mcp-cli endpoint -H config-manager.example.com
 nvcm-mcp-cli token -H config-manager.example.com
 ```
 
-For local development environments that use a self-signed certificate, add
-`-k`.
+For local development environments that use a self-signed certificate, add `-k`.
 
 ### Use discovery directly
 
-You can also tell an MCP-capable assistant or client to discover the server
-details from:
+You can also tell an MCP-capable assistant or client to discover the server details from:
 
 ```text
 https://config-manager.example.com/auth/discovery
@@ -58,15 +48,10 @@ https://config-manager.example.com/auth/discovery
 For example:
 
 ```text
-Connect to the NVIDIA Config Manager MCP server. Discover the MCP endpoint and
-auth details from https://config-manager.example.com/auth/discovery. Do not
-start a local MCP server.
+Connect to the NVIDIA Config Manager MCP server. Discover the MCP endpoint and auth details from https://config-manager.example.com/auth/discovery. Do not start a local MCP server.
 ```
 
-The discovery response tells the client which remote MCP endpoint to use and
-whether bearer authentication is required. In SSO-enabled environments, the MCP
-tools act with the signed-in user's bearer token. They do not switch to broader
-service credentials for Config Manager APIs.
+The discovery response tells the client which remote MCP endpoint to use and whether bearer authentication is required. In SSO-enabled environments, the MCP tools act with the signed-in user's bearer token. They do not switch to broader service credentials for Config Manager APIs.
 
 ## Client Settings
 
@@ -78,35 +63,24 @@ Use these settings when configuring a client manually:
 | URL | Use `nvcm-mcp-cli endpoint -H <hostname>` or the endpoint from `/auth/discovery` |
 | Authentication | Use bearer authentication only when discovery or the helper says it is required |
 
-When bearer authentication is required, prefer an environment variable or the
-client's secret storage instead of writing tokens into static configuration
-files.
+When bearer authentication is required, prefer an environment variable or the client's secret storage instead of writing tokens into static configuration files.
 
 ## What You Can Ask
 
-The available tools are discoverable at runtime, so exact tool names may vary by
-deployment. In general, the operational Config Manager MCP server can answer
-questions like these:
+The available tools are discoverable at runtime, so exact tool names may vary by deployment. In general, the operational Config Manager MCP server can answer questions like these:
 
-- "Find device `leaf1.example.com` and summarize its role, site, serial number,
-  platform, and Nautobot ID."
-- "How many DHCP reservations do we have, split by pool reservations and static
-  reservations?"
+- "Find device `leaf1.example.com` and summarize its role, site, serial number, platform, and Nautobot ID."
+- "How many DHCP reservations do we have, split by pool reservations and static reservations?"
 - "Show the DHCP reservation details for `leaf1.example.com`."
 - "List the intended config files for `leaf1.example.com`."
-- "Show the latest stored running config for this device, with secrets
-  redacted."
-- "Compare two stored config versions for this device and summarize the
-  differences."
-- "List recent failed workflows for this site and include the Config Manager
-  workflow links."
+- "Show the latest stored running config for this device, with secrets redacted."
+- "Compare two stored config versions for this device and summarize the differences."
+- "List recent failed workflows for this site and include the Config Manager workflow links."
 - "Run a backup for `leaf1.example.com` and give me the workflow URL."
 - "Run cable validation for this site and summarize the result."
 - "Check the InfiniBand fabric for unhealthy ports."
 
-MCP clients can also inspect the Nautobot GraphQL schema through the server. If
-you are asking a broad inventory question, it is usually best to let the client
-explore the schema and then issue targeted read-only queries.
+MCP clients can also inspect the Nautobot GraphQL schema through the server. If you are asking a broad inventory question, it is usually best to let the client explore the schema and then issue targeted read-only queries.
 
 ## Public Documentation MCP
 
@@ -116,12 +90,9 @@ NVIDIA also publishes a public documentation MCP server for Config Manager:
 https://docs.nvidia.com/switch-infrastructure/config-manager/_mcp/server
 ```
 
-Connect to this as a separate MCP server when you want product documentation,
-usage guidance, or conceptual reference. It does not require authentication.
+Connect to this as a separate MCP server when you want product documentation, usage guidance, or conceptual reference. It does not require authentication.
 
-The operational Config Manager MCP server includes a
-`list_related_mcp_servers` tool that returns the public docs MCP URL for clients
-that support discovering related servers.
+The operational Config Manager MCP server includes a `list_related_mcp_servers` tool that returns the public docs MCP URL for clients that support discovering related servers.
 
 Examples of documentation-focused questions:
 
@@ -131,15 +102,11 @@ Examples of documentation-focused questions:
 - "Find the installation guidance for SSO-enabled deployments."
 - "Which documented workflow should I use to validate cabling?"
 
-For the best results, connect both MCP servers: use the deployment MCP server
-for live operational data, and use the public documentation MCP server for
-product guidance.
+For the best results, connect both MCP servers: use the deployment MCP server for live operational data, and use the public documentation MCP server for product guidance.
 
 ## Security Notes
 
 - The bearer token represents the signed-in user.
 - MCP tools use the caller's access for Config Manager APIs.
-- External Nautobot deployments may use a configured read-only Nautobot token
-  for MCP Nautobot queries.
-- Token values should be treated as secrets and kept out of documentation,
-  logs, and committed configuration.
+- External Nautobot deployments may use a configured read-only Nautobot token for MCP Nautobot queries.
+- Token values should be treated as secrets and kept out of documentation, logs, and committed configuration.

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -1,0 +1,108 @@
+---
+title: Remote MCP Access
+sidebar-title: Remote MCP
+position: 95
+---
+
+NVIDIA Config Manager exposes a remote Model Context Protocol (MCP) endpoint for MCP-capable clients. The endpoint is a Streamable HTTP service that runs in the Config Manager deployment; users do not need to run a local MCP server process.
+
+## Connection Model
+
+When SSO is enabled, use the JWT-only service hostname for MCP client connections:
+
+```text
+https://svc-mcp.<base-hostname>/mcp
+```
+
+The client sends a bearer token for the signed-in user:
+
+```text
+Authorization: Bearer <user-token>
+```
+
+When SSO is not enabled, use the regular MCP hostname and omit the Authorization header:
+
+```text
+https://mcp.<base-hostname>/mcp
+```
+
+Config Manager MCP tools use the caller's bearer token when SSO is enabled. The tools do not switch to broader service credentials for user-authorized APIs.
+
+## CLI Helper
+
+The `nvcm-mcp-cli` command handles OIDC login, token retrieval, endpoint resolution, and generic connection output.
+
+Authenticate to an environment:
+
+```sh
+uv run nvcm-mcp-cli login -H <base-hostname>
+```
+
+Print the remote MCP endpoint:
+
+```sh
+uv run nvcm-mcp-cli endpoint -H <base-hostname>
+```
+
+In SSO-enabled environments, export a bearer token for an MCP-capable client:
+
+```sh
+export NVCM_MCP_BEARER_TOKEN="$(uv run nvcm-mcp-cli token -H <base-hostname>)"
+```
+
+Print generic Streamable HTTP connection details:
+
+```sh
+uv run nvcm-mcp-cli config -H <base-hostname>
+```
+
+Check token availability and service health:
+
+```sh
+uv run nvcm-mcp-cli check -H <base-hostname>
+```
+
+## Client Configuration
+
+Configure the MCP-capable client for Streamable HTTP using:
+
+| Setting | Value |
+| :------ | :---- |
+| Transport | Streamable HTTP |
+| URL | Use `nvcm-mcp-cli endpoint -H <base-hostname>` |
+| Authentication | Use bearer authentication when `nvcm-mcp-cli config` reports it; otherwise omit Authorization |
+
+When bearer authentication is required, prefer passing the token through an environment variable rather than writing token values into static configuration files.
+
+## Custom Endpoints
+
+If the deployment uses a custom MCP URL, pass it explicitly:
+
+```sh
+uv run nvcm-mcp-cli endpoint --mcp-url https://svc-mcp.example.com/mcp
+uv run nvcm-mcp-cli token --mcp-url https://svc-mcp.example.com/mcp
+```
+
+OIDC discovery normally uses the OIDC-enabled `mcp.<base-hostname>` endpoint. If discovery is served from a different URL, provide it separately:
+
+```sh
+uv run nvcm-mcp-cli token \
+  --mcp-url https://svc-mcp.example.com/mcp \
+  --discovery-url https://mcp.example.com/mcp
+```
+
+If automatic discovery is not available, provide the OIDC issuer and client ID:
+
+```sh
+uv run nvcm-mcp-cli token \
+  --mcp-url https://svc-mcp.example.com/mcp \
+  --issuer https://issuer.example.com \
+  --client-id <client-id>
+```
+
+## Security Notes
+
+- The token represents the signed-in user.
+- In SSO-enabled environments, MCP tools call Config Manager APIs with the user's bearer token.
+- The CLI does not create service credentials or elevate access.
+- Token values should be treated as secrets and kept out of committed configuration.

--- a/docs/temporal/temporal-cli.mdx
+++ b/docs/temporal/temporal-cli.mdx
@@ -24,8 +24,8 @@ The examples in this guide use `uv run`.
 
 The CLI auto-detects whether SSO is enabled for the target deployment:
 
-- If the workflow gateway redirects to an OIDC provider, the CLI uses browser-based OIDC PKCE authentication and sends workflow API requests to `https://svc-workflow.<hostname>/v1/workflow` with a bearer token.
-- If SSO is not enabled, the CLI sends unauthenticated requests to `https://workflow.<hostname>/v1/workflow`.
+- If `https://<hostname>/auth/discovery` reports SSO is enabled, the CLI uses browser-based OIDC PKCE authentication and sends workflow API requests to the advertised workflow service URL with a bearer token.
+- If discovery reports SSO is not enabled, the CLI sends unauthenticated requests to the advertised workflow URL.
 
 Cached OIDC tokens are stored in `~/.nv-config-manager/token.json`.
 
@@ -44,7 +44,7 @@ uv run workflow-cli logout
 uv run workflow-cli login -H config-manager.example.com --force
 ```
 
-If gateway OIDC discovery is not available, pass the issuer and client ID directly:
+If auth discovery is not available, the CLI falls back to the older gateway redirect discovery path. If automatic discovery is not available, pass the issuer and client ID directly:
 
 ```bash
 uv run workflow-cli login \

--- a/installer/src/nv_config_manager_installer/deployer.py
+++ b/installer/src/nv_config_manager_installer/deployer.py
@@ -1953,7 +1953,10 @@ class Deployer:
     def _create_core_secrets(self, step: DeployStep, s: dict[str, str]) -> None:
         """Create Redis, Nautobot, DB, NATS, and device credential secrets."""
         self._apply_secret(step, "redis-password", {"password": s.get("redis_password", "")})
-        self._apply_secret(step, "nautobot-token", {"token": s.get("nautobot_token", "")})
+        nautobot_token_data = {"token": s.get("nautobot_token", "")}
+        if ro_token := s.get("nautobot_read_only_token"):
+            nautobot_token_data["read-only-token"] = ro_token
+        self._apply_secret(step, "nautobot-token", nautobot_token_data)
 
         for db in ["temporal", "temporal_visibility", "config_store", "dhcp", "nautobot"]:
             self._apply_secret(

--- a/installer/src/nv_config_manager_installer/helm_values.py
+++ b/installer/src/nv_config_manager_installer/helm_values.py
@@ -548,6 +548,8 @@ def _build_oidc(config: NVConfigManagerInstallConfig, values: dict[str, Any]) ->
         "enabled": True,
         "issuerUrl": config.sso.issuer_url,
         "clientId": config.sso.client_id,
+        "cliClientId": config.sso.cli_client_id or config.sso.client_id,
+        "authUtility": {"enabled": True},
         "audiences": (
             config.sso.audiences.split(",") if config.sso.audiences else sso_defaults["audiences"]
         ),
@@ -875,6 +877,10 @@ def build_values(
     values["temporal"] = temporal_section
     values["rbac"] = _build_rbac(config)
     values["configStore"] = {"enabled": svc.config_store, "client": {"useInternalEndpoint": True}}
+    has_nautobot = svc.nautobot or bool(svc.external_nautobot_url)
+    values["mcp"] = {
+        "enabled": has_nautobot and svc.temporal and svc.config_store and svc.dhcp,
+    }
     values["nautobot"] = _build_nautobot(config)
 
     nats: dict[str, Any] = {"enabled": False}

--- a/installer/src/nv_config_manager_installer/helm_values.py
+++ b/installer/src/nv_config_manager_installer/helm_values.py
@@ -373,6 +373,9 @@ def _build_global(
         "serviceAccountName": "vault-access-sa",
     }
 
+    if c.environment == "local":
+        section["deploymentStrategy"] = {"type": "Recreate"}
+
     if is_local:
         section["imagePullSecrets"] = []
         section["imagePullPolicy"] = "IfNotPresent"

--- a/installer/src/nv_config_manager_installer/schema.py
+++ b/installer/src/nv_config_manager_installer/schema.py
@@ -145,7 +145,11 @@ class VaultPathsConfig(BaseModel):
     """All vault secret path groups consumed by the Helm chart."""
 
     nautobot: VaultPathConfig = Field(
-        default_factory=lambda: _path(token="token", natsPassword="nats_password")
+        default_factory=lambda: _path(
+            token="token",
+            readOnlyToken="read_only_token",
+            natsPassword="nats_password",
+        )
     )
     redis: VaultPathConfig = Field(default_factory=lambda: _path(password="password"))
     postgres: VaultPathConfig = Field(
@@ -291,6 +295,7 @@ class SSOConfig(BaseModel):
     provider: SSOProvider = SSOProvider.KEYCLOAK
     issuer_url: str = ""
     client_id: str = ""
+    cli_client_id: str = ""
     client_secret: str = ""
     jwks_uri: str = ""
     internal_issuer: str = ""

--- a/installer/src/nv_config_manager_installer/secrets.py
+++ b/installer/src/nv_config_manager_installer/secrets.py
@@ -87,6 +87,8 @@ _DB_GROUPS: list[tuple[str, str, str]] = [
 def _generate_core_k8s_secrets(state: dict[str, str], _v: Any) -> None:
     """Populate core Kubernetes secrets (Nautobot, Redis, PostgreSQL)."""
     state["nautobot_token"] = _v("nautobot", "token") or _generate_token(40)
+    if ro_token := _v("nautobot", "readOnlyToken"):
+        state["nautobot_read_only_token"] = ro_token
     state["nats_password"] = _v("nautobot", "natsPassword") or _generate_url_safe_password()
     state["redis_password"] = _v("redis", "password") or _generate_url_safe_password()
     state["nautobot_admin_password"] = _v("nautobot_app", "adminPassword") or _generate_password()

--- a/installer/src/nv_config_manager_installer/tui/screens/sso.py
+++ b/installer/src/nv_config_manager_installer/tui/screens/sso.py
@@ -108,6 +108,13 @@ class SSOScreen(Container):
             yield Label("Client ID", classes="field-label")
             yield Input(value=sso.client_id, placeholder="OIDC client ID", id="sso-client-id")
 
+            yield Label("CLI Client ID (optional)", classes="field-label")
+            yield Input(
+                value=sso.cli_client_id,
+                placeholder="Defaults to client ID",
+                id="sso-cli-client-id",
+            )
+
             yield Label("Client Secret", classes="field-label")
             yield Input(
                 value=sso.client_secret,
@@ -183,6 +190,7 @@ class SSOScreen(Container):
 
         config.sso.issuer_url = self.query_one("#sso-issuer-url", Input).value
         config.sso.client_id = self.query_one("#sso-client-id", Input).value
+        config.sso.cli_client_id = self.query_one("#sso-cli-client-id", Input).value
         config.sso.client_secret = self.query_one("#sso-client-secret", Input).value
         config.sso.jwks_uri = self.query_one("#sso-jwks-uri", Input).value
         config.sso.audiences = self.query_one("#sso-audiences", Input).value
@@ -201,6 +209,7 @@ class SSOScreen(Container):
 
         self.query_one("#sso-issuer-url", Input).value = sso.issuer_url
         self.query_one("#sso-client-id", Input).value = sso.client_id
+        self.query_one("#sso-cli-client-id", Input).value = sso.cli_client_id
         self.query_one("#sso-client-secret", Input).value = sso.client_secret
         self.query_one("#sso-jwks-uri", Input).value = sso.jwks_uri
         self.query_one("#sso-audiences", Input).value = sso.audiences

--- a/installer/tests/test_deployer.py
+++ b/installer/tests/test_deployer.py
@@ -52,11 +52,14 @@ from nv_config_manager_installer.schema import (
     ImageSource,
     JobPath,
     JobsConfig,
+    K8sSecretGroup,
+    KubernetesSecretsConfig,
     NetworkSecretEntry,
     NVConfigManagerInstallConfig,
     RedfishConfig,
     RedfishVendorCreds,
     SecretsConfig,
+    SecretsMethod,
     ServicesConfig,
     SiteConfig,
     TemplatePath,
@@ -1297,6 +1300,46 @@ class TestK8sClientIntegration:
         assert "redis-password" in secret_names
         assert "nautobot-token" in secret_names
         assert "nautobot-admin" in secret_names
+        nautobot_token_call = next(
+            call
+            for call in mock_k8s.apply_secret.call_args_list
+            if call.args[0] == "nautobot-token"
+        )
+        assert "read-only-token" not in nautobot_token_call.args[2]
+
+    @patch("nv_config_manager_installer.deployer._run_logged")
+    @patch("nv_config_manager_installer.deployer._run")
+    @patch("nv_config_manager_installer.deployer.K8sClient")
+    @patch("nv_config_manager_installer.deployer.shutil.which", return_value="/usr/bin/kubectl")
+    def test_create_secrets_includes_configured_nautobot_read_only_token(
+        self,
+        mock_which,
+        mock_k8s_class,
+        mock_run,
+        mock_run_logged,
+    ):
+        mock_k8s = _mock_k8s()
+        mock_k8s_class.return_value = mock_k8s
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_run_logged.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        config = _make_config()
+        config.secrets = SecretsConfig(
+            method=SecretsMethod.KUBERNETES,
+            k8s=KubernetesSecretsConfig(
+                nautobot=K8sSecretGroup(values={"readOnlyToken": "ro-token"}),
+            ),
+        )
+        cb = RecordingCallback()
+        deployer = Deployer(config, DeployOptions(dry_run=True), cb)
+        deployer.run()
+
+        nautobot_token_call = next(
+            call
+            for call in mock_k8s.apply_secret.call_args_list
+            if call.args[0] == "nautobot-token"
+        )
+        assert nautobot_token_call.args[2]["read-only-token"] == "ro-token"
 
     def test_api_token_retrieval(self):
         config = _make_config()

--- a/installer/tests/test_helm_values.py
+++ b/installer/tests/test_helm_values.py
@@ -113,6 +113,7 @@ class TestGenerateHelmValues:
         assert ext["redis"]["localHost"] == "redis-master"
         assert ext["postgres"]["temporal"]["host"] == "cluster-temporal-rw"
         assert ext["postgres"]["configStore"]["host"] == "cluster-config-store-rw"
+        assert values["mcp"]["enabled"] is True
 
     def test_local_environment_uses_recreate_deployment_strategy(self):
         values = _gen(
@@ -356,6 +357,8 @@ class TestGenerateHelmValues:
 
         assert values["oidc"]["enabled"] is True
         assert values["oidc"]["issuerUrl"] == "https://kc.test/realms/nv-config-manager"
+        assert values["oidc"]["cliClientId"] == "test-client"
+        assert values["oidc"]["authUtility"]["enabled"] is True
         assert (
             values["oidc"]["jwksUri"]
             == "https://kc.test/realms/nv-config-manager/protocol/openid-connect/certs"
@@ -370,6 +373,21 @@ class TestGenerateHelmValues:
         # Keycloak default audiences include "account"
         assert "account" in values["oidc"]["audiences"]
         assert "test-client" in values["oidc"]["audiences"]
+
+    def test_sso_cli_client_id_can_be_configured(self):
+        config = _make_config(
+            sso=SSOConfig(
+                enabled=True,
+                provider=SSOProvider.KEYCLOAK,
+                issuer_url="https://kc.test/realms/nv-config-manager",
+                client_id="test-client",
+                cli_client_id="test-cli-client",
+            ),
+        )
+        values = _gen(config)
+
+        assert values["oidc"]["clientId"] == "test-client"
+        assert values["oidc"]["cliClientId"] == "test-cli-client"
 
     def test_sso_azure_endpoints(self):
         tenant = "43083d15-7273-40c1-b7db-39efd9ccc17a"
@@ -507,6 +525,7 @@ class TestGenerateHelmValues:
         assert values["renderService"]["enabled"] is False
         assert values["networkDhcp"]["enabled"] is False
         assert values["networkZtp"]["enabled"] is True
+        assert values["mcp"]["enabled"] is False
 
     def test_nodeport_when_no_lb(self):
         config = _make_config(
@@ -582,6 +601,7 @@ class TestGenerateHelmValues:
         assert "nats" not in ext
         assert ext["redis"]["local"] is True
         assert ext["postgres"]["temporal"]["host"] == "cluster-temporal-rw"
+        assert values["mcp"]["enabled"] is True
 
 
 class TestImagesInHelmValues:

--- a/installer/tests/test_helm_values.py
+++ b/installer/tests/test_helm_values.py
@@ -114,6 +114,13 @@ class TestGenerateHelmValues:
         assert ext["postgres"]["temporal"]["host"] == "cluster-temporal-rw"
         assert ext["postgres"]["configStore"]["host"] == "cluster-config-store-rw"
 
+    def test_local_environment_uses_recreate_deployment_strategy(self):
+        values = _gen(
+            _make_config(cluster=ClusterConfig(hostname="local.test", environment="local"))
+        )
+
+        assert values["global"]["deploymentStrategy"] == {"type": "Recreate"}
+
     def test_key_names_match_chart(self):
         values = _gen(_make_config())
 

--- a/installer/tests/test_schema.py
+++ b/installer/tests/test_schema.py
@@ -87,6 +87,7 @@ class TestNVConfigManagerInstallConfig:
                 enabled=True,
                 provider=SSOProvider.KEYCLOAK,
                 issuer_url="https://kc.test/realms/nv-config-manager",
+                cli_client_id="nv-config-manager-cli",
             ),
         )
 
@@ -107,6 +108,7 @@ class TestNVConfigManagerInstallConfig:
             assert loaded.sites[0].name == "dc01"
             assert loaded.sso.enabled is True
             assert loaded.sso.provider == SSOProvider.KEYCLOAK
+            assert loaded.sso.cli_client_id == "nv-config-manager-cli"
         finally:
             path.unlink(missing_ok=True)
 

--- a/installer/tests/test_secrets.py
+++ b/installer/tests/test_secrets.py
@@ -61,10 +61,24 @@ class TestGenerateSecrets:
 
         assert "nautobot_token" in state
         assert len(state["nautobot_token"]) == 40
+        assert "nautobot_read_only_token" not in state
         assert "redis_password" in state
         assert "nats_password" in state
         assert "django_secret_key" in state
         assert "temporal_db_password" in state
+
+    def test_kubernetes_nautobot_read_only_token_passes_through(self):
+        config = NVConfigManagerInstallConfig(
+            secrets=SecretsConfig(
+                method=SecretsMethod.KUBERNETES,
+                k8s=KubernetesSecretsConfig(
+                    nautobot=K8sSecretGroup(values={"readOnlyToken": "ro-token"}),
+                ),
+            ),
+        )
+        state = generate_secrets(config)
+
+        assert state["nautobot_read_only_token"] == "ro-token"
 
     def test_kubernetes_nautobot_admin_password_override(self):
         config = NVConfigManagerInstallConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ dependencies = [
     "py-markdown-table>=1.1.0",
     # Documentation
     "mkdocs>=1.6.1",
+    # Model Context Protocol
+    "mcp>=1.8.0",
     # Network Templates (render service)
     "nv-config-manager-templates",
 ]
@@ -122,6 +124,10 @@ nv-config-manager-render-template-updater = "nv_config_manager.render.producer:c
 # Config Store Service
 nv-config-manager-config-store-api = "nv_config_manager.config_store.api.main:main"
 nv-config-manager-config-store-cache-refresh = "nv_config_manager.config_store.cache_refresh_service:cli_main"
+
+# MCP Service
+nvidia-config-manager-mcp = "nv_config_manager.mcp.main:main"
+nvcm-mcp-cli = "nv_config_manager.mcp.cli:main"
 
 [dependency-groups]
 integration-test = [

--- a/scripts/create-local-security-nautobot-users
+++ b/scripts/create-local-security-nautobot-users
@@ -17,6 +17,10 @@ Options:
   --release-name NAME  Helm release name used for Nautobot labels (default: nv-config-manager)
   --timeout DURATION   Wait timeout for Nautobot readiness (default: 15m)
   --help               Show this help
+
+Environment:
+  ALLOW_WEAK_LOCAL_USERS=true
+      Allow static local test credentials outside the default kind namespace/context guard.
 EOF
 }
 
@@ -84,6 +88,15 @@ pod="$(
 if [[ -z "$pod" ]]; then
     echo "Unable to find a Nautobot pod after rollout." >&2
     exit 1
+fi
+
+if [[ "${ALLOW_WEAK_LOCAL_USERS:-false}" != "true" ]]; then
+    current_context="$(kubectl config current-context 2>/dev/null || true)"
+    if [[ "$NAMESPACE" != "nv-config-manager" || "$current_context" != kind-* ]]; then
+        echo "Refusing to create static local security users outside the default kind test environment." >&2
+        echo "Set ALLOW_WEAK_LOCAL_USERS=true only for local security test environments." >&2
+        exit 1
+    fi
 fi
 
 echo "Creating local security users in Nautobot pod ${pod}..."

--- a/scripts/install-security-dependencies
+++ b/scripts/install-security-dependencies
@@ -590,6 +590,90 @@ spec:
               }'
           fi
 
+          cli_client_uuid() {
+            curl -sf -H "Authorization: Bearer $TOKEN" \
+              "http://keycloak:80/admin/realms/nv-config-manager/clients?clientId=nv-config-manager-cli" \
+              | tr '{' '\n' \
+              | grep '"clientId":"nv-config-manager-cli"' \
+              | sed -n 's/.*"id":"\([^"]*\)".*/\1/p' \
+              | head -n 1
+          }
+
+          if [ -z "$(cli_client_uuid)" ]; then
+            curl -sf -X POST "http://keycloak:80/admin/realms/nv-config-manager/clients" \
+              -H "Authorization: Bearer $TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "clientId": "nv-config-manager-cli",
+                "name": "NVIDIA Config Manager CLI",
+                "enabled": true,
+                "publicClient": true,
+                "directAccessGrantsEnabled": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "serviceAccountsEnabled": false,
+                "protocol": "openid-connect",
+                "redirectUris": ["http://localhost:*", "http://127.0.0.1:*"],
+                "webOrigins": ["*"],
+                "attributes": {
+                  "access.token.lifespan": "3600",
+                  "pkce.code.challenge.method": "S256"
+                }
+              }'
+          fi
+
+          CLI_CLIENT_UUID=$(cli_client_uuid)
+          if [ -z "$CLI_CLIENT_UUID" ]; then
+            echo "Failed to resolve nv-config-manager-cli client id"
+            exit 1
+          fi
+
+          curl -sf -X PUT "http://keycloak:80/admin/realms/nv-config-manager/clients/${CLI_CLIENT_UUID}" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "clientId": "nv-config-manager-cli",
+              "name": "NVIDIA Config Manager CLI",
+              "enabled": true,
+              "publicClient": true,
+              "directAccessGrantsEnabled": false,
+              "standardFlowEnabled": true,
+              "implicitFlowEnabled": false,
+              "serviceAccountsEnabled": false,
+              "protocol": "openid-connect",
+              "redirectUris": ["http://localhost:*", "http://127.0.0.1:*"],
+              "webOrigins": ["*"],
+              "attributes": {
+                "access.token.lifespan": "3600",
+                "pkce.code.challenge.method": "S256"
+              }
+            }'
+
+          if curl -sf -H "Authorization: Bearer $TOKEN" \
+            "http://keycloak:80/admin/realms/nv-config-manager/clients/${CLI_CLIENT_UUID}/protocol-mappers/models" \
+            | grep -q '"name":"realm roles"'; then
+            echo "CLI realm roles mapper exists"
+          else
+            curl -sf -X POST \
+              "http://keycloak:80/admin/realms/nv-config-manager/clients/${CLI_CLIENT_UUID}/protocol-mappers/models" \
+              -H "Authorization: Bearer $TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "name": "realm roles",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                "consentRequired": false,
+                "config": {
+                  "multivalued": "true",
+                  "userinfo.token.claim": "true",
+                  "id.token.claim": "true",
+                  "access.token.claim": "true",
+                  "claim.name": "roles",
+                  "jsonType.label": "String"
+                }
+              }'
+          fi
+
           ensure_realm_role() {
             role="$1"
             description="$2"

--- a/scripts/render-local-security-config
+++ b/scripts/render-local-security-config
@@ -45,6 +45,7 @@ def main() -> int:
 
     sso = require_mapping(config.setdefault("sso", {}), "sso")
     sso["issuer_url"] = f"https://{args.keycloak_hostname}/realms/nv-config-manager"
+    sso["cli_client_id"] = "nv-config-manager-cli"
     sso["client_secret"] = args.oidc_client_secret
 
     spiffe = require_mapping(config.setdefault("spiffe", {}), "spiffe")

--- a/src/nv_config_manager/common/client/__init__.py
+++ b/src/nv_config_manager/common/client/__init__.py
@@ -23,6 +23,9 @@ from nv_config_manager.common.client.config_store import (
     ConfigStoreFileNotFound,
 )
 
+# DHCP Client
+from nv_config_manager.common.client.dhcp import DHCPClient, DHCPClientException
+
 # NATS Client
 from nv_config_manager.common.client.nats import (
     NatsClient,
@@ -71,6 +74,9 @@ __all__ = [
     "ConfigStoreClient",
     "ConfigStoreException",
     "ConfigStoreFileNotFound",
+    # DHCP
+    "DHCPClient",
+    "DHCPClientException",
     # NATS
     "NatsClient",
     "NatsConsumer",

--- a/src/nv_config_manager/common/client/config_store.py
+++ b/src/nv_config_manager/common/client/config_store.py
@@ -34,6 +34,8 @@ from nv_config_manager.common.log import LogCategory, get_logger
 if TYPE_CHECKING:
     from nv_config_manager.common.config import ConfigStoreType
 
+_FILE_TYPE_UNSET = object()
+
 
 class ConfigStoreException(Exception):
     """Exception interacting with Config Store."""
@@ -150,6 +152,29 @@ class ConfigStoreClient(_WhoamiViaRetryClientMixin):
                 client_certificate=get_mtls_cert_paths(config),
             )
 
+    @classmethod
+    def for_mcp(
+        cls,
+        target: str,
+        headers: dict[str, str] | Callable[[], dict[str, str]],
+        file_type: ConfigStoreType | str = "intended",
+        ui_url: str | None = None,
+        verify: bool | str = True,
+    ) -> ConfigStoreClient:
+        """Create a Config Store client for MCP with explicit caller-scoped headers."""
+        if hasattr(file_type, "value"):
+            file_type_str = str(file_type.value)
+        else:
+            file_type_str = str(file_type)
+        return cls(
+            target=target,
+            file_type=file_type_str,
+            ui_url=ui_url or target,
+            verify=verify,
+            client_certificate=None,
+            headers=headers,
+        )
+
     @staticmethod
     def _sanitize_url(url: str) -> str:
         """Remove duplicate slashes from URL."""
@@ -233,6 +258,117 @@ class ConfigStoreClient(_WhoamiViaRetryClientMixin):
         except Exception as e:
             raise ConfigStoreException(f"Failed to load {filename}: {e}") from e
 
+    async def list_device_configs(
+        self,
+        device_uuid: str,
+        file_type: str | None | object = _FILE_TYPE_UNSET,
+    ) -> dict[str, object]:
+        """List latest configuration files for a device."""
+        try:
+            async with self._new_session() as session:
+                async with session.get(
+                    f"{self.config_url}/device/{device_uuid}",
+                    params=self._file_type_params(file_type),
+                ) as rsp:
+                    rsp.raise_for_status()
+                    data: dict[str, object] = await rsp.json()
+                    return data
+        except aiohttp.ClientResponseError as exc:
+            raise ConfigStoreException(
+                f"Failed to list configs for {device_uuid}: {exc.status} {exc.message}"
+            ) from exc
+        except Exception as exc:
+            raise ConfigStoreException(f"Failed to list configs for {device_uuid}: {exc}") from exc
+
+    async def get_config_file(
+        self,
+        device_uuid: str,
+        filename: str,
+        file_type: str | None | object = _FILE_TYPE_UNSET,
+        version: int | None = None,
+    ) -> dict[str, object]:
+        """Get a configuration file from Config Store."""
+        params = self._file_type_params(file_type)
+        if version is not None:
+            params["version"] = version
+        try:
+            async with self._new_session() as session:
+                async with session.get(
+                    f"{self.config_url}/{device_uuid}/{quote(filename, safe='')}",
+                    params=params,
+                ) as rsp:
+                    rsp.raise_for_status()
+                    data: dict[str, object] = await rsp.json()
+                    return data
+        except aiohttp.ClientResponseError as exc:
+            if exc.status == 404:
+                raise ConfigStoreFileNotFound(
+                    f"Did not locate {filename} for device {device_uuid}"
+                ) from exc
+            raise ConfigStoreException(
+                f"Failed to get config {device_uuid}/{filename}: {exc.status} {exc.message}"
+            ) from exc
+        except Exception as exc:
+            raise ConfigStoreException(
+                f"Failed to get config {device_uuid}/{filename}: {exc}"
+            ) from exc
+
+    async def get_config_versions(
+        self,
+        device_uuid: str,
+        filename: str,
+        file_type: str | None | object = _FILE_TYPE_UNSET,
+        limit: int = 100,
+    ) -> dict[str, object]:
+        """List versions for a device configuration file."""
+        params = self._file_type_params(file_type)
+        params["limit"] = limit
+        try:
+            async with self._new_session() as session:
+                async with session.get(
+                    f"{self.config_url}/{device_uuid}/{quote(filename, safe='')}/versions",
+                    params=params,
+                ) as rsp:
+                    rsp.raise_for_status()
+                    data: dict[str, object] = await rsp.json()
+                    return data
+        except aiohttp.ClientResponseError as exc:
+            raise ConfigStoreException(
+                f"Failed to list versions for {device_uuid}/{filename}: {exc.status} {exc.message}"
+            ) from exc
+        except Exception as exc:
+            raise ConfigStoreException(
+                f"Failed to list versions for {device_uuid}/{filename}: {exc}"
+            ) from exc
+
+    async def get_config_diff(
+        self,
+        device_uuid: str,
+        filename: str,
+        from_version: int,
+        to_version: int,
+        file_type: str | None | object = _FILE_TYPE_UNSET,
+    ) -> dict[str, object]:
+        """Get a diff between two Config Store versions."""
+        params = self._file_type_params(file_type)
+        params["from_version"] = from_version
+        params["to_version"] = to_version
+        try:
+            async with self._new_session() as session:
+                async with session.get(
+                    f"{self.config_url}/{device_uuid}/{quote(filename, safe='')}/diff",
+                    params=params,
+                ) as rsp:
+                    rsp.raise_for_status()
+                    data: dict[str, object] = await rsp.json()
+                    return data
+        except aiohttp.ClientResponseError as exc:
+            raise ConfigStoreException(
+                f"Failed to diff {device_uuid}/{filename}: {exc.status} {exc.message}"
+            ) from exc
+        except Exception as exc:
+            raise ConfigStoreException(f"Failed to diff {device_uuid}/{filename}: {exc}") from exc
+
     async def persist_files(
         self,
         device_uuid: str,
@@ -310,6 +446,13 @@ class ConfigStoreClient(_WhoamiViaRetryClientMixin):
         """Close the connector."""
         if self.connector and not self.connector.closed:
             await self.connector.close()
+
+    def _file_type_params(self, file_type: str | None | object) -> dict[str, object]:
+        if file_type is None:
+            return {}
+        if file_type is _FILE_TYPE_UNSET:
+            return {"file_type": self.file_type}
+        return {"file_type": file_type}
 
     async def __aenter__(self) -> ConfigStoreClient:
         """Async context manager entry."""

--- a/src/nv_config_manager/common/client/dhcp.py
+++ b/src/nv_config_manager/common/client/dhcp.py
@@ -20,7 +20,7 @@ import ssl
 import types
 from collections.abc import Callable
 from configparser import ConfigParser
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from aiohttp import ClientTimeout, TCPConnector
@@ -111,9 +111,10 @@ class DHCPClient:
 
     def _resolve_headers(self) -> dict[str, str] | None:
         """Return headers for the current request/session."""
-        if callable(self._headers):
-            return self._headers()
-        return self._headers
+        headers = self._headers
+        if isinstance(headers, dict) or headers is None:
+            return cast(dict[str, str] | None, headers)
+        return headers()
 
     async def _request(
         self,

--- a/src/nv_config_manager/common/client/dhcp.py
+++ b/src/nv_config_manager/common/client/dhcp.py
@@ -91,7 +91,6 @@ class DHCPClient:
         self._session = aiohttp.ClientSession(
             connector=_connector(self._verify, self._client_certificate),
             timeout=ClientTimeout(total=30, connect=10),
-            headers=self._resolve_headers(),
         )
         return self
 
@@ -130,6 +129,7 @@ class DHCPClient:
                 method,
                 f"{self.base_url}{path}",
                 params=params,
+                headers=self._resolve_headers(),
             ) as rsp:
                 payload = await _response_payload(rsp)
                 if not rsp.ok:

--- a/src/nv_config_manager/common/client/dhcp.py
+++ b/src/nv_config_manager/common/client/dhcp.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import json
 import ssl
 import types
 from collections.abc import Callable
@@ -144,7 +145,7 @@ class DHCPClient:
 async def _response_payload(response: aiohttp.ClientResponse) -> Any:
     try:
         return await response.json()
-    except aiohttp.ContentTypeError:
+    except (aiohttp.ContentTypeError, json.JSONDecodeError):
         return await response.text()
 
 

--- a/src/nv_config_manager/common/client/dhcp.py
+++ b/src/nv_config_manager/common/client/dhcp.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DHCP Service API client."""
+
+from __future__ import annotations
+
+import ssl
+import types
+from collections.abc import Callable
+from configparser import ConfigParser
+from typing import Any
+
+import aiohttp
+from aiohttp import ClientTimeout, TCPConnector
+
+
+class DHCPClientException(Exception):
+    """Exception raised for errors in the DHCP client."""
+
+
+class DHCPClient:
+    """Async client for interacting with the DHCP API service."""
+
+    def __init__(
+        self,
+        base_url: str,
+        verify: bool | str = True,
+        client_certificate: tuple[str, str] | None = None,
+        headers: dict[str, str] | Callable[[], dict[str, str]] | None = None,
+    ) -> None:
+        """Initialize the DHCP API client."""
+        self.base_url = base_url.rstrip("/")
+        self._verify = verify
+        self._client_certificate = client_certificate
+        self._headers = headers
+        self._session: aiohttp.ClientSession | None = None
+
+    @classmethod
+    def from_config(
+        cls,
+        config: ConfigParser,
+        section: str = "dhcp",
+    ) -> DHCPClient:
+        """Create a DHCP client from INI configuration."""
+        # Imported lazily because nv_config_manager.common.config imports common clients.
+        from nv_config_manager.common.config import (
+            get_internal_auth_headers,
+            get_mtls_cert_paths,
+            parse_verify_param,
+        )
+
+        dhcp_config = config[section]
+        use_internal = dhcp_config.getboolean("use_internal_endpoint", fallback=False)
+        if use_internal:
+            return cls(
+                base_url=dhcp_config["api_service"],
+                verify=False,
+                client_certificate=None,
+                headers=get_internal_auth_headers,
+            )
+        return cls(
+            base_url=dhcp_config["api_url"],
+            verify=parse_verify_param(dhcp_config),
+            client_certificate=get_mtls_cert_paths(config),
+        )
+
+    @classmethod
+    def for_mcp(
+        cls,
+        base_url: str,
+        headers: dict[str, str] | Callable[[], dict[str, str]],
+        verify: bool | str = True,
+    ) -> DHCPClient:
+        """Create a DHCP client for MCP with explicit caller-scoped headers."""
+        return cls(base_url=base_url, verify=verify, client_certificate=None, headers=headers)
+
+    async def __aenter__(self) -> DHCPClient:
+        """Async context manager entry."""
+        self._session = aiohttp.ClientSession(
+            connector=_connector(self._verify, self._client_certificate),
+            timeout=ClientTimeout(total=30, connect=10),
+            headers=self._resolve_headers(),
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        """Async context manager exit."""
+        if self._session:
+            await self._session.close()
+
+    async def get_config(self, ip_version: int = 4) -> Any:
+        """Get the sanitized running DHCP configuration."""
+        return await self._request("GET", "/config", params={"ip_version": ip_version})
+
+    def _resolve_headers(self) -> dict[str, str] | None:
+        """Return headers for the current request/session."""
+        if callable(self._headers):
+            return self._headers()
+        return self._headers
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        if not self._session:
+            raise RuntimeError("DHCPClient must be used as async context manager")
+
+        try:
+            async with self._session.request(
+                method,
+                f"{self.base_url}{path}",
+                params=params,
+            ) as rsp:
+                payload = await _response_payload(rsp)
+                if not rsp.ok:
+                    raise DHCPClientException(
+                        f"{method} {path} failed with HTTP {rsp.status}: {payload}"
+                    )
+                return payload
+        except aiohttp.ClientError as exc:
+            raise DHCPClientException(f"{method} {path} failed: {exc}") from exc
+
+
+async def _response_payload(response: aiohttp.ClientResponse) -> Any:
+    try:
+        return await response.json()
+    except aiohttp.ContentTypeError:
+        return await response.text()
+
+
+def _connector(
+    verify: bool | str = True,
+    client_certificate: tuple[str, str] | None = None,
+) -> TCPConnector:
+    ssl_context = ssl.create_default_context()
+    if isinstance(verify, str):
+        ssl_context.load_verify_locations(verify)
+    elif verify is False:
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+
+    if client_certificate:
+        ssl_context.load_cert_chain(client_certificate[0], client_certificate[1])
+
+    return TCPConnector(ssl=ssl_context)

--- a/src/nv_config_manager/common/client/nautobot.py
+++ b/src/nv_config_manager/common/client/nautobot.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import ssl
 import types
+from collections.abc import Callable
 from configparser import ConfigParser
 from typing import Any, Self, cast
 
@@ -51,9 +52,10 @@ class NautobotClient:
     def __init__(
         self,
         nautobot_url: str,
-        token: str,
+        token: str = "",
         verify: bool | str = True,
         timeout: int = 30,
+        headers: dict[str, str] | Callable[[], dict[str, str]] | None = None,
     ) -> None:
         """Initialize the Nautobot client.
 
@@ -62,11 +64,14 @@ class NautobotClient:
             token: API token for authentication
             verify: SSL verification - True (default), False (disable), or str (path to CA cert)
             timeout: Default request timeout in seconds
+            headers: Static dict or callable returning fresh headers per-request.
+                If set, these headers take precedence over token auth.
         """
         self.nautobot_url = nautobot_url.rstrip("/") + "/"
         self.token = token
         self._verify = verify
         self._timeout = timeout
+        self._headers = headers
         self.graphql_endpoint = f"{self.nautobot_url}api/graphql/"
         self.rest_endpoint = f"{self.nautobot_url}api/"
         self._session: aiohttp.ClientSession | None = None
@@ -90,6 +95,22 @@ class NautobotClient:
             nautobot_url=nautobot_config["server"],
             token=nautobot_config["token"],
             verify=parse_verify_param(nautobot_config),
+        )
+
+    @classmethod
+    def for_mcp(
+        cls,
+        nautobot_url: str,
+        headers: dict[str, str] | Callable[[], dict[str, str]],
+        verify: bool | str = True,
+        timeout: int = 30,
+    ) -> Self:
+        """Create a Nautobot client for MCP with explicit caller-scoped headers."""
+        return cls(
+            nautobot_url=nautobot_url,
+            verify=verify,
+            timeout=timeout,
+            headers=headers,
         )
 
     async def __aenter__(self) -> Self:
@@ -125,11 +146,21 @@ class NautobotClient:
             timeout = ClientTimeout(total=self._timeout, connect=10)
 
             self._session = aiohttp.ClientSession(
-                headers={"Authorization": f"Token {self.token}"},
+                headers=self._resolve_headers(),
                 connector=connector,
                 timeout=timeout,
             )
         return self._session
+
+    def _resolve_headers(self) -> dict[str, str] | None:
+        """Return auth headers for the current request/session."""
+        if callable(self._headers):
+            return self._headers()
+        if self._headers:
+            return self._headers
+        if self.token:
+            return {"Authorization": f"Token {self.token}"}
+        return None
 
     async def close(self) -> None:
         """Close the HTTP client session.

--- a/src/nv_config_manager/common/client/nautobot.py
+++ b/src/nv_config_manager/common/client/nautobot.py
@@ -146,7 +146,6 @@ class NautobotClient:
             timeout = ClientTimeout(total=self._timeout, connect=10)
 
             self._session = aiohttp.ClientSession(
-                headers=self._resolve_headers(),
                 connector=connector,
                 timeout=timeout,
             )
@@ -223,7 +222,10 @@ class NautobotClient:
 
         request_timeout = aiohttp.ClientTimeout(total=timeout or self._timeout)
         async with session.post(
-            self.graphql_endpoint, json=payload, timeout=request_timeout
+            self.graphql_endpoint,
+            json=payload,
+            timeout=request_timeout,
+            headers=self._resolve_headers(),
         ) as rsp:
             if rsp.status == 400:
                 data = await rsp.json()
@@ -255,6 +257,7 @@ class NautobotClient:
             f"{self.rest_endpoint}{path}",
             params=params,
             timeout=request_timeout,
+            headers=self._resolve_headers(),
         ) as rsp:
             if not rsp.ok:
                 await self._handle_error_response(rsp, "GET", path)
@@ -277,6 +280,7 @@ class NautobotClient:
             f"{self.rest_endpoint}{path}",
             json=data,
             timeout=request_timeout,
+            headers=self._resolve_headers(),
         ) as rsp:
             if not rsp.ok:
                 await self._handle_error_response(rsp, "POST", path)
@@ -299,6 +303,7 @@ class NautobotClient:
             f"{self.rest_endpoint}{path}",
             json=data,
             timeout=request_timeout,
+            headers=self._resolve_headers(),
         ) as rsp:
             if not rsp.ok:
                 await self._handle_error_response(rsp, "PATCH", path)
@@ -316,6 +321,7 @@ class NautobotClient:
         async with session.delete(
             f"{self.rest_endpoint}{path}",
             timeout=request_timeout,
+            headers=self._resolve_headers(),
         ) as rsp:
             if not rsp.ok:
                 await self._handle_error_response(rsp, "DELETE", path)

--- a/src/nv_config_manager/common/client/nautobot.py
+++ b/src/nv_config_manager/common/client/nautobot.py
@@ -154,10 +154,11 @@ class NautobotClient:
 
     def _resolve_headers(self) -> dict[str, str] | None:
         """Return auth headers for the current request/session."""
-        if callable(self._headers):
-            return self._headers()
-        if self._headers:
-            return self._headers
+        headers = self._headers
+        if isinstance(headers, dict):
+            return cast(dict[str, str], headers)
+        if headers is not None:
+            return headers()
         if self.token:
             return {"Authorization": f"Token {self.token}"}
         return None

--- a/src/nv_config_manager/common/client/temporal.py
+++ b/src/nv_config_manager/common/client/temporal.py
@@ -20,6 +20,7 @@ import ssl
 import types
 from collections.abc import Callable
 from configparser import ConfigParser
+from typing import Any
 
 import aiohttp
 from aiohttp import ClientTimeout, TCPConnector
@@ -103,6 +104,21 @@ class TemporalClient:
                 client_certificate=get_mtls_cert_paths(config),
             )
 
+    @classmethod
+    def for_mcp(
+        cls,
+        base_url: str,
+        headers: dict[str, str] | Callable[[], dict[str, str]],
+        user_domain: str = "nvidia.com",
+    ) -> TemporalClient:
+        """Create a Temporal API client for MCP with explicit caller-scoped headers."""
+        return cls(
+            base_url=base_url,
+            user_domain=user_domain,
+            client_certificate=None,
+            headers=headers,
+        )
+
     async def __aenter__(self) -> TemporalClient:
         """Async context manager entry."""
         if self._client_certificate:
@@ -113,11 +129,10 @@ class TemporalClient:
         else:
             connector = TCPConnector()
 
-        headers = self._headers() if callable(self._headers) else self._headers  # type: ignore[ty:call-top-callable]  # ty can't narrow dict|Callable union
         self._session = aiohttp.ClientSession(
             connector=connector,
             timeout=ClientTimeout(total=30),
-            headers=headers,
+            headers=self._resolve_headers(),
         )
         return self
 
@@ -154,6 +169,18 @@ class TemporalClient:
                 return data
         except aiohttp.ClientError as exc:
             raise TemporalClientException(f"Failed to fetch whoami: {exc}") from exc
+
+    async def list_workflows(self, params: dict[str, Any] | None = None) -> Any:
+        """List workflow executions from the Workflow API."""
+        return await self._request("GET", "/v1/workflow", params=params)
+
+    async def get_workflow(self, workflow_id: str) -> Any:
+        """Get a workflow execution from the Workflow API."""
+        return await self._request("GET", f"/v1/workflow/{workflow_id}")
+
+    async def start_workflow(self, endpoint: str, payload: dict[str, Any]) -> Any:
+        """Start a workflow through a dynamic Workflow API endpoint."""
+        return await self._request("POST", f"/v1/workflow{endpoint}", json_body=payload)
 
     async def invoke_backup_workflow(self, device_id: str, user: str = "nv-config-manager") -> str:
         """Invoke the backup workflow for a device.
@@ -198,3 +225,42 @@ class TemporalClient:
                 str(exc),
             )
             raise TemporalClientException(f"Failed to invoke backup workflow: {exc}") from exc
+
+    def _resolve_headers(self) -> dict[str, str] | None:
+        """Return headers for the current request/session."""
+        if callable(self._headers):
+            return self._headers()
+        return self._headers
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> Any:
+        if not self._session:
+            raise RuntimeError("TemporalClient must be used as async context manager")
+
+        try:
+            async with self._session.request(
+                method,
+                f"{self.base_url}{path}",
+                params=params,
+                json=json_body,
+            ) as rsp:
+                payload = await _response_payload(rsp)
+                if not rsp.ok:
+                    raise TemporalClientException(
+                        f"{method} {path} failed with HTTP {rsp.status}: {payload}"
+                    )
+                return payload
+        except aiohttp.ClientError as exc:
+            raise TemporalClientException(f"{method} {path} failed: {exc}") from exc
+
+
+async def _response_payload(response: aiohttp.ClientResponse) -> Any:
+    try:
+        return await response.json()
+    except aiohttp.ContentTypeError:
+        return await response.text()

--- a/src/nv_config_manager/common/client/temporal.py
+++ b/src/nv_config_manager/common/client/temporal.py
@@ -20,7 +20,7 @@ import ssl
 import types
 from collections.abc import Callable
 from configparser import ConfigParser
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from aiohttp import ClientTimeout, TCPConnector
@@ -228,9 +228,10 @@ class TemporalClient:
 
     def _resolve_headers(self) -> dict[str, str] | None:
         """Return headers for the current request/session."""
-        if callable(self._headers):
-            return self._headers()
-        return self._headers
+        headers = self._headers
+        if isinstance(headers, dict) or headers is None:
+            return cast(dict[str, str] | None, headers)
+        return headers()
 
     async def _request(
         self,

--- a/src/nv_config_manager/common/client/temporal.py
+++ b/src/nv_config_manager/common/client/temporal.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import json
 import ssl
 import types
 from collections.abc import Callable
@@ -132,7 +133,6 @@ class TemporalClient:
         self._session = aiohttp.ClientSession(
             connector=connector,
             timeout=ClientTimeout(total=30),
-            headers=self._resolve_headers(),
         )
         return self
 
@@ -163,7 +163,10 @@ class TemporalClient:
         if not self._session:
             raise RuntimeError("TemporalClient must be used as async context manager")
         try:
-            async with self._session.get(f"{self.base_url}/whoami") as rsp:
+            async with self._session.get(
+                f"{self.base_url}/whoami",
+                headers=self._resolve_headers(),
+            ) as rsp:
                 rsp.raise_for_status()
                 data: WhoamiResult = await rsp.json()
                 return data
@@ -210,6 +213,7 @@ class TemporalClient:
             async with self._session.post(
                 f"{self.base_url}/v1/workflow/ngc/backup",
                 json=payload,
+                headers=self._resolve_headers(),
             ) as rsp:
                 rsp.raise_for_status()
                 result = await rsp.json()
@@ -249,6 +253,7 @@ class TemporalClient:
                 f"{self.base_url}{path}",
                 params=params,
                 json=json_body,
+                headers=self._resolve_headers(),
             ) as rsp:
                 payload = await _response_payload(rsp)
                 if not rsp.ok:
@@ -263,5 +268,5 @@ class TemporalClient:
 async def _response_payload(response: aiohttp.ClientResponse) -> Any:
     try:
         return await response.json()
-    except aiohttp.ContentTypeError:
+    except (aiohttp.ContentTypeError, json.JSONDecodeError):
         return await response.text()

--- a/src/nv_config_manager/common/config.py
+++ b/src/nv_config_manager/common/config.py
@@ -40,6 +40,7 @@ from requests.adapters import HTTPAdapter
 # =============================================================================
 from nv_config_manager.common.client import (
     ConfigStoreClient,
+    DHCPClient,
     NatsClient,
     NautobotClient,
     RedisClient,
@@ -358,6 +359,20 @@ def config_store_ui_url(config: ConfigParser | None = None) -> str:
     if config is None:
         config = load_config()
     return config["config_store.client"]["ui_url"]
+
+
+def dhcp_client(config: ConfigParser | None = None) -> DHCPClient:
+    """Create a DHCPClient for this environment.
+
+    Args:
+        config: ConfigParser instance (uses load_config() if None)
+
+    Returns:
+        Configured DHCPClient instance
+    """
+    if config is None:
+        config = load_config()
+    return DHCPClient.from_config(config)
 
 
 def nautobot_client(config: ConfigParser | None = None) -> NautobotClient:

--- a/src/nv_config_manager/common/oidc.py
+++ b/src/nv_config_manager/common/oidc.py
@@ -41,6 +41,8 @@ import hashlib
 import json
 import secrets
 import webbrowser
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -53,6 +55,17 @@ import requests
 from nv_config_manager.common.log import LogCategory, get_logger
 
 logger = get_logger(__name__, category=LogCategory.AUTH)
+
+
+@dataclass(frozen=True)
+class AuthDiscovery:
+    """Public auth metadata advertised by a Config Manager deployment."""
+
+    auth_required: bool
+    issuer_url: str | None = None
+    client_id: str | None = None
+    scopes: tuple[str, ...] = ()
+    services: Mapping[str, str] = field(default_factory=dict)
 
 
 def decode_jwt_claims(token: str) -> dict[str, Any] | None:
@@ -82,6 +95,170 @@ def decode_jwt_claims(token: str) -> dict[str, Any] | None:
         return None
 
 
+def _metadata_url(issuer_url: str) -> str:
+    """Return the standard OIDC discovery URL for an issuer."""
+    return f"{issuer_url.rstrip('/')}/.well-known/openid-configuration"
+
+
+def _fetch_oidc_metadata(issuer_url: str, verify: bool | str = True) -> dict[str, Any]:
+    """Fetch OIDC provider metadata for an issuer."""
+    metadata_url = _metadata_url(issuer_url)
+    response = requests.get(metadata_url, timeout=10, verify=verify)
+    response.raise_for_status()
+    try:
+        metadata = response.json()
+    except ValueError as e:
+        raise RuntimeError(
+            f"OIDC metadata discovery returned invalid JSON at {metadata_url}"
+        ) from e
+    if not isinstance(metadata, dict):
+        raise RuntimeError(
+            f"OIDC metadata discovery returned a non-object payload at {metadata_url}"
+        )
+    return metadata
+
+
+def _discover_issuer_from_authorization_redirect(
+    redirect_url: str,
+    verify: bool | str = True,
+) -> str | None:
+    """Discover the issuer whose metadata owns an authorization redirect URL."""
+    authorization_endpoint = _normalized_endpoint_url(redirect_url)
+    for candidate in _issuer_candidates_from_authorization_redirect(redirect_url):
+        try:
+            metadata = _fetch_oidc_metadata(candidate, verify)
+        except (requests.exceptions.RequestException, RuntimeError):
+            continue
+
+        metadata_authorization_endpoint = metadata.get("authorization_endpoint")
+        if not isinstance(metadata_authorization_endpoint, str):
+            continue
+        if _normalized_endpoint_url(metadata_authorization_endpoint) != authorization_endpoint:
+            continue
+
+        issuer = metadata.get("issuer")
+        if isinstance(issuer, str) and issuer:
+            return issuer.rstrip("/")
+        return candidate
+
+    return None
+
+
+def _issuer_candidates_from_authorization_redirect(redirect_url: str) -> list[str]:
+    """Return likely issuer URLs for an authorization endpoint redirect."""
+    parsed = urlparse(redirect_url)
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path.rstrip("/")
+    candidates: list[str] = []
+
+    def add(path_value: str) -> None:
+        normalized_path = path_value.rstrip("/")
+        candidate = f"{origin}{normalized_path}" if normalized_path else origin
+        if candidate not in candidates:
+            candidates.append(candidate)
+
+    # Common provider-specific authorization endpoint shapes. These are path
+    # based, not hostname based, and are only used to find metadata to verify.
+    if path.endswith("/protocol/openid-connect/auth"):
+        add(path.rsplit("/protocol/openid-connect/auth", 1)[0])
+    if path.endswith("/oauth2/v2.0/authorize"):
+        prefix = path.rsplit("/oauth2/v2.0/authorize", 1)[0]
+        add(f"{prefix}/v2.0")
+    if path.endswith("/authorize"):
+        add(path.rsplit("/authorize", 1)[0])
+
+    parts = [part for part in path.strip("/").split("/") if part]
+    for index in range(len(parts), 0, -1):
+        add("/" + "/".join(parts[:index]))
+    add("")
+
+    return candidates
+
+
+def _fallback_issuer_from_authorization_redirect(redirect_url: str) -> str:
+    """Best-effort issuer derivation when provider metadata is unavailable."""
+    parsed = urlparse(redirect_url)
+    issuer_path = parsed.path.rstrip("/")
+
+    if issuer_path.endswith("/protocol/openid-connect/auth"):
+        issuer_path = issuer_path.rsplit("/protocol/openid-connect/auth", 1)[0]
+    elif issuer_path.endswith("/oauth2/v2.0/authorize"):
+        prefix = issuer_path.rsplit("/oauth2/v2.0/authorize", 1)[0]
+        issuer_path = f"{prefix}/v2.0"
+    elif issuer_path.endswith("/authorize"):
+        issuer_path = issuer_path.rsplit("/authorize", 1)[0]
+
+    return f"{parsed.scheme}://{parsed.netloc}{issuer_path}".rstrip("/")
+
+
+def _normalized_endpoint_url(url: str) -> str:
+    """Normalize an endpoint URL for metadata comparison."""
+    parsed = urlparse(url)
+    return parsed._replace(
+        netloc=parsed.netloc.lower(),
+        path=parsed.path.rstrip("/"),
+        params="",
+        query="",
+        fragment="",
+    ).geturl()
+
+
+def _parse_scope_payload(value: Any) -> tuple[str, ...]:
+    """Parse scope metadata from JSON arrays or delimited strings."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        if not value.strip():
+            return ()
+        return tuple(scope for scope in value.replace(",", " ").split() if scope)
+    if isinstance(value, list | tuple):
+        return tuple(str(scope).strip() for scope in value if str(scope).strip())
+    return ()
+
+
+def _parse_service_payload(value: Any) -> dict[str, str]:
+    """Parse service URL metadata, dropping non-string or empty values."""
+    if not isinstance(value, dict):
+        return {}
+    services: dict[str, str] = {}
+    for name, url in value.items():
+        if not isinstance(name, str) or not isinstance(url, str):
+            continue
+        normalized = url.rstrip("/")
+        if normalized:
+            services[name] = normalized
+    return services
+
+
+def _parse_auth_discovery_payload(payload: Any) -> AuthDiscovery:
+    """Validate and normalize /auth/discovery JSON."""
+    if not isinstance(payload, dict):
+        raise RuntimeError("Auth discovery returned a non-object payload.")
+
+    auth_required = payload.get("authRequired", payload.get("auth_required"))
+    if not isinstance(auth_required, bool):
+        raise RuntimeError("Auth discovery payload must include boolean authRequired.")
+
+    issuer_url = payload.get("issuerUrl", payload.get("issuer_url"))
+    client_id = payload.get("clientId", payload.get("client_id"))
+    scopes = _parse_scope_payload(payload.get("scopes"))
+    services = _parse_service_payload(payload.get("services"))
+
+    if auth_required:
+        if not isinstance(issuer_url, str) or not issuer_url:
+            raise RuntimeError("Auth discovery payload is missing issuerUrl.")
+        if not isinstance(client_id, str) or not client_id:
+            raise RuntimeError("Auth discovery payload is missing clientId.")
+
+    return AuthDiscovery(
+        auth_required=auth_required,
+        issuer_url=issuer_url.rstrip("/") if isinstance(issuer_url, str) and issuer_url else None,
+        client_id=client_id if isinstance(client_id, str) and client_id else None,
+        scopes=scopes,
+        services=services,
+    )
+
+
 class OIDCAuth:
     """OIDC PKCE authentication handler.
 
@@ -101,6 +278,7 @@ class OIDCAuth:
         redirect_port: int = 8765,
         scopes: list[str] | None = None,
         token_file: Path | None = None,
+        verify: bool | str = True,
     ) -> None:
         """Initialize OIDC auth handler.
 
@@ -110,14 +288,15 @@ class OIDCAuth:
             redirect_port: Local port for OAuth callback (default: 8765).
             scopes: OAuth scopes to request. Defaults to api://<client_id>/.default + openid + profile.
             token_file: Path for cached token storage. Defaults to ~/.nv-config-manager/token.json.
+            verify: Whether to verify TLS certificates, or a CA bundle path.
         """
         self.issuer_url = issuer_url.rstrip("/")
         self.client_id = client_id
         self.redirect_port = redirect_port
-        # Request app-specific scope to get a token for THIS app (not Microsoft Graph).
-        # Without api://<client_id>/.default, Azure AD issues a Graph token (aud=00000003-...).
-        self.scopes = scopes or [f"api://{client_id}/.default", "openid", "profile"]
+        self.verify = verify
+        self.scopes = scopes or self._default_scopes()
         self.redirect_uri = f"http://localhost:{redirect_port}/callback"
+        self._metadata: dict[str, Any] | None = None
 
         # Token storage
         self.token_file = token_file or (Path.home() / ".nv-config-manager" / "token.json")
@@ -142,28 +321,77 @@ class OIDCAuth:
     # ── Endpoint resolution ───────────────────────────────────────────────
 
     def _get_token_endpoint(self) -> str:
-        """Get token endpoint URL.
+        """Get token endpoint URL."""
+        if endpoint := self._metadata_endpoint("token_endpoint"):
+            return endpoint
 
-        Handles issuer as .../v2.0 or .../oauth2/v2.0 (from redirect discovery).
-        """
-        if "microsoftonline.com" in self.issuer_url:
+        if self._is_azure_issuer():
             if "/oauth2/v2.0" in self.issuer_url:
                 return f"{self.issuer_url.rstrip('/')}/token"
             base = self.issuer_url.replace("/v2.0", "").rstrip("/")
             return f"{base}/oauth2/v2.0/token"
+
+        if self._is_keycloak_issuer():
+            return f"{self.issuer_url}/protocol/openid-connect/token"
+
         return f"{self.issuer_url}/token"
 
     def _get_auth_endpoint(self) -> str:
-        """Get authorization endpoint URL.
+        """Get authorization endpoint URL."""
+        if endpoint := self._metadata_endpoint("authorization_endpoint"):
+            return endpoint
 
-        Handles issuer as .../v2.0 or .../oauth2/v2.0 (from redirect discovery).
-        """
-        if "microsoftonline.com" in self.issuer_url:
+        if self._is_azure_issuer():
             if "/oauth2/v2.0" in self.issuer_url:
                 return f"{self.issuer_url.rstrip('/')}/authorize"
             base = self.issuer_url.replace("/v2.0", "").rstrip("/")
             return f"{base}/oauth2/v2.0/authorize"
+
+        if self._is_keycloak_issuer():
+            return f"{self.issuer_url}/protocol/openid-connect/auth"
+
         return f"{self.issuer_url}/authorize"
+
+    def _default_scopes(self) -> list[str]:
+        """Return provider-appropriate default scopes."""
+        if self._is_azure_issuer():
+            # Request app-specific scope to get a token for THIS app, not Microsoft Graph.
+            return [f"api://{self.client_id}/.default", "openid", "profile"]
+        return ["openid", "profile", "email"]
+
+    def _metadata_endpoint(self, key: str) -> str | None:
+        """Resolve an OIDC endpoint from provider metadata when available."""
+        metadata = self._provider_metadata()
+        value = metadata.get(key)
+        if isinstance(value, str) and value:
+            return value
+        return None
+
+    def _provider_metadata(self) -> dict[str, Any]:
+        """Fetch OIDC provider metadata, falling back to provider-specific heuristics."""
+        if self._metadata is not None:
+            return self._metadata
+
+        try:
+            metadata = _fetch_oidc_metadata(self.issuer_url, self.verify)
+        except (requests.exceptions.RequestException, RuntimeError) as e:
+            metadata_url = _metadata_url(self.issuer_url)
+            logger.debug("OIDC metadata discovery failed at %s: %s", metadata_url, e)
+            self._metadata = {}
+            return self._metadata
+
+        self._metadata = metadata
+        return self._metadata
+
+    def _is_azure_issuer(self) -> bool:
+        """Return True when the issuer URL looks like an Azure AD issuer."""
+        parsed = urlparse(self.issuer_url)
+        return "microsoftonline.com" in parsed.netloc.lower()
+
+    def _is_keycloak_issuer(self) -> bool:
+        """Return True when the issuer URL looks like a Keycloak realm issuer."""
+        parsed = urlparse(self.issuer_url)
+        return "keycloak" in parsed.netloc.lower() or "/realms/" in parsed.path
 
     # ── Authorization URL ─────────────────────────────────────────────────
 
@@ -213,7 +441,7 @@ class OIDCAuth:
         }
         token_endpoint = self._get_token_endpoint()
         try:
-            response = requests.post(token_endpoint, data=data, timeout=30)
+            response = requests.post(token_endpoint, data=data, timeout=30, verify=self.verify)
             response.raise_for_status()
             return response.json()  # type: ignore[no-any-return]
         except requests.exceptions.HTTPError as e:
@@ -501,22 +729,53 @@ class OIDCAuth:
 
         parsed = urlparse(redirect_url)
 
-        # Derive issuer from the redirect path (remove /authorize or Keycloak /auth suffix)
-        issuer_path = parsed.path.rstrip("/")
-        if issuer_path.endswith("/authorize"):
-            issuer_path = issuer_path[:-10]
-        elif issuer_path.endswith("/protocol/openid-connect/auth"):
-            issuer_path = issuer_path.rsplit("/protocol/openid-connect/auth", 1)[0]
-
-        issuer_url = f"{parsed.scheme}://{parsed.netloc}{issuer_path}"
-
         query_params = parse_qs(parsed.query)
         client_id = query_params.get("client_id", [None])[0]
 
         if not client_id:
             raise RuntimeError(f"Could not extract client_id from redirect URL: {redirect_url}")
 
+        issuer_url = _discover_issuer_from_authorization_redirect(redirect_url, verify)
+        if issuer_url is None:
+            issuer_url = _fallback_issuer_from_authorization_redirect(redirect_url)
+
         return issuer_url, client_id
+
+    @staticmethod
+    def discover_auth_config(
+        discovery_url: str,
+        verify: bool | str = True,
+    ) -> AuthDiscovery | None:
+        """Discover public Config Manager auth metadata from /auth/discovery.
+
+        A return value of ``None`` means the discovery endpoint is not available
+        on that deployment, so callers should fall back to legacy gateway
+        redirect discovery.
+        """
+        try:
+            response = requests.get(
+                discovery_url,
+                allow_redirects=False,
+                timeout=10,
+                verify=verify,
+            )
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(f"Failed to reach auth discovery at {discovery_url}: {e}") from e
+
+        if response.status_code in (301, 302, 303, 307, 308, 404):
+            return None
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            raise RuntimeError(f"Auth discovery failed at {discovery_url}: {e}") from e
+
+        try:
+            payload = response.json()
+        except ValueError as e:
+            raise RuntimeError(f"Auth discovery returned invalid JSON at {discovery_url}") from e
+
+        return _parse_auth_discovery_payload(payload)
 
     @classmethod
     def discover_from_gateway(
@@ -542,4 +801,5 @@ class OIDCAuth:
         if result is None:
             return None
         issuer_url, client_id = result
+        kwargs.setdefault("verify", verify)
         return cls(issuer_url=issuer_url, client_id=client_id, **kwargs)

--- a/src/nv_config_manager/common/oidc.py
+++ b/src/nv_config_manager/common/oidc.py
@@ -653,7 +653,7 @@ class OIDCAuth:
     # ── SSO detection and OIDC discovery from gateway redirect ─────────────
 
     @staticmethod
-    def is_sso_enabled(gateway_url: str, verify: bool = True) -> bool:
+    def is_sso_enabled(gateway_url: str, verify: bool | str = True) -> bool:
         """Probe the gateway to determine whether SSO/OIDC is enabled.
 
         Makes a lightweight unauthenticated request (to /whoami relative to the
@@ -688,7 +688,7 @@ class OIDCAuth:
     @staticmethod
     def discover_oidc_config(
         gateway_url: str,
-        verify: bool = True,
+        verify: bool | str = True,
     ) -> tuple[str, str] | None:
         """Discover OIDC issuer and client_id from a gateway's login redirect.
 
@@ -781,7 +781,7 @@ class OIDCAuth:
     def discover_from_gateway(
         cls,
         gateway_url: str,
-        verify: bool = True,
+        verify: bool | str = True,
         **kwargs: Any,
     ) -> "OIDCAuth | None":
         """Create an OIDCAuth instance by auto-discovering config from a gateway.

--- a/src/nv_config_manager/mcp/__init__.py
+++ b/src/nv_config_manager/mcp/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NVIDIA Config Manager MCP server package."""

--- a/src/nv_config_manager/mcp/auth.py
+++ b/src/nv_config_manager/mcp/auth.py
@@ -20,7 +20,14 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+from nv_config_manager.common.auth import (
+    DEFAULT_UNAUTHENTICATED_PATHS,
+    require_authenticated_identity,
+)
 
 AUTHORIZATION_HEADER = "authorization"
 AUTH_CONTEXT_HEADERS = {
@@ -87,6 +94,36 @@ class RequestAuthMiddleware:
             return await self.app(scope, receive, send)
         finally:
             _REQUEST_AUTH.reset(token)
+
+
+class ServiceAuthMiddleware:
+    """Enforce configured service-side auth for MCP HTTP requests."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        unauthenticated_paths: frozenset[str] = DEFAULT_UNAUTHENTICATED_PATHS,
+    ) -> None:
+        self.app = app
+        self.unauthenticated_paths = unauthenticated_paths
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Any:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        path = str(scope.get("path", "")).rstrip("/") or "/"
+        method = str(scope.get("method", ""))
+        if path in self.unauthenticated_paths or method == "OPTIONS":
+            return await self.app(scope, receive, send)
+
+        request = Request(scope, receive=receive)
+        try:
+            await require_authenticated_identity(request)
+        except HTTPException as exc:
+            response = JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+            return await response(scope, receive, send)
+
+        return await self.app(scope, receive, send)
 
 
 def current_request_auth() -> RequestAuth | None:

--- a/src/nv_config_manager/mcp/auth.py
+++ b/src/nv_config_manager/mcp/auth.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Request-scoped auth handling for the MCP server."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+AUTHORIZATION_HEADER = "authorization"
+AUTH_CONTEXT_HEADERS = {
+    "x-auth-request-email": "X-Auth-Request-Email",
+    "x-auth-request-user": "X-Auth-Request-User",
+    "x-auth-request-preferred-username": "X-Auth-Request-Preferred-Username",
+    "x-auth-request-name": "X-Auth-Request-Name",
+    "x-auth-request-groups": "X-Auth-Request-Groups",
+    "x-auth-request-subject": "X-Auth-Request-Subject",
+}
+
+
+class MissingBearerTokenError(Exception):
+    """Raised when an MCP tool requires the caller's bearer token."""
+
+
+@dataclass(frozen=True)
+class RequestAuth:
+    """Authentication material extracted from the inbound MCP HTTP request."""
+
+    authorization: str | None
+    identity_headers: dict[str, str]
+
+    @classmethod
+    def from_asgi_headers(cls, headers: list[tuple[bytes, bytes]]) -> RequestAuth:
+        """Build auth context from ASGI headers."""
+        decoded_headers = {
+            key.decode("latin-1").lower(): value.decode("latin-1") for key, value in headers
+        }
+        identity_headers = {
+            canonical_name: decoded_headers[header_name]
+            for header_name, canonical_name in AUTH_CONTEXT_HEADERS.items()
+            if decoded_headers.get(header_name)
+        }
+        return cls(
+            authorization=decoded_headers.get(AUTHORIZATION_HEADER),
+            identity_headers=identity_headers,
+        )
+
+    @property
+    def bearer_authorization(self) -> str | None:
+        """Return the inbound Bearer authorization header, if one is present."""
+        if self.authorization and self.authorization.lower().startswith("bearer "):
+            return self.authorization
+        return None
+
+
+_REQUEST_AUTH: ContextVar[RequestAuth | None] = ContextVar("mcp_request_auth", default=None)
+
+
+class RequestAuthMiddleware:
+    """Capture inbound HTTP auth headers for downstream service calls."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Any:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        auth = RequestAuth.from_asgi_headers(scope.get("headers", []))
+        token = _REQUEST_AUTH.set(auth)
+        try:
+            return await self.app(scope, receive, send)
+        finally:
+            _REQUEST_AUTH.reset(token)
+
+
+def current_request_auth() -> RequestAuth | None:
+    """Return auth context for the current MCP request."""
+    return _REQUEST_AUTH.get()
+
+
+def downstream_auth_headers() -> dict[str, str]:
+    """Return headers for downstream NVIDIA Config Manager APIs.
+
+    MCP tools must act with the caller's authority. Do not fall back to service
+    identity or gateway-derived identity headers here; Nautobot is handled
+    separately because some environments intentionally use a read-only token.
+    """
+    auth = current_request_auth()
+    if auth:
+        bearer = auth.bearer_authorization
+        if bearer:
+            return {"Authorization": bearer}
+
+    raise MissingBearerTokenError("MCP request must include an Authorization: Bearer token.")
+
+
+def user_bearer_authorization() -> str | None:
+    """Return the inbound user Bearer authorization header, if available."""
+    auth = current_request_auth()
+    if not auth:
+        return None
+    return auth.bearer_authorization

--- a/src/nv_config_manager/mcp/cli.py
+++ b/src/nv_config_manager/mcp/cli.py
@@ -182,6 +182,17 @@ def _discover_auth_config(
         raise click.ClickException(f"OIDC auto-discovery failed: {e}") from e
 
 
+def _enforce_secure_endpoint(endpoint_url: str, auth_required: bool) -> None:
+    """Refuse bearer-token use over plaintext MCP endpoints."""
+    if not auth_required:
+        return
+    parsed = urlparse(endpoint_url)
+    if parsed.scheme.lower() != "https":
+        raise click.ClickException(
+            f"Refusing non-HTTPS MCP endpoint for bearer auth: {endpoint_url}"
+        )
+
+
 def _resolve_connection(
     hostname: str | None,
     environment: str | None,
@@ -201,7 +212,7 @@ def _resolve_connection(
     )
 
     if auth_mode == AUTH_MODE_NONE:
-        return ResolvedMCPConnection(
+        connection = ResolvedMCPConnection(
             endpoint_url=_resolve_mcp_endpoint(
                 hostname=hostname,
                 environment=environment,
@@ -212,9 +223,11 @@ def _resolve_connection(
             discovery_url=resolved_discovery_url,
             auth_required=False,
         )
+        _enforce_secure_endpoint(connection.endpoint_url, connection.auth_required)
+        return connection
 
     if auth_mode == AUTH_MODE_SSO:
-        return ResolvedMCPConnection(
+        connection = ResolvedMCPConnection(
             endpoint_url=_resolve_mcp_endpoint(
                 hostname=hostname,
                 environment=environment,
@@ -225,6 +238,8 @@ def _resolve_connection(
             discovery_url=resolved_discovery_url,
             auth_required=True,
         )
+        _enforce_secure_endpoint(connection.endpoint_url, connection.auth_required)
+        return connection
 
     redirect_discovery_url = _resolve_redirect_discovery_endpoint(
         hostname=hostname,
@@ -241,7 +256,7 @@ def _resolve_connection(
         auth_required = auth_discovery.auth_required
         service_endpoint = auth_discovery.services.get("mcp")
         resolved_auth_mode = AUTH_MODE_SSO if auth_required else AUTH_MODE_NONE
-        return ResolvedMCPConnection(
+        connection = ResolvedMCPConnection(
             endpoint_url=(_normalize_url(service_endpoint) if service_endpoint else None)
             or _resolve_mcp_endpoint(
                 hostname=hostname,
@@ -255,9 +270,11 @@ def _resolve_connection(
             discovered_oidc=discovered,
             discovered_scopes=auth_discovery.scopes,
         )
+        _enforce_secure_endpoint(connection.endpoint_url, connection.auth_required)
+        return connection
 
     resolved_auth_mode = AUTH_MODE_SSO if discovered else AUTH_MODE_NONE
-    return ResolvedMCPConnection(
+    connection = ResolvedMCPConnection(
         endpoint_url=_resolve_mcp_endpoint(
             hostname=hostname,
             environment=environment,
@@ -269,6 +286,8 @@ def _resolve_connection(
         auth_required=discovered is not None,
         discovered_oidc=discovered,
     )
+    _enforce_secure_endpoint(connection.endpoint_url, connection.auth_required)
+    return connection
 
 
 def _resolve_healthcheck_url(mcp_endpoint: str) -> str:
@@ -603,6 +622,8 @@ def config_command(
         "--mcp-url",
         connection.endpoint_url,
     ]
+    if insecure:
+        token_command.append("--insecure")
     if issuer:
         token_command.extend(["--issuer", issuer])
     if client_id:

--- a/src/nv_config_manager/mcp/cli.py
+++ b/src/nv_config_manager/mcp/cli.py
@@ -51,6 +51,17 @@ def _normalize_url(url: str) -> str:
     return url.rstrip("/")
 
 
+def _normalize_auth_discovery_url(url: str) -> str:
+    """Return an HTTPS auth discovery URL without a trailing slash."""
+    normalized_url = _normalize_url(url)
+    parsed = urlparse(normalized_url)
+    if parsed.scheme.lower() != "https":
+        raise click.ClickException(f"Refusing non-HTTPS auth discovery URL: {normalized_url}")
+    if not parsed.netloc:
+        raise click.ClickException(f"Invalid auth discovery URL: {normalized_url}")
+    return normalized_url
+
+
 def _resolve_base_hostname(
     hostname: str | None,
     environment: str | None,
@@ -103,11 +114,11 @@ def _resolve_auth_discovery_endpoint(
 ) -> str:
     """Resolve the URL used to discover public auth settings."""
     if discovery_url:
-        return _normalize_url(discovery_url)
+        return _normalize_auth_discovery_url(discovery_url)
 
     if hostname or environment:
         base_hostname = _resolve_base_hostname(hostname, environment, domain)
-        return f"https://{base_hostname}/auth/discovery"
+        return _normalize_auth_discovery_url(f"https://{base_hostname}/auth/discovery")
 
     if mcp_url:
         return _auth_discovery_url_from_mcp_url(mcp_url)
@@ -119,7 +130,7 @@ def _auth_discovery_url_from_mcp_url(mcp_url: str) -> str:
     """Derive the base-host /auth/discovery URL from an MCP endpoint URL."""
     parsed = urlparse(mcp_url)
     if not parsed.scheme or not parsed.netloc:
-        return _normalize_url(mcp_url)
+        return _normalize_auth_discovery_url(mcp_url)
 
     netloc = parsed.netloc
     for prefix in ("svc-mcp.", "mcp."):
@@ -127,13 +138,33 @@ def _auth_discovery_url_from_mcp_url(mcp_url: str) -> str:
             netloc = netloc.removeprefix(prefix)
             break
 
-    return parsed._replace(
+    discovery_url = parsed._replace(
         netloc=netloc,
         path="/auth/discovery",
         params="",
         query="",
         fragment="",
     ).geturl()
+    return _normalize_auth_discovery_url(discovery_url)
+
+
+def _resolve_configured_auth_discovery_endpoint(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    discovery_url: str | None,
+) -> str:
+    """Resolve an explicitly configured discovery URL without deriving it from MCP URLs."""
+    if discovery_url or hostname or environment:
+        return _resolve_auth_discovery_endpoint(
+            hostname=hostname,
+            environment=environment,
+            domain=domain,
+            mcp_url=mcp_url,
+            discovery_url=discovery_url,
+        )
+    return ""
 
 
 def _resolve_redirect_discovery_endpoint(
@@ -203,15 +234,14 @@ def _resolve_connection(
     insecure: bool,
 ) -> ResolvedMCPConnection:
     """Resolve endpoint and auth requirements for an MCP-capable client."""
-    resolved_discovery_url = _resolve_auth_discovery_endpoint(
-        hostname=hostname,
-        environment=environment,
-        domain=domain,
-        mcp_url=mcp_url,
-        discovery_url=discovery_url,
-    )
-
     if auth_mode == AUTH_MODE_NONE:
+        resolved_discovery_url = _resolve_configured_auth_discovery_endpoint(
+            hostname=hostname,
+            environment=environment,
+            domain=domain,
+            mcp_url=mcp_url,
+            discovery_url=discovery_url,
+        )
         connection = ResolvedMCPConnection(
             endpoint_url=_resolve_mcp_endpoint(
                 hostname=hostname,
@@ -227,6 +257,13 @@ def _resolve_connection(
         return connection
 
     if auth_mode == AUTH_MODE_SSO:
+        resolved_discovery_url = _resolve_configured_auth_discovery_endpoint(
+            hostname=hostname,
+            environment=environment,
+            domain=domain,
+            mcp_url=mcp_url,
+            discovery_url=discovery_url,
+        )
         connection = ResolvedMCPConnection(
             endpoint_url=_resolve_mcp_endpoint(
                 hostname=hostname,
@@ -241,6 +278,13 @@ def _resolve_connection(
         _enforce_secure_endpoint(connection.endpoint_url, connection.auth_required)
         return connection
 
+    resolved_discovery_url = _resolve_auth_discovery_endpoint(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+        discovery_url=discovery_url,
+    )
     redirect_discovery_url = _resolve_redirect_discovery_endpoint(
         hostname=hostname,
         environment=environment,
@@ -624,6 +668,8 @@ def config_command(
     ]
     if insecure:
         token_command.append("--insecure")
+    if discovery_url:
+        token_command.extend(["--discovery-url", connection.discovery_url])
     if issuer:
         token_command.extend(["--issuer", issuer])
     if client_id:

--- a/src/nv_config_manager/mcp/cli.py
+++ b/src/nv_config_manager/mcp/cli.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import shlex
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -24,7 +25,7 @@ import click
 import requests
 import urllib3
 
-from nv_config_manager.common.oidc import OIDCAuth
+from nv_config_manager.common.oidc import AuthDiscovery, OIDCAuth
 
 DEFAULT_DOMAIN = "config-manager.example.com"
 DEFAULT_TOKEN_ENV_VAR = "NVCM_MCP_BEARER_TOKEN"
@@ -42,6 +43,7 @@ class ResolvedMCPConnection:
     discovery_url: str
     auth_required: bool
     discovered_oidc: tuple[str, str] | None = None
+    discovered_scopes: tuple[str, ...] = ()
 
 
 def _normalize_url(url: str) -> str:
@@ -92,17 +94,55 @@ def _replace_svc_mcp_host(mcp_url: str) -> str:
     return _normalize_url(parsed._replace(netloc=netloc, query="", fragment="").geturl())
 
 
-def _resolve_discovery_endpoint(
+def _resolve_auth_discovery_endpoint(
     hostname: str | None,
     environment: str | None,
     domain: str,
     mcp_url: str | None,
     discovery_url: str | None,
 ) -> str:
-    """Resolve the URL used to discover OIDC settings."""
+    """Resolve the URL used to discover public auth settings."""
     if discovery_url:
         return _normalize_url(discovery_url)
 
+    if hostname or environment:
+        base_hostname = _resolve_base_hostname(hostname, environment, domain)
+        return f"https://{base_hostname}/auth/discovery"
+
+    if mcp_url:
+        return _auth_discovery_url_from_mcp_url(mcp_url)
+
+    raise click.ClickException("Either --hostname, --environment, or --mcp-url is required.")
+
+
+def _auth_discovery_url_from_mcp_url(mcp_url: str) -> str:
+    """Derive the base-host /auth/discovery URL from an MCP endpoint URL."""
+    parsed = urlparse(mcp_url)
+    if not parsed.scheme or not parsed.netloc:
+        return _normalize_url(mcp_url)
+
+    netloc = parsed.netloc
+    for prefix in ("svc-mcp.", "mcp."):
+        if netloc.startswith(prefix):
+            netloc = netloc.removeprefix(prefix)
+            break
+
+    return parsed._replace(
+        netloc=netloc,
+        path="/auth/discovery",
+        params="",
+        query="",
+        fragment="",
+    ).geturl()
+
+
+def _resolve_redirect_discovery_endpoint(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+) -> str:
+    """Resolve the legacy OIDC redirect discovery URL."""
     if hostname or environment:
         base_hostname = _resolve_base_hostname(hostname, environment, domain)
         return f"https://mcp.{base_hostname}/mcp"
@@ -113,10 +153,31 @@ def _resolve_discovery_endpoint(
     raise click.ClickException("Either --hostname, --environment, or --mcp-url is required.")
 
 
-def _discover_oidc_config(discovery_url: str, insecure: bool) -> tuple[str, str] | None:
-    """Discover OIDC settings from the MCP gateway."""
+def _discovered_oidc_tuple(discovery: AuthDiscovery) -> tuple[str, str] | None:
+    """Return issuer/client tuple when auth discovery includes OIDC settings."""
+    if not discovery.issuer_url or not discovery.client_id:
+        return None
+    return (discovery.issuer_url, discovery.client_id)
+
+
+def _discover_auth_config(
+    auth_discovery_url: str,
+    redirect_discovery_url: str,
+    insecure: bool,
+) -> tuple[AuthDiscovery | None, tuple[str, str] | None]:
+    """Discover auth settings, falling back to legacy OIDC redirect parsing."""
     try:
-        return OIDCAuth.discover_oidc_config(discovery_url, verify=not insecure)
+        discovery = OIDCAuth.discover_auth_config(auth_discovery_url, verify=not insecure)
+    except RuntimeError as e:
+        raise click.ClickException(f"OIDC auto-discovery failed: {e}") from e
+    if discovery is not None:
+        return discovery, _discovered_oidc_tuple(discovery)
+
+    try:
+        return None, OIDCAuth.discover_oidc_config(
+            redirect_discovery_url,
+            verify=not insecure,
+        )
     except RuntimeError as e:
         raise click.ClickException(f"OIDC auto-discovery failed: {e}") from e
 
@@ -131,7 +192,7 @@ def _resolve_connection(
     insecure: bool,
 ) -> ResolvedMCPConnection:
     """Resolve endpoint and auth requirements for an MCP-capable client."""
-    resolved_discovery_url = _resolve_discovery_endpoint(
+    resolved_discovery_url = _resolve_auth_discovery_endpoint(
         hostname=hostname,
         environment=environment,
         domain=domain,
@@ -165,7 +226,36 @@ def _resolve_connection(
             auth_required=True,
         )
 
-    discovered = _discover_oidc_config(resolved_discovery_url, insecure)
+    redirect_discovery_url = _resolve_redirect_discovery_endpoint(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+    )
+    auth_discovery, discovered = _discover_auth_config(
+        resolved_discovery_url,
+        redirect_discovery_url,
+        insecure,
+    )
+    if auth_discovery is not None:
+        auth_required = auth_discovery.auth_required
+        service_endpoint = auth_discovery.services.get("mcp")
+        resolved_auth_mode = AUTH_MODE_SSO if auth_required else AUTH_MODE_NONE
+        return ResolvedMCPConnection(
+            endpoint_url=(_normalize_url(service_endpoint) if service_endpoint else None)
+            or _resolve_mcp_endpoint(
+                hostname=hostname,
+                environment=environment,
+                domain=domain,
+                mcp_url=mcp_url,
+                auth_mode=resolved_auth_mode,
+            ),
+            discovery_url=resolved_discovery_url,
+            auth_required=auth_required,
+            discovered_oidc=discovered,
+            discovered_scopes=auth_discovery.scopes,
+        )
+
     resolved_auth_mode = AUTH_MODE_SSO if discovered else AUTH_MODE_NONE
     return ResolvedMCPConnection(
         endpoint_url=_resolve_mcp_endpoint(
@@ -193,22 +283,28 @@ def _build_auth(
     issuer: str | None,
     client_id: str | None,
     connection: ResolvedMCPConnection,
+    insecure: bool,
 ) -> OIDCAuth:
     """Build an OIDC auth helper from explicit settings or gateway discovery."""
-    if issuer and client_id:
-        return OIDCAuth(issuer_url=issuer, client_id=client_id)
+    discovered_issuer, discovered_client_id = (
+        connection.discovered_oidc if connection.discovered_oidc else (None, None)
+    )
+    resolved_issuer = issuer or discovered_issuer
+    resolved_client_id = client_id or discovered_client_id
 
-    if issuer or client_id:
-        raise click.ClickException("--issuer and --client-id must be provided together.")
-
-    if connection.discovered_oidc is None:
+    if not resolved_issuer or not resolved_client_id:
         raise click.ClickException(
             "OIDC configuration was not discovered from the MCP gateway. "
-            "Provide --issuer and --client-id explicitly."
+            "Provide --issuer and --client-id explicitly, or use a gateway that "
+            "supports auth discovery."
         )
 
-    discovered_issuer, discovered_client_id = connection.discovered_oidc
-    return OIDCAuth(issuer_url=discovered_issuer, client_id=discovered_client_id)
+    return OIDCAuth(
+        issuer_url=resolved_issuer,
+        client_id=resolved_client_id,
+        scopes=list(connection.discovered_scopes) or None,
+        verify=not insecure,
+    )
 
 
 def _target_options(function: Any) -> Any:
@@ -263,19 +359,19 @@ def _auth_options(function: Any) -> Any:
             "--discovery-url",
             default=None,
             envvar="NV_CONFIG_MANAGER_MCP_DISCOVERY_URL",
-            help="Explicit URL used for OIDC discovery. Defaults to the mcp.<base> endpoint.",
+            help="Explicit URL used for auth discovery. Defaults to https://<base>/auth/discovery.",
         ),
         click.option(
             "--issuer",
             default=None,
             envvar="NV_CONFIG_MANAGER_OIDC_ISSUER",
-            help="OIDC issuer URL. Must be provided with --client-id.",
+            help="OIDC issuer URL. Auto-discovered from the gateway when omitted.",
         ),
         click.option(
             "--client-id",
             default=None,
             envvar="NV_CONFIG_MANAGER_OIDC_CLIENT_ID",
-            help="OIDC client ID. Must be provided with --issuer.",
+            help="OIDC client ID. Overrides the gateway-discovered client ID when provided.",
         ),
         click.option(
             "--insecure",
@@ -301,8 +397,11 @@ def _resolve_auth(
     insecure: bool,
 ) -> tuple[ResolvedMCPConnection, OIDCAuth | None]:
     """Resolve an auth helper for the selected MCP endpoint."""
-    if issuer or client_id:
+    requested_auth_mode = auth_mode
+    if issuer and client_id:
         auth_mode = AUTH_MODE_SSO
+    elif issuer or client_id or auth_mode == AUTH_MODE_SSO:
+        auth_mode = AUTH_MODE_AUTO
 
     connection = _resolve_connection(
         hostname=hostname,
@@ -314,11 +413,19 @@ def _resolve_auth(
         insecure=insecure,
     )
     if not connection.auth_required:
-        if issuer or client_id:
-            raise click.ClickException("--issuer and --client-id require --auth-mode sso.")
+        if issuer or client_id or requested_auth_mode == AUTH_MODE_SSO:
+            raise click.ClickException(
+                "OIDC configuration was not discovered from the MCP gateway. "
+                "Provide --issuer and --client-id explicitly."
+            )
         return connection, None
 
-    return connection, _build_auth(issuer=issuer, client_id=client_id, connection=connection)
+    return connection, _build_auth(
+        issuer=issuer,
+        client_id=client_id,
+        connection=connection,
+        insecure=insecure,
+    )
 
 
 @click.group()
@@ -488,11 +595,20 @@ def config_command(
     click.echo("Required HTTP header:")
     click.echo(f"  Authorization: Bearer ${{{token_env_var}}}")
     click.echo("Token command:")
-    click.echo(
-        "  "
-        f'export {token_env_var}="$(nvcm-mcp-cli token '
-        f'--auth-mode sso --mcp-url {connection.endpoint_url})"'
-    )
+    token_command = [
+        "nvcm-mcp-cli",
+        "token",
+        "--auth-mode",
+        "sso",
+        "--mcp-url",
+        connection.endpoint_url,
+    ]
+    if issuer:
+        token_command.extend(["--issuer", issuer])
+    if client_id:
+        token_command.extend(["--client-id", client_id])
+    token_command_text = " ".join(shlex.quote(part) for part in token_command)
+    click.echo(f'  export {token_env_var}="$({token_command_text})"')
 
 
 @main.command()

--- a/src/nv_config_manager/mcp/cli.py
+++ b/src/nv_config_manager/mcp/cli.py
@@ -1,0 +1,561 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLI helpers for remote NVIDIA Config Manager MCP endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+import click
+import requests
+import urllib3
+
+from nv_config_manager.common.oidc import OIDCAuth
+
+DEFAULT_DOMAIN = "config-manager.example.com"
+DEFAULT_TOKEN_ENV_VAR = "NVCM_MCP_BEARER_TOKEN"
+DEFAULT_TIMEOUT_SECONDS = 10
+AUTH_MODE_AUTO = "auto"
+AUTH_MODE_SSO = "sso"
+AUTH_MODE_NONE = "none"
+
+
+@dataclass(frozen=True)
+class ResolvedMCPConnection:
+    """Resolved MCP endpoint and authentication requirements."""
+
+    endpoint_url: str
+    discovery_url: str
+    auth_required: bool
+    discovered_oidc: tuple[str, str] | None = None
+
+
+def _normalize_url(url: str) -> str:
+    """Return a URL without a trailing slash."""
+    return url.rstrip("/")
+
+
+def _resolve_base_hostname(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+) -> str:
+    """Resolve a deployment base hostname from explicit or environment-based input."""
+    if hostname:
+        return hostname.removeprefix("https://").removeprefix("http://").strip("/")
+    if environment:
+        return f"{environment}.{domain}"
+    raise click.ClickException("Either --hostname, --environment, or --mcp-url is required.")
+
+
+def _resolve_mcp_endpoint(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    auth_mode: str = AUTH_MODE_SSO,
+) -> str:
+    """Resolve the remote Streamable HTTP MCP endpoint."""
+    if mcp_url:
+        return _normalize_url(mcp_url)
+
+    base_hostname = _resolve_base_hostname(hostname, environment, domain)
+    if auth_mode == AUTH_MODE_NONE:
+        return f"https://mcp.{base_hostname}/mcp"
+    return f"https://svc-mcp.{base_hostname}/mcp"
+
+
+def _replace_svc_mcp_host(mcp_url: str) -> str:
+    """Convert a svc-mcp endpoint URL into its OIDC-enabled mcp hostname."""
+    parsed = urlparse(mcp_url)
+    if not parsed.scheme or not parsed.netloc:
+        return _normalize_url(mcp_url)
+
+    netloc = parsed.netloc
+    if netloc.startswith("svc-mcp."):
+        netloc = netloc.removeprefix("svc-")
+
+    return _normalize_url(parsed._replace(netloc=netloc, query="", fragment="").geturl())
+
+
+def _resolve_discovery_endpoint(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    discovery_url: str | None,
+) -> str:
+    """Resolve the URL used to discover OIDC settings."""
+    if discovery_url:
+        return _normalize_url(discovery_url)
+
+    if hostname or environment:
+        base_hostname = _resolve_base_hostname(hostname, environment, domain)
+        return f"https://mcp.{base_hostname}/mcp"
+
+    if mcp_url:
+        return _replace_svc_mcp_host(mcp_url)
+
+    raise click.ClickException("Either --hostname, --environment, or --mcp-url is required.")
+
+
+def _discover_oidc_config(discovery_url: str, insecure: bool) -> tuple[str, str] | None:
+    """Discover OIDC settings from the MCP gateway."""
+    try:
+        return OIDCAuth.discover_oidc_config(discovery_url, verify=not insecure)
+    except RuntimeError as e:
+        raise click.ClickException(f"OIDC auto-discovery failed: {e}") from e
+
+
+def _resolve_connection(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    discovery_url: str | None,
+    auth_mode: str,
+    insecure: bool,
+) -> ResolvedMCPConnection:
+    """Resolve endpoint and auth requirements for an MCP-capable client."""
+    resolved_discovery_url = _resolve_discovery_endpoint(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+        discovery_url=discovery_url,
+    )
+
+    if auth_mode == AUTH_MODE_NONE:
+        return ResolvedMCPConnection(
+            endpoint_url=_resolve_mcp_endpoint(
+                hostname=hostname,
+                environment=environment,
+                domain=domain,
+                mcp_url=mcp_url,
+                auth_mode=AUTH_MODE_NONE,
+            ),
+            discovery_url=resolved_discovery_url,
+            auth_required=False,
+        )
+
+    if auth_mode == AUTH_MODE_SSO:
+        return ResolvedMCPConnection(
+            endpoint_url=_resolve_mcp_endpoint(
+                hostname=hostname,
+                environment=environment,
+                domain=domain,
+                mcp_url=mcp_url,
+                auth_mode=AUTH_MODE_SSO,
+            ),
+            discovery_url=resolved_discovery_url,
+            auth_required=True,
+        )
+
+    discovered = _discover_oidc_config(resolved_discovery_url, insecure)
+    resolved_auth_mode = AUTH_MODE_SSO if discovered else AUTH_MODE_NONE
+    return ResolvedMCPConnection(
+        endpoint_url=_resolve_mcp_endpoint(
+            hostname=hostname,
+            environment=environment,
+            domain=domain,
+            mcp_url=mcp_url,
+            auth_mode=resolved_auth_mode,
+        ),
+        discovery_url=resolved_discovery_url,
+        auth_required=discovered is not None,
+        discovered_oidc=discovered,
+    )
+
+
+def _resolve_healthcheck_url(mcp_endpoint: str) -> str:
+    """Resolve the healthcheck URL for a remote MCP endpoint."""
+    parsed = urlparse(mcp_endpoint)
+    if not parsed.scheme or not parsed.netloc:
+        raise click.ClickException(f"Invalid MCP endpoint URL: {mcp_endpoint}")
+    return parsed._replace(path="/healthcheck", params="", query="", fragment="").geturl()
+
+
+def _build_auth(
+    issuer: str | None,
+    client_id: str | None,
+    connection: ResolvedMCPConnection,
+) -> OIDCAuth:
+    """Build an OIDC auth helper from explicit settings or gateway discovery."""
+    if issuer and client_id:
+        return OIDCAuth(issuer_url=issuer, client_id=client_id)
+
+    if issuer or client_id:
+        raise click.ClickException("--issuer and --client-id must be provided together.")
+
+    if connection.discovered_oidc is None:
+        raise click.ClickException(
+            "OIDC configuration was not discovered from the MCP gateway. "
+            "Provide --issuer and --client-id explicitly."
+        )
+
+    discovered_issuer, discovered_client_id = connection.discovered_oidc
+    return OIDCAuth(issuer_url=discovered_issuer, client_id=discovered_client_id)
+
+
+def _target_options(function: Any) -> Any:
+    """Apply common target resolution options."""
+    options = [
+        click.option(
+            "--hostname",
+            "-H",
+            default=None,
+            envvar="NV_CONFIG_MANAGER_HOSTNAME",
+            help="Deployment base hostname, for example config-manager.example.com.",
+        ),
+        click.option(
+            "--environment",
+            "-e",
+            default=None,
+            help="Environment name. Combined with --domain to form <environment>.<domain>.",
+        ),
+        click.option(
+            "--domain",
+            "-d",
+            default=DEFAULT_DOMAIN,
+            show_default=True,
+            help="Base domain used with --environment.",
+        ),
+        click.option(
+            "--mcp-url",
+            default=None,
+            envvar="NV_CONFIG_MANAGER_MCP_URL",
+            help="Explicit remote MCP endpoint URL. Overrides hostname resolution.",
+        ),
+    ]
+    for option in reversed(options):
+        function = option(function)
+    return function
+
+
+def _auth_options(function: Any) -> Any:
+    """Apply common authentication options."""
+    options = [
+        click.option(
+            "--auth-mode",
+            type=click.Choice([AUTH_MODE_AUTO, AUTH_MODE_SSO, AUTH_MODE_NONE]),
+            default=AUTH_MODE_AUTO,
+            show_default=True,
+            help=(
+                "Authentication mode. auto discovers SSO from the MCP gateway; "
+                "sso uses svc-mcp with a bearer token; none uses mcp without auth."
+            ),
+        ),
+        click.option(
+            "--discovery-url",
+            default=None,
+            envvar="NV_CONFIG_MANAGER_MCP_DISCOVERY_URL",
+            help="Explicit URL used for OIDC discovery. Defaults to the mcp.<base> endpoint.",
+        ),
+        click.option(
+            "--issuer",
+            default=None,
+            envvar="NV_CONFIG_MANAGER_OIDC_ISSUER",
+            help="OIDC issuer URL. Must be provided with --client-id.",
+        ),
+        click.option(
+            "--client-id",
+            default=None,
+            envvar="NV_CONFIG_MANAGER_OIDC_CLIENT_ID",
+            help="OIDC client ID. Must be provided with --issuer.",
+        ),
+        click.option(
+            "--insecure",
+            "-k",
+            is_flag=True,
+            help="Disable TLS certificate verification for discovery and checks.",
+        ),
+    ]
+    for option in reversed(options):
+        function = option(function)
+    return function
+
+
+def _resolve_auth(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    discovery_url: str | None,
+    auth_mode: str,
+    issuer: str | None,
+    client_id: str | None,
+    insecure: bool,
+) -> tuple[ResolvedMCPConnection, OIDCAuth | None]:
+    """Resolve an auth helper for the selected MCP endpoint."""
+    if issuer or client_id:
+        auth_mode = AUTH_MODE_SSO
+
+    connection = _resolve_connection(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+        discovery_url=discovery_url,
+        auth_mode=auth_mode,
+        insecure=insecure,
+    )
+    if not connection.auth_required:
+        if issuer or client_id:
+            raise click.ClickException("--issuer and --client-id require --auth-mode sso.")
+        return connection, None
+
+    return connection, _build_auth(issuer=issuer, client_id=client_id, connection=connection)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def main() -> None:
+    """Authenticate and configure clients for remote NVIDIA Config Manager MCP."""
+
+
+@main.command()
+@_target_options
+@_auth_options
+@click.option("--force", is_flag=True, help="Force a new login even if a token is cached.")
+def login(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    auth_mode: str,
+    discovery_url: str | None,
+    issuer: str | None,
+    client_id: str | None,
+    insecure: bool,
+    force: bool,
+) -> None:
+    """Authenticate with OIDC and cache a user bearer token."""
+    if insecure:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    _connection, auth = _resolve_auth(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+        discovery_url=discovery_url,
+        auth_mode=auth_mode,
+        issuer=issuer,
+        client_id=client_id,
+        insecure=insecure,
+    )
+    if auth is None:
+        click.echo("SSO is not enabled for this MCP endpoint; no login is required.")
+        return
+
+    auth.get_access_token(force_refresh=force)
+    click.echo("Authentication successful.")
+
+
+@main.command()
+@_target_options
+@_auth_options
+@click.option(
+    "--force-auth-refresh",
+    is_flag=True,
+    help="Force a new login before printing the token.",
+)
+def token(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    auth_mode: str,
+    discovery_url: str | None,
+    issuer: str | None,
+    client_id: str | None,
+    insecure: bool,
+    force_auth_refresh: bool,
+) -> None:
+    """Print a valid user bearer token."""
+    if insecure:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    _connection, auth = _resolve_auth(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+        discovery_url=discovery_url,
+        auth_mode=auth_mode,
+        issuer=issuer,
+        client_id=client_id,
+        insecure=insecure,
+    )
+    if auth is None:
+        click.echo(
+            "SSO is not enabled for this MCP endpoint; no bearer token is required.", err=True
+        )
+        return
+
+    click.echo(auth.get_access_token(force_refresh=force_auth_refresh))
+
+
+@main.command()
+@_target_options
+@_auth_options
+def endpoint(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    auth_mode: str,
+    discovery_url: str | None,
+    issuer: str | None,
+    client_id: str | None,
+    insecure: bool,
+) -> None:
+    """Print the remote MCP endpoint URL."""
+    if insecure:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    if issuer or client_id:
+        auth_mode = AUTH_MODE_SSO
+    connection = _resolve_connection(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+        discovery_url=discovery_url,
+        auth_mode=auth_mode,
+        insecure=insecure,
+    )
+    click.echo(connection.endpoint_url)
+
+
+@main.command(name="config")
+@_target_options
+@_auth_options
+@click.option(
+    "--token-env-var",
+    default=DEFAULT_TOKEN_ENV_VAR,
+    show_default=True,
+    help="Environment variable name that will hold the bearer token.",
+)
+def config_command(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    auth_mode: str,
+    discovery_url: str | None,
+    issuer: str | None,
+    client_id: str | None,
+    insecure: bool,
+    token_env_var: str,
+) -> None:
+    """Print generic Streamable HTTP MCP connection details."""
+    if insecure:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    if issuer or client_id:
+        auth_mode = AUTH_MODE_SSO
+    connection = _resolve_connection(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+        discovery_url=discovery_url,
+        auth_mode=auth_mode,
+        insecure=insecure,
+    )
+    click.echo("MCP transport: Streamable HTTP")
+    click.echo(f"MCP endpoint: {connection.endpoint_url}")
+    if not connection.auth_required:
+        click.echo("Authentication: none")
+        click.echo("No Authorization header is required.")
+        return
+
+    click.echo("Authentication: bearer token")
+    click.echo(f"Bearer token environment variable: {token_env_var}")
+    click.echo("Required HTTP header:")
+    click.echo(f"  Authorization: Bearer ${{{token_env_var}}}")
+    click.echo("Token command:")
+    click.echo(
+        "  "
+        f'export {token_env_var}="$(nvcm-mcp-cli token '
+        f'--auth-mode sso --mcp-url {connection.endpoint_url})"'
+    )
+
+
+@main.command()
+@_target_options
+@_auth_options
+@click.option(
+    "--force-auth-refresh",
+    is_flag=True,
+    help="Force a new login before checking the endpoint.",
+)
+def check(
+    hostname: str | None,
+    environment: str | None,
+    domain: str,
+    mcp_url: str | None,
+    auth_mode: str,
+    discovery_url: str | None,
+    issuer: str | None,
+    client_id: str | None,
+    insecure: bool,
+    force_auth_refresh: bool,
+) -> None:
+    """Validate token availability and remote MCP service health."""
+    if insecure:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    connection, auth = _resolve_auth(
+        hostname=hostname,
+        environment=environment,
+        domain=domain,
+        mcp_url=mcp_url,
+        discovery_url=discovery_url,
+        auth_mode=auth_mode,
+        issuer=issuer,
+        client_id=client_id,
+        insecure=insecure,
+    )
+    headers: dict[str, str] = {}
+    if auth is not None:
+        access_token = auth.get_access_token(force_refresh=force_auth_refresh)
+        headers["Authorization"] = f"Bearer {access_token}"
+
+    healthcheck_url = _resolve_healthcheck_url(connection.endpoint_url)
+
+    try:
+        response = requests.get(
+            healthcheck_url,
+            headers=headers,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            allow_redirects=False,
+            verify=not insecure,
+        )
+        if response.status_code in (301, 302, 303, 307, 308):
+            raise click.ClickException(
+                "The MCP healthcheck redirected instead of accepting the request. "
+                "Verify the MCP endpoint and authentication mode."
+            )
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(f"Remote MCP healthcheck failed: {e}") from e
+
+    if connection.auth_required:
+        click.echo(f"Token available for endpoint: {connection.endpoint_url}")
+    else:
+        click.echo(f"No bearer token required for endpoint: {connection.endpoint_url}")
+    click.echo(f"Healthcheck passed: {healthcheck_url}")

--- a/src/nv_config_manager/mcp/clients.py
+++ b/src/nv_config_manager/mcp/clients.py
@@ -85,12 +85,13 @@ def bounded_response(value: Any, max_response_bytes: int) -> dict[str, Any]:
     """Return redacted data with a byte-size boundary indicator."""
     redacted = redact_data(value)
     encoded = json.dumps(redacted, default=str, sort_keys=True)
-    if len(encoded.encode("utf-8")) <= max_response_bytes:
+    encoded_bytes = encoded.encode("utf-8")
+    if len(encoded_bytes) <= max_response_bytes:
         return {"truncated": False, "data": redacted}
     return {
         "truncated": True,
         "max_response_bytes": max_response_bytes,
-        "preview": encoded[:max_response_bytes],
+        "preview": encoded_bytes[:max_response_bytes].decode("utf-8", errors="ignore"),
     }
 
 
@@ -229,7 +230,7 @@ async def fetch_workflows(
 
     async def call() -> Any:
         async with workflow_client(settings) as client:
-            return await client.list_workflows(params=params)
+            return _add_workflow_ui_links(settings, await client.list_workflows(params=params))
 
     return await _bounded_client_call(call, settings.max_response_bytes)
 
@@ -239,7 +240,7 @@ async def fetch_workflow_detail(settings: MCPSettings, workflow_id: str) -> dict
 
     async def call() -> Any:
         async with workflow_client(settings) as client:
-            return await client.get_workflow(workflow_id)
+            return _add_workflow_ui_links(settings, await client.get_workflow(workflow_id))
 
     return await _bounded_client_call(call, settings.max_response_bytes)
 
@@ -253,7 +254,7 @@ async def start_workflow(
 
     async def call() -> Any:
         async with workflow_client(settings) as client:
-            return await client.start_workflow(endpoint, payload)
+            return _add_workflow_ui_links(settings, await client.start_workflow(endpoint, payload))
 
     return await _bounded_client_call(call, settings.max_response_bytes)
 
@@ -321,22 +322,56 @@ def mcp_downstream_auth_headers() -> dict[str, str]:
 
 def _nautobot_auth_headers(settings: MCPSettings) -> dict[str, str]:
     if settings.nautobot_auth_mode == "token":
-        if not settings.nautobot_token:
-            raise MCPAuthError("Nautobot token auth is configured but no token is available.")
-        return {"Authorization": f"Token {settings.nautobot_token}"}
+        if not settings.nautobot_read_only_token:
+            raise MCPAuthError(
+                "Nautobot token auth is configured but [mcp] "
+                "nautobot_read_only_token is not configured."
+            )
+        return {"Authorization": f"Token {settings.nautobot_read_only_token}"}
 
     bearer = user_bearer_authorization()
     if bearer:
         return {"Authorization": bearer}
 
     if not config_auth_required():
-        if settings.nautobot_token:
-            return {"Authorization": f"Token {settings.nautobot_token}"}
+        if settings.nautobot_read_only_token:
+            return {"Authorization": f"Token {settings.nautobot_read_only_token}"}
         return {}
 
-    if settings.nautobot_token_fallback_enabled and settings.nautobot_token:
-        return {"Authorization": f"Token {settings.nautobot_token}"}
+    if settings.nautobot_token_fallback_enabled and settings.nautobot_read_only_token:
+        return {"Authorization": f"Token {settings.nautobot_read_only_token}"}
 
     raise MCPAuthError(
         "Nautobot JWT auth is configured, but the MCP request did not include a Bearer token."
     )
+
+
+def _add_workflow_ui_links(settings: MCPSettings, value: Any) -> Any:
+    """Add Config Manager UI links to Workflow API payloads without changing href."""
+    if isinstance(value, list):
+        return [_add_workflow_ui_links(settings, item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    result = dict(value)
+    workflows = result.get("workflows")
+    if isinstance(workflows, list):
+        result["workflows"] = [_add_workflow_ui_links(settings, item) for item in workflows]
+
+    workflow_id = result.get("id")
+    if isinstance(workflow_id, str) and workflow_id:
+        ui_href = build_workflow_ui_href(settings, workflow_id)
+        if ui_href:
+            result.setdefault("ui_href", ui_href)
+        href = result.get("href")
+        if isinstance(href, str) and href and href != ui_href:
+            result.setdefault("temporal_href", href)
+
+    return result
+
+
+def build_workflow_ui_href(settings: MCPSettings, workflow_id: str) -> str:
+    """Build the end-user Config Manager UI URL for a workflow execution."""
+    if not settings.workflow_ui_url:
+        return ""
+    return f"{settings.workflow_ui_url.rstrip('/')}/workflows/{workflow_id}"

--- a/src/nv_config_manager/mcp/clients.py
+++ b/src/nv_config_manager/mcp/clients.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""HTTP clients used by the MCP tool layer."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from nv_config_manager.common.auth import auth_required as config_auth_required
+from nv_config_manager.common.client import (
+    ConfigStoreClient,
+    ConfigStoreException,
+    DHCPClient,
+    DHCPClientException,
+    NautobotClient,
+    NautobotException,
+    TemporalClient,
+    TemporalClientException,
+)
+from nv_config_manager.mcp.auth import (
+    MissingBearerTokenError,
+    downstream_auth_headers,
+    user_bearer_authorization,
+)
+from nv_config_manager.mcp.settings import MCPSettings
+
+SECRET_KEY_RE = re.compile(r"(password|passwd|secret|token|api[_-]?key|private[_-]?key)", re.I)
+SECRET_LINE_RE = re.compile(
+    r"(?i)^(\s*[^#\n]*(password|secret|token|api[_-]?key)[^:=\n]*\s*[:=]\s*).*$"
+)
+MAX_LIMIT = 100
+
+
+class MCPClientError(Exception):
+    """Raised when an MCP backing service call fails."""
+
+
+class MCPAuthError(MCPClientError):
+    """Raised when a tool needs user auth material that is not available."""
+
+
+def clamp_limit(limit: int, maximum: int = MAX_LIMIT) -> int:
+    """Clamp user-supplied limits to a bounded range."""
+    return max(1, min(limit, maximum))
+
+
+def redact_data(value: Any) -> Any:
+    """Recursively redact likely secret values."""
+    if isinstance(value, dict):
+        return {
+            key: "<redacted>" if SECRET_KEY_RE.search(str(key)) else redact_data(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_data(item) for item in value]
+    if isinstance(value, str):
+        return redact_text(value)
+    return value
+
+
+def redact_text(value: str) -> str:
+    """Redact likely secret assignments from text blobs."""
+    lines = value.splitlines()
+    if len(lines) <= 1:
+        return value
+    return "\n".join(SECRET_LINE_RE.sub(r"\1<redacted>", line) for line in lines)
+
+
+def bounded_response(value: Any, max_response_bytes: int) -> dict[str, Any]:
+    """Return redacted data with a byte-size boundary indicator."""
+    redacted = redact_data(value)
+    encoded = json.dumps(redacted, default=str, sort_keys=True)
+    if len(encoded.encode("utf-8")) <= max_response_bytes:
+        return {"truncated": False, "data": redacted}
+    return {
+        "truncated": True,
+        "max_response_bytes": max_response_bytes,
+        "preview": encoded[:max_response_bytes],
+    }
+
+
+def reject_non_readonly_graphql(query: str) -> None:
+    """Reject GraphQL operations that are not read-only queries."""
+    normalized = re.sub(r"\s+", " ", query).strip().lower()
+    if re.search(r"\b(mutation|subscription)\b", normalized):
+        raise MCPClientError("Only read-only GraphQL query operations are allowed.")
+    if not (normalized.startswith("query") or normalized.startswith("{")):
+        raise MCPClientError("GraphQL operation must be a query.")
+
+
+async def nautobot_graphql_query(
+    settings: MCPSettings,
+    query: str,
+    variables: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute a bounded, read-only Nautobot GraphQL query for MCP."""
+    reject_non_readonly_graphql(query)
+
+    async def call() -> Any:
+        async with nautobot_client(settings) as client:
+            return await client.graphql_query(query, variables)
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def nautobot_rest_get(
+    settings: MCPSettings,
+    path: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute a bounded Nautobot REST GET for MCP."""
+
+    async def call() -> Any:
+        async with nautobot_client(settings) as client:
+            return await client.get(path.lstrip("/"), params=params)
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def fetch_dhcp_config(settings: MCPSettings, ip_version: int) -> dict[str, Any]:
+    """Get a bounded sanitized DHCP configuration."""
+
+    async def call() -> Any:
+        async with dhcp_client(settings) as client:
+            return await client.get_config(ip_version)
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def fetch_device_configs(
+    settings: MCPSettings,
+    device_id: str,
+    file_type: str | None = "intended",
+) -> dict[str, Any]:
+    """List bounded Config Store files for a device."""
+
+    async def call() -> Any:
+        async with config_store_client(settings, file_type or "intended") as client:
+            return await client.list_device_configs(device_id, file_type=file_type)
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def fetch_device_config(
+    settings: MCPSettings,
+    device_id: str,
+    filename: str,
+    file_type: str = "intended",
+    version: int | None = None,
+) -> dict[str, Any]:
+    """Get a bounded Config Store file."""
+
+    async def call() -> Any:
+        async with config_store_client(settings, file_type) as client:
+            return await client.get_config_file(
+                device_id,
+                filename,
+                file_type=file_type,
+                version=version,
+            )
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def fetch_config_versions(
+    settings: MCPSettings,
+    device_id: str,
+    filename: str,
+    file_type: str = "intended",
+    limit: int = 100,
+) -> dict[str, Any]:
+    """List bounded Config Store versions."""
+
+    async def call() -> Any:
+        async with config_store_client(settings, file_type) as client:
+            return await client.get_config_versions(
+                device_id,
+                filename,
+                file_type=file_type,
+                limit=limit,
+            )
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def fetch_config_diff(
+    settings: MCPSettings,
+    device_id: str,
+    filename: str,
+    from_version: int,
+    to_version: int,
+    file_type: str = "intended",
+) -> dict[str, Any]:
+    """Get a bounded Config Store diff."""
+
+    async def call() -> Any:
+        async with config_store_client(settings, file_type) as client:
+            return await client.get_config_diff(
+                device_id,
+                filename,
+                from_version,
+                to_version,
+                file_type=file_type,
+            )
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def fetch_workflows(
+    settings: MCPSettings,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """List bounded Workflow API executions."""
+
+    async def call() -> Any:
+        async with workflow_client(settings) as client:
+            return await client.list_workflows(params=params)
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def fetch_workflow_detail(settings: MCPSettings, workflow_id: str) -> dict[str, Any]:
+    """Get bounded Workflow API execution details."""
+
+    async def call() -> Any:
+        async with workflow_client(settings) as client:
+            return await client.get_workflow(workflow_id)
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+async def start_workflow(
+    settings: MCPSettings,
+    endpoint: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Start a workflow through the Workflow API and return a bounded result."""
+
+    async def call() -> Any:
+        async with workflow_client(settings) as client:
+            return await client.start_workflow(endpoint, payload)
+
+    return await _bounded_client_call(call, settings.max_response_bytes)
+
+
+def nautobot_client(settings: MCPSettings) -> NautobotClient:
+    """Create a common Nautobot client for MCP."""
+    return NautobotClient.for_mcp(
+        nautobot_url=settings.nautobot_url,
+        verify=settings.nautobot_verify,
+        headers=lambda: _nautobot_auth_headers(settings),
+    )
+
+
+def workflow_client(settings: MCPSettings) -> TemporalClient:
+    """Create a common Workflow API client for MCP."""
+    return TemporalClient.for_mcp(
+        base_url=settings.workflow_api_url,
+        headers=mcp_downstream_auth_headers,
+    )
+
+
+def config_store_client(settings: MCPSettings, file_type: str = "intended") -> ConfigStoreClient:
+    """Create a Config Store API client."""
+    return ConfigStoreClient.for_mcp(
+        target=settings.config_store_api_url,
+        file_type=file_type,
+        headers=mcp_downstream_auth_headers,
+    )
+
+
+def dhcp_client(settings: MCPSettings) -> DHCPClient:
+    """Create a DHCP API client."""
+    return DHCPClient.for_mcp(
+        base_url=settings.dhcp_api_url,
+        headers=mcp_downstream_auth_headers,
+    )
+
+
+async def _bounded_client_call(
+    call: Callable[[], Awaitable[Any]],
+    max_response_bytes: int,
+) -> dict[str, Any]:
+    try:
+        return bounded_response(await call(), max_response_bytes)
+    except MissingBearerTokenError as exc:
+        raise MCPAuthError(str(exc)) from exc
+    except (
+        ConfigStoreException,
+        DHCPClientException,
+        NautobotException,
+        TemporalClientException,
+    ) as exc:
+        raise MCPClientError(str(exc)) from exc
+
+
+def mcp_downstream_auth_headers() -> dict[str, str]:
+    """Return caller-scoped headers, or no headers when service auth is disabled."""
+    try:
+        return downstream_auth_headers()
+    except MissingBearerTokenError:
+        if not config_auth_required():
+            return {}
+        raise
+
+
+def _nautobot_auth_headers(settings: MCPSettings) -> dict[str, str]:
+    if settings.nautobot_auth_mode == "token":
+        if not settings.nautobot_token:
+            raise MCPAuthError("Nautobot token auth is configured but no token is available.")
+        return {"Authorization": f"Token {settings.nautobot_token}"}
+
+    bearer = user_bearer_authorization()
+    if bearer:
+        return {"Authorization": bearer}
+
+    if not config_auth_required():
+        if settings.nautobot_token:
+            return {"Authorization": f"Token {settings.nautobot_token}"}
+        return {}
+
+    if settings.nautobot_token_fallback_enabled and settings.nautobot_token:
+        return {"Authorization": f"Token {settings.nautobot_token}"}
+
+    raise MCPAuthError(
+        "Nautobot JWT auth is configured, but the MCP request did not include a Bearer token."
+    )

--- a/src/nv_config_manager/mcp/clients.py
+++ b/src/nv_config_manager/mcp/clients.py
@@ -75,10 +75,7 @@ def redact_data(value: Any) -> Any:
 
 def redact_text(value: str) -> str:
     """Redact likely secret assignments from text blobs."""
-    lines = value.splitlines()
-    if len(lines) <= 1:
-        return value
-    return "\n".join(SECRET_LINE_RE.sub(r"\1<redacted>", line) for line in lines)
+    return "\n".join(SECRET_LINE_RE.sub(r"\1<redacted>", line) for line in value.splitlines())
 
 
 def bounded_response(value: Any, max_response_bytes: int) -> dict[str, Any]:

--- a/src/nv_config_manager/mcp/main.py
+++ b/src/nv_config_manager/mcp/main.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NVIDIA Config Manager MCP Streamable HTTP server."""
+
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+from nv_config_manager.common.log import configure_logging
+from nv_config_manager.mcp.auth import RequestAuthMiddleware
+from nv_config_manager.mcp.settings import MCPSettings
+from nv_config_manager.mcp.tools import register_tools
+
+configure_logging(service="mcp")
+
+
+def create_mcp_server(settings: MCPSettings | None = None) -> FastMCP:
+    """Create the FastMCP server and register tools."""
+    resolved_settings = settings or MCPSettings.from_config()
+    server = FastMCP(
+        "nvidia-config-manager-mcp",
+        instructions=(
+            "Read-only NVIDIA Config Manager operator tools plus explicitly "
+            "enabled safe diagnostic workflow starters. When auth is enabled, tools "
+            "use the caller's Bearer token for Config Manager APIs. Nautobot auth "
+            "mode is configured per environment."
+        ),
+        host="0.0.0.0",
+        json_response=True,
+        stateless_http=True,
+        streamable_http_path="/mcp",
+    )
+
+    @server.custom_route("/healthcheck", methods=["GET"], include_in_schema=False)
+    async def healthcheck(request: Request) -> JSONResponse:
+        return JSONResponse({"status": "healthy"})
+
+    @server.custom_route("/metrics", methods=["GET"], include_in_schema=False)
+    async def metrics(request: Request) -> Response:
+        return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    register_tools(server, resolved_settings)
+    return server
+
+
+def create_app(settings: MCPSettings | None = None) -> ASGIApp:
+    """Create the ASGI application for Streamable HTTP MCP."""
+    return RequestAuthMiddleware(create_mcp_server(settings).streamable_http_app())
+
+
+def main() -> None:
+    """CLI entrypoint for the MCP service."""
+    parser = argparse.ArgumentParser(description="NVIDIA Config Manager MCP Server")
+    parser.add_argument("--port", type=int, default=9000, help="Port to listen on")
+    parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to bind to")
+    args = parser.parse_args()
+
+    uvicorn.run(
+        create_app(),
+        host=args.host,
+        port=args.port,
+        proxy_headers=True,
+        log_config=None,
+    )

--- a/src/nv_config_manager/mcp/main.py
+++ b/src/nv_config_manager/mcp/main.py
@@ -26,7 +26,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
 from nv_config_manager.common.log import configure_logging
-from nv_config_manager.mcp.auth import RequestAuthMiddleware
+from nv_config_manager.mcp.auth import RequestAuthMiddleware, ServiceAuthMiddleware
 from nv_config_manager.mcp.settings import MCPSettings
 from nv_config_manager.mcp.tools import register_tools
 
@@ -42,7 +42,9 @@ def create_mcp_server(settings: MCPSettings | None = None) -> FastMCP:
             "Read-only NVIDIA Config Manager operator tools plus explicitly "
             "enabled safe diagnostic workflow starters. When auth is enabled, tools "
             "use the caller's Bearer token for Config Manager APIs. Nautobot auth "
-            "mode is configured per environment."
+            "mode is configured per environment. Use list_related_mcp_servers to "
+            "discover public documentation MCP servers that clients can connect to "
+            "directly."
         ),
         host="0.0.0.0",
         json_response=True,
@@ -64,7 +66,9 @@ def create_mcp_server(settings: MCPSettings | None = None) -> FastMCP:
 
 def create_app(settings: MCPSettings | None = None) -> ASGIApp:
     """Create the ASGI application for Streamable HTTP MCP."""
-    return RequestAuthMiddleware(create_mcp_server(settings).streamable_http_app())
+    return ServiceAuthMiddleware(
+        RequestAuthMiddleware(create_mcp_server(settings).streamable_http_app())
+    )
 
 
 def main() -> None:

--- a/src/nv_config_manager/mcp/settings.py
+++ b/src/nv_config_manager/mcp/settings.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Configuration for the NVIDIA Config Manager MCP server."""
+
+from __future__ import annotations
+
+from configparser import ConfigParser
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from nv_config_manager.common.config import load_config, parse_verify_param
+
+NAUTOBOT_AUTH_MODES = {"auto", "jwt", "token"}
+
+
+@dataclass(frozen=True)
+class MCPSettings:
+    """Resolved MCP service configuration."""
+
+    workflow_api_url: str
+    config_store_api_url: str
+    dhcp_api_url: str
+    nautobot_url: str
+    nautobot_token: str
+    nautobot_verify: bool | str
+    nautobot_auth_mode: str
+    nautobot_token_fallback_enabled: bool
+    max_response_bytes: int
+
+    @classmethod
+    def from_config(cls, config: ConfigParser | None = None) -> MCPSettings:
+        """Resolve MCP settings from nv-config-manager.ini."""
+        config = config or load_config()
+        use_internal = _get_bool(config, "mcp", "use_internal_endpoints", True)
+        configured_auth_mode = _get_value(config, "mcp", "nautobot_auth_mode", "auto").lower()
+        if configured_auth_mode not in NAUTOBOT_AUTH_MODES:
+            raise ValueError(
+                f"mcp.nautobot_auth_mode must be one of: {', '.join(sorted(NAUTOBOT_AUTH_MODES))}"
+            )
+
+        return cls(
+            workflow_api_url=_service_url(config, "temporal", use_internal),
+            config_store_api_url=_service_url(config, "config_store.client", use_internal),
+            dhcp_api_url=_service_url(config, "dhcp", use_internal),
+            nautobot_url=_get_required(config, "nautobot", "server"),
+            nautobot_token=_get_value(config, "nautobot", "token", ""),
+            nautobot_verify=_verify_value(config, "nautobot"),
+            nautobot_auth_mode=_resolve_nautobot_auth_mode(
+                configured_auth_mode, _get_required(config, "nautobot", "server")
+            ),
+            nautobot_token_fallback_enabled=_get_bool(
+                config, "mcp", "nautobot_token_fallback_enabled", False
+            ),
+            max_response_bytes=_get_int(config, "mcp", "max_response_bytes", 100_000),
+        )
+
+
+def _get_value(config: ConfigParser, section: str, key: str, fallback: str) -> str:
+    if not config.has_section(section):
+        return fallback
+    return config[section].get(key, fallback=fallback)
+
+
+def _get_required(config: ConfigParser, section: str, key: str) -> str:
+    if not config.has_section(section) or key not in config[section]:
+        raise ValueError(f"Missing required config value [{section}] {key}")
+    return config[section][key]
+
+
+def _get_bool(config: ConfigParser, section: str, key: str, fallback: bool) -> bool:
+    if not config.has_section(section):
+        return fallback
+    return config[section].getboolean(key, fallback=fallback)
+
+
+def _get_int(config: ConfigParser, section: str, key: str, fallback: int) -> int:
+    if not config.has_section(section):
+        return fallback
+    return config[section].getint(key, fallback=fallback)
+
+
+def _service_url(config: ConfigParser, section: str, use_internal: bool) -> str:
+    key = "api_service" if use_internal else "api_url"
+    return _get_required(config, section, key).rstrip("/")
+
+
+def _verify_value(config: ConfigParser, section: str) -> bool | str:
+    if not config.has_section(section):
+        return True
+    return parse_verify_param(config[section])
+
+
+def _resolve_nautobot_auth_mode(configured_auth_mode: str, nautobot_url: str) -> str:
+    if configured_auth_mode != "auto":
+        return configured_auth_mode
+    if _looks_like_local_nautobot(nautobot_url):
+        return "jwt"
+    return "token"
+
+
+def _looks_like_local_nautobot(nautobot_url: str) -> bool:
+    parsed = urlparse(nautobot_url)
+    hostname = parsed.hostname or nautobot_url
+    return (
+        hostname == "nautobot"
+        or hostname.endswith("-nautobot")
+        or hostname.endswith(".svc")
+        or ".svc." in hostname
+        or hostname.endswith(".svc.cluster.local")
+    )

--- a/src/nv_config_manager/mcp/settings.py
+++ b/src/nv_config_manager/mcp/settings.py
@@ -30,10 +30,11 @@ class MCPSettings:
     """Resolved MCP service configuration."""
 
     workflow_api_url: str
+    workflow_ui_url: str
     config_store_api_url: str
     dhcp_api_url: str
     nautobot_url: str
-    nautobot_token: str
+    nautobot_read_only_token: str
     nautobot_verify: bool | str
     nautobot_auth_mode: str
     nautobot_token_fallback_enabled: bool
@@ -52,10 +53,11 @@ class MCPSettings:
 
         return cls(
             workflow_api_url=_service_url(config, "temporal", use_internal),
+            workflow_ui_url=_workflow_ui_url(config),
             config_store_api_url=_service_url(config, "config_store.client", use_internal),
             dhcp_api_url=_service_url(config, "dhcp", use_internal),
             nautobot_url=_get_required(config, "nautobot", "server"),
-            nautobot_token=_get_value(config, "nautobot", "token", ""),
+            nautobot_read_only_token=_get_value(config, "mcp", "nautobot_read_only_token", ""),
             nautobot_verify=_verify_value(config, "nautobot"),
             nautobot_auth_mode=_resolve_nautobot_auth_mode(
                 configured_auth_mode, _get_required(config, "nautobot", "server")
@@ -94,6 +96,22 @@ def _get_int(config: ConfigParser, section: str, key: str, fallback: int) -> int
 def _service_url(config: ConfigParser, section: str, use_internal: bool) -> str:
     key = "api_service" if use_internal else "api_url"
     return _get_required(config, section, key).rstrip("/")
+
+
+def _workflow_ui_url(config: ConfigParser) -> str:
+    configured = _get_value(config, "temporal", "ui_url", "").strip()
+    if configured:
+        return configured.rstrip("/")
+
+    api_url = _get_value(config, "temporal", "api_url", "").strip()
+    parsed = urlparse(api_url)
+    if not parsed.scheme or not parsed.netloc:
+        return api_url.rstrip("/")
+
+    hostname = parsed.netloc
+    if hostname.startswith("workflow."):
+        hostname = hostname.removeprefix("workflow.")
+    return f"{parsed.scheme}://{hostname}"
 
 
 def _verify_value(config: ConfigParser, section: str) -> bool | str:

--- a/src/nv_config_manager/mcp/tools.py
+++ b/src/nv_config_manager/mcp/tools.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from mcp.server.fastmcp import FastMCP
 
@@ -41,9 +41,34 @@ from nv_config_manager.mcp.workflows import (
     normalize_workflow_parameters,
 )
 
+PUBLIC_DOCS_MCP_SERVER_URL = (
+    "https://docs.nvidia.com/switch-infrastructure/config-manager/_mcp/server"
+)
+
 
 def register_tools(server: FastMCP, settings: MCPSettings) -> None:
     """Register NVIDIA Config Manager MCP tools."""
+
+    @server.tool()
+    async def list_related_mcp_servers() -> dict[str, Any]:
+        """List related MCP servers that clients can connect to directly."""
+        return {
+            "servers": [
+                {
+                    "name": "nvidia-config-manager-public-docs",
+                    "url": PUBLIC_DOCS_MCP_SERVER_URL,
+                    "purpose": (
+                        "Public NVIDIA Config Manager documentation. Use this server for "
+                        "product documentation, usage guidance, and conceptual reference."
+                    ),
+                    "authentication": "none",
+                    "notes": (
+                        "Connect the MCP-capable client directly to this URL; the operational "
+                        "Config Manager MCP server does not proxy public documentation tools."
+                    ),
+                }
+            ]
+        }
 
     @server.tool()
     async def search_devices(
@@ -285,9 +310,16 @@ def _register_workflow_starter(
         """Start a safe diagnostic workflow."""
         normalized = normalize_workflow_parameters(workflow, parameters)
         result = await start_workflow(settings, workflow.endpoint, normalized)
+        workflow_result = result.get("data") if isinstance(result, dict) else None
+        workflow_id = workflow_result.get("id") if isinstance(workflow_result, dict) else None
+        workflow_ui_href = (
+            workflow_result.get("ui_href") if isinstance(workflow_result, dict) else None
+        )
         return {
             "workflow": workflow.workflow_name,
             "endpoint": workflow.endpoint,
+            "workflow_id": workflow_id,
+            "workflow_ui_href": workflow_ui_href,
             "input_schema": workflow.input_schema,
             "result": result,
         }
@@ -296,6 +328,7 @@ def _register_workflow_starter(
     run_workflow.__doc__ = (
         f"{workflow.description}\n\n"
         "Pass workflow input fields as the `parameters` object. "
+        "Use `workflow_ui_href` as the end-user Config Manager workflow link. "
         "The response includes the workflow input schema for reference."
     )
     server.tool(name=workflow.tool_name, description=workflow.description)(run_workflow)
@@ -308,13 +341,24 @@ def _drop_none(values: dict[str, Any]) -> dict[str, Any]:
 def _extract_devices(data: Any) -> list[dict[str, Any]]:
     if isinstance(data, dict) and isinstance(data.get("data"), dict):
         data = data["data"]
-    if isinstance(data, dict) and isinstance(data.get("results"), list):
-        return data["results"]
-    if isinstance(data, dict) and isinstance(data.get("interfaces"), list):
+    if isinstance(data, dict):
+        results = data.get("results")
+        if isinstance(results, list):
+            return [cast(dict[str, Any], result) for result in results if isinstance(result, dict)]
+    if isinstance(data, dict):
+        interfaces = data.get("interfaces")
+        if not isinstance(interfaces, list):
+            return []
         devices: dict[str, dict[str, Any]] = {}
-        for interface in data["interfaces"]:
-            device = interface.get("device") or (interface.get("module") or {}).get("device")
-            if isinstance(device, dict) and device.get("id"):
-                devices[device["id"]] = device
+        for interface in interfaces:
+            if not isinstance(interface, dict):
+                continue
+            module = interface.get("module")
+            device = interface.get("device")
+            if not isinstance(device, dict) and isinstance(module, dict):
+                device = module.get("device")
+            device_id = device.get("id") if isinstance(device, dict) else None
+            if device_id:
+                devices[str(device_id)] = cast(dict[str, Any], device)
         return list(devices.values())
     return []

--- a/src/nv_config_manager/mcp/tools.py
+++ b/src/nv_config_manager/mcp/tools.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MCP tool registration for NVIDIA Config Manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from nv_config_manager.mcp.clients import (
+    MCPClientError,
+    clamp_limit,
+    fetch_config_diff,
+    fetch_config_versions,
+    fetch_device_config,
+    fetch_device_configs,
+    fetch_dhcp_config,
+    fetch_workflow_detail,
+    fetch_workflows,
+    nautobot_graphql_query,
+    nautobot_rest_get,
+    start_workflow,
+)
+from nv_config_manager.mcp.settings import MCPSettings
+from nv_config_manager.mcp.workflows import (
+    MCPWorkflow,
+    discover_mcp_workflows,
+    normalize_workflow_parameters,
+)
+
+
+def register_tools(server: FastMCP, settings: MCPSettings) -> None:
+    """Register NVIDIA Config Manager MCP tools."""
+
+    @server.tool()
+    async def search_devices(
+        query: str | None = None,
+        hostname: str | None = None,
+        serial: str | None = None,
+        mac_address: str | None = None,
+        device_id: str | None = None,
+        cf_nico_machine_id: str | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        """Search Nautobot devices by common operator identifiers."""
+        bounded_limit = clamp_limit(limit)
+
+        if mac_address:
+            gql_query = """
+                query ($mac_address: [String]) {
+                  interfaces(mac_address: $mac_address) {
+                    id
+                    name
+                    mac_address
+                    device {
+                      id
+                      name
+                      serial
+                      role { name }
+                      platform { name }
+                      location { name }
+                    }
+                    module {
+                      device {
+                        id
+                        name
+                        serial
+                        role { name }
+                        platform { name }
+                        location { name }
+                      }
+                    }
+                  }
+                }
+            """
+            return await nautobot_graphql_query(settings, gql_query, {"mac_address": [mac_address]})
+
+        params: dict[str, Any] = {"limit": bounded_limit}
+        if query:
+            params["q"] = query
+        if hostname:
+            params["name"] = hostname
+        if serial:
+            params["serial"] = serial
+        if device_id:
+            params["id"] = device_id
+        if cf_nico_machine_id:
+            params["cf_nico_machine_id"] = cf_nico_machine_id
+        if len(params) == 1:
+            raise MCPClientError("At least one search identifier is required.")
+        return await nautobot_rest_get(settings, "dcim/devices/", params=params)
+
+    @server.tool()
+    async def get_device_id(
+        query: str | None = None,
+        hostname: str | None = None,
+        serial: str | None = None,
+        mac_address: str | None = None,
+        cf_nico_machine_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a device identifier to a Nautobot device ID."""
+        result = await search_devices(
+            query=query,
+            hostname=hostname,
+            serial=serial,
+            mac_address=mac_address,
+            cf_nico_machine_id=cf_nico_machine_id,
+            limit=2,
+        )
+        devices = _extract_devices(result.get("data"))
+        if not devices:
+            return {"found": False, "matches": []}
+        if len(devices) > 1:
+            return {"found": False, "ambiguous": True, "matches": devices}
+        return {"found": True, "device": devices[0], "device_id": devices[0].get("id")}
+
+    @server.tool()
+    async def query_nautobot(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Run a read-only Nautobot GraphQL query."""
+        return await nautobot_graphql_query(settings, query, variables)
+
+    @server.tool()
+    async def list_nautobot_types(
+        name_contains: str | None = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """List Nautobot GraphQL schema types."""
+        gql_query = """
+            query {
+              __schema {
+                types {
+                  name
+                  kind
+                  description
+                }
+              }
+            }
+        """
+        result = await nautobot_graphql_query(settings, gql_query)
+        types = result.get("data", {}).get("data", {}).get("__schema", {}).get("types", [])
+        if name_contains:
+            needle = name_contains.lower()
+            types = [item for item in types if needle in str(item.get("name", "")).lower()]
+        return {"truncated": False, "data": {"types": types[: clamp_limit(limit)]}}
+
+    @server.tool()
+    async def get_nautobot_type(type_name: str) -> dict[str, Any]:
+        """Inspect a Nautobot GraphQL schema type."""
+        gql_query = """
+            query ($type_name: String!) {
+              __type(name: $type_name) {
+                name
+                kind
+                description
+                fields {
+                  name
+                  description
+                  type { kind name ofType { kind name ofType { kind name } } }
+                }
+                inputFields {
+                  name
+                  description
+                  type { kind name ofType { kind name ofType { kind name } } }
+                }
+                enumValues {
+                  name
+                  description
+                }
+              }
+            }
+        """
+        return await nautobot_graphql_query(settings, gql_query, {"type_name": type_name})
+
+    @server.tool()
+    async def get_dhcp_config(ip_version: int = 4) -> dict[str, Any]:
+        """Get the sanitized running DHCP configuration."""
+        if ip_version not in {4, 6}:
+            raise MCPClientError("ip_version must be 4 or 6.")
+        return await fetch_dhcp_config(settings, ip_version)
+
+    @server.tool()
+    async def list_device_configs(
+        device_id: str,
+        file_type: str | None = "intended",
+    ) -> dict[str, Any]:
+        """List configuration files for a device from Config Store."""
+        return await fetch_device_configs(settings, device_id, file_type=file_type)
+
+    @server.tool()
+    async def get_device_config(
+        device_id: str,
+        filename: str,
+        file_type: str = "intended",
+        version: int | None = None,
+    ) -> dict[str, Any]:
+        """Get a redacted configuration file from Config Store."""
+        return await fetch_device_config(settings, device_id, filename, file_type, version)
+
+    @server.tool()
+    async def get_config_versions(
+        device_id: str,
+        filename: str,
+        file_type: str = "intended",
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """List Config Store versions for a device config file."""
+        return await fetch_config_versions(
+            settings,
+            device_id,
+            filename,
+            file_type=file_type,
+            limit=clamp_limit(limit),
+        )
+
+    @server.tool()
+    async def get_config_diff(
+        device_id: str,
+        filename: str,
+        from_version: int,
+        to_version: int,
+        file_type: str = "intended",
+    ) -> dict[str, Any]:
+        """Get a redacted diff between two Config Store versions."""
+        return await fetch_config_diff(
+            settings,
+            device_id,
+            filename,
+            from_version,
+            to_version,
+            file_type=file_type,
+        )
+
+    @server.tool()
+    async def list_workflows(
+        user: str | None = None,
+        workflow_type: str | None = None,
+        device_id: str | None = None,
+        device_name: str | None = None,
+        site: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+        next_page_token: str | None = None,
+    ) -> dict[str, Any]:
+        """List Workflow API executions visible to the caller."""
+        params = _drop_none(
+            {
+                "user": user,
+                "workflow_type": workflow_type,
+                "device_id": device_id,
+                "device_name": device_name,
+                "site": site,
+                "status": status,
+                "limit": clamp_limit(limit),
+                "next_page_token": next_page_token,
+            }
+        )
+        return await fetch_workflows(settings, params)
+
+    @server.tool()
+    async def get_workflow_detail(workflow_id: str) -> dict[str, Any]:
+        """Get details for a Workflow API execution visible to the caller."""
+        return await fetch_workflow_detail(settings, workflow_id)
+
+    for workflow in discover_mcp_workflows():
+        _register_workflow_starter(server, settings, workflow)
+
+
+def _register_workflow_starter(
+    server: FastMCP, settings: MCPSettings, workflow: MCPWorkflow
+) -> None:
+    async def run_workflow(parameters: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Start a safe diagnostic workflow."""
+        normalized = normalize_workflow_parameters(workflow, parameters)
+        result = await start_workflow(settings, workflow.endpoint, normalized)
+        return {
+            "workflow": workflow.workflow_name,
+            "endpoint": workflow.endpoint,
+            "input_schema": workflow.input_schema,
+            "result": result,
+        }
+
+    run_workflow.__name__ = workflow.tool_name
+    run_workflow.__doc__ = (
+        f"{workflow.description}\n\n"
+        "Pass workflow input fields as the `parameters` object. "
+        "The response includes the workflow input schema for reference."
+    )
+    server.tool(name=workflow.tool_name, description=workflow.description)(run_workflow)
+
+
+def _drop_none(values: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def _extract_devices(data: Any) -> list[dict[str, Any]]:
+    if isinstance(data, dict) and isinstance(data.get("data"), dict):
+        data = data["data"]
+    if isinstance(data, dict) and isinstance(data.get("results"), list):
+        return data["results"]
+    if isinstance(data, dict) and isinstance(data.get("interfaces"), list):
+        devices: dict[str, dict[str, Any]] = {}
+        for interface in data["interfaces"]:
+            device = interface.get("device") or (interface.get("module") or {}).get("device")
+            if isinstance(device, dict) and device.get("id"):
+                devices[device["id"]] = device
+        return list(devices.values())
+    return []

--- a/src/nv_config_manager/mcp/tools.py
+++ b/src/nv_config_manager/mcp/tools.py
@@ -175,11 +175,12 @@ def register_tools(server: FastMCP, settings: MCPSettings) -> None:
             }
         """
         result = await nautobot_graphql_query(settings, gql_query)
+        upstream_truncated = bool(result.get("truncated", False))
         types = result.get("data", {}).get("data", {}).get("__schema", {}).get("types", [])
         if name_contains:
             needle = name_contains.lower()
             types = [item for item in types if needle in str(item.get("name", "")).lower()]
-        return {"truncated": False, "data": {"types": types[: clamp_limit(limit)]}}
+        return {"truncated": upstream_truncated, "data": {"types": types[: clamp_limit(limit)]}}
 
     @server.tool()
     async def get_nautobot_type(type_name: str) -> dict[str, Any]:

--- a/src/nv_config_manager/mcp/workflows.py
+++ b/src/nv_config_manager/mcp/workflows.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Workflow metadata helpers for MCP tool registration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, get_args
+
+from pydantic import BaseModel
+
+from nv_config_manager.temporal.common.mixins.metadata import WorkflowMetadataMixin
+from nv_config_manager.temporal.hello_world.workflows import (
+    REGISTERED_WORKFLOWS as HELLO_WORLD_WORKFLOWS,
+)
+from nv_config_manager.temporal.ngc.workflows import REGISTERED_WORKFLOWS as NGC_WORKFLOWS
+
+
+@dataclass(frozen=True)
+class MCPWorkflow:
+    """Workflow metadata used to expose a safe MCP workflow starter."""
+
+    tool_name: str
+    workflow_name: str
+    description: str
+    endpoint: str
+    input_class: type[BaseModel]
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        """Return the Pydantic JSON schema for the workflow input model."""
+        return self.input_class.model_json_schema()
+
+
+def discover_mcp_workflows() -> list[MCPWorkflow]:
+    """Discover workflows explicitly enabled for MCP."""
+    workflows: list[MCPWorkflow] = []
+    for workflow_class in NGC_WORKFLOWS + HELLO_WORLD_WORKFLOWS:
+        if not issubclass(workflow_class, WorkflowMetadataMixin):
+            continue
+        if not workflow_class.has_complete_metadata():
+            continue
+        if not workflow_class.get_workflow_mcp_enabled():
+            continue
+
+        endpoint = workflow_class.get_workflow_api_endpoint()
+        input_class = workflow_class.get_workflow_input_class()
+        if not endpoint or not input_class:
+            continue
+
+        workflow_name = workflow_class.__name__
+        workflows.append(
+            MCPWorkflow(
+                tool_name=_tool_name_from_endpoint(endpoint),
+                workflow_name=workflow_name,
+                description=workflow_class.get_workflow_description(),
+                endpoint=endpoint,
+                input_class=input_class,
+            )
+        )
+    return sorted(workflows, key=lambda workflow: workflow.tool_name)
+
+
+def normalize_workflow_parameters(
+    workflow: MCPWorkflow, parameters: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Fill neutral API defaults for existing workflow input models."""
+    normalized = dict(parameters or {})
+    fields = workflow.input_class.model_fields
+
+    if "trigger" in fields and "trigger" not in normalized:
+        normalized["trigger"] = "API"
+
+    for field_name, field_info in fields.items():
+        if field_name in normalized:
+            continue
+        if _allows_none(field_info.annotation):
+            normalized[field_name] = None
+
+    return normalized
+
+
+def _tool_name_from_endpoint(endpoint: str) -> str:
+    slug = endpoint.strip("/").split("/")[-1]
+    return f"run_{slug.replace('-', '_')}"
+
+
+def _allows_none(annotation: Any) -> bool:
+    if annotation is None or annotation is type(None):
+        return True
+    return type(None) in get_args(annotation)

--- a/src/nv_config_manager/mcp/workflows.py
+++ b/src/nv_config_manager/mcp/workflows.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, get_args
+from typing import Any, cast, get_args
 
 from pydantic import BaseModel
 
@@ -50,13 +50,14 @@ def discover_mcp_workflows() -> list[MCPWorkflow]:
     for workflow_class in NGC_WORKFLOWS + HELLO_WORLD_WORKFLOWS:
         if not issubclass(workflow_class, WorkflowMetadataMixin):
             continue
-        if not workflow_class.has_complete_metadata():
+        metadata_workflow = cast(type[WorkflowMetadataMixin], workflow_class)
+        if not metadata_workflow.has_complete_metadata():
             continue
-        if not workflow_class.get_workflow_mcp_enabled():
+        if not metadata_workflow.get_workflow_mcp_enabled():
             continue
 
-        endpoint = workflow_class.get_workflow_api_endpoint()
-        input_class = workflow_class.get_workflow_input_class()
+        endpoint = metadata_workflow.get_workflow_api_endpoint()
+        input_class = metadata_workflow.get_workflow_input_class()
         if not endpoint or not input_class:
             continue
 
@@ -65,7 +66,7 @@ def discover_mcp_workflows() -> list[MCPWorkflow]:
             MCPWorkflow(
                 tool_name=_tool_name_from_endpoint(endpoint),
                 workflow_name=workflow_name,
-                description=workflow_class.get_workflow_description(),
+                description=metadata_workflow.get_workflow_description(),
                 endpoint=endpoint,
                 input_class=input_class,
             )

--- a/src/nv_config_manager/temporal/api/dynamic_endpoints.py
+++ b/src/nv_config_manager/temporal/api/dynamic_endpoints.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Dynamic API endpoint generation from workflow metadata."""
 
-import os
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
@@ -23,6 +22,7 @@ from pydantic import BaseModel, computed_field
 
 from nv_config_manager.common.auth import get_sso_user
 from nv_config_manager.common.log import LogCategory, get_logger
+from nv_config_manager.temporal.api.links import temporal_ui_workflow_href
 from nv_config_manager.temporal.common.mixins.metadata import WorkflowMetadataMixin
 from nv_config_manager.temporal.common.rbac_config import RBACConfig
 from nv_config_manager.temporal.hello_world.workflows import (
@@ -41,8 +41,7 @@ class WorkflowResponse(BaseModel):
     @computed_field
     def href(self) -> str:
         """Calculate URL to Temporal UI Workflow View."""
-        ui_server = os.getenv("TEMPORAL_UI", "http://localhost:8080")
-        return f"{ui_server}/namespaces/default/workflows/{self.id}"
+        return temporal_ui_workflow_href(self.id)
 
 
 # Import the start_workflow function - this will be available when this module is imported

--- a/src/nv_config_manager/temporal/api/links.py
+++ b/src/nv_config_manager/temporal/api/links.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from configparser import ConfigParser
+from urllib.parse import quote
 
 from nv_config_manager.common.config import load_config
 
@@ -26,11 +27,12 @@ def temporal_ui_workflow_href(workflow_id: str, config: ConfigParser | None = No
     if config is None:
         config = load_config()
 
+    safe_workflow_id = quote(workflow_id, safe="")
     ui_url = config.get("temporal", "temporal_ui_url", fallback="").strip()
     if not ui_url:
-        raise RuntimeError("Missing [temporal] temporal_ui_url in nv-config-manager.ini")
+        return ""
 
-    return f"{_normalize_base_url(ui_url)}/namespaces/default/workflows/{workflow_id}"
+    return f"{_normalize_base_url(ui_url)}/namespaces/default/workflows/{safe_workflow_id}"
 
 
 def _normalize_base_url(url: str) -> str:

--- a/src/nv_config_manager/temporal/api/links.py
+++ b/src/nv_config_manager/temporal/api/links.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Temporal API link helpers."""
+
+from __future__ import annotations
+
+from configparser import ConfigParser
+
+from nv_config_manager.common.config import load_config
+
+
+def temporal_ui_workflow_href(workflow_id: str, config: ConfigParser | None = None) -> str:
+    """Build the Temporal Web URL for a workflow execution."""
+    if config is None:
+        config = load_config()
+
+    ui_url = config.get("temporal", "temporal_ui_url", fallback="").strip()
+    if not ui_url:
+        raise RuntimeError("Missing [temporal] temporal_ui_url in nv-config-manager.ini")
+
+    return f"{_normalize_base_url(ui_url)}/namespaces/default/workflows/{workflow_id}"
+
+
+def _normalize_base_url(url: str) -> str:
+    base_url = url.rstrip("/")
+    if base_url.startswith(("http://", "https://")):
+        return base_url
+    return f"https://{base_url}"

--- a/src/nv_config_manager/temporal/api/workflow_v1.py
+++ b/src/nv_config_manager/temporal/api/workflow_v1.py
@@ -45,6 +45,7 @@ from nv_config_manager.temporal.api.dynamic_endpoints import (
     register_dynamic_endpoints,
     set_start_workflow_function,
 )
+from nv_config_manager.temporal.api.links import temporal_ui_workflow_href
 from nv_config_manager.temporal.client.redis import RedisClient
 from nv_config_manager.temporal.common.mixins.base import BaseMixin
 from nv_config_manager.temporal.common.mixins.stage import (
@@ -176,8 +177,7 @@ class WorkflowResponse(BaseModel):
     @computed_field
     def href(self) -> str:
         """Calculate URL to Temporal UI Workflow View."""
-        ui_server = os.getenv("TEMPORAL_UI", "http://localhost:8080")
-        return f"{ui_server}/namespaces/default/workflows/{self.id}"
+        return temporal_ui_workflow_href(self.id)
 
 
 class WorkflowSummaryResponse(WorkflowResponse):

--- a/src/nv_config_manager/temporal/cli.py
+++ b/src/nv_config_manager/temporal/cli.py
@@ -23,16 +23,18 @@ OIDCAuth class from nv_config_manager.common.oidc.
 """
 
 import json
+import re
 import sys
 from typing import Any, NoReturn, get_type_hints
 
 import click
 import requests
+import urllib3
 from pydantic import BaseModel
 
-from nv_config_manager.common.oidc import OIDCAuth, decode_jwt_claims
+from nv_config_manager.common.oidc import AuthDiscovery, OIDCAuth, decode_jwt_claims
 
-# Import workflows and metadata mixin
+# Keep workflow imports guarded so a packaging/import issue produces a CLI-friendly error.
 try:
     from nv_config_manager.temporal.common.mixins.metadata import WorkflowMetadataMixin
     from nv_config_manager.temporal.hello_world.workflows import (
@@ -200,8 +202,6 @@ class WorkflowDiscovery:
     @staticmethod
     def _camel_to_kebab(name: str) -> str:
         """Convert CamelCase to kebab-case."""
-        import re
-
         # Insert hyphens before uppercase letters (except the first one)
         s1 = re.sub("(.)([A-Z][a-z]+)", r"\1-\2", name)
         # Insert hyphens before uppercase letters that follow lowercase letters or numbers
@@ -221,20 +221,30 @@ class WorkflowClient:
         base_hostname: str,
         auth: OIDCAuth | None = None,
         insecure: bool = False,
+        base_url: str | None = None,
     ) -> None:
         self.base_hostname = base_hostname
         self.auth = auth
         self.verify = not insecure
 
-        if auth:
+        if base_url:
+            self.base_url = base_url.rstrip("/")
+        elif auth:
             self.base_url = f"https://svc-workflow.{base_hostname}/v1/workflow"
         else:
             self.base_url = f"https://workflow.{base_hostname}/v1/workflow"
+        self.api_root_url = self._derive_api_root_url(self.base_url)
 
         if insecure:
-            import urllib3
-
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    @staticmethod
+    def _derive_api_root_url(workflow_base_url: str) -> str:
+        """Return the /v1 API root from a /v1/workflow URL."""
+        suffix = "/workflow"
+        if workflow_base_url.endswith(suffix):
+            return workflow_base_url[: -len(suffix)]
+        return workflow_base_url.rstrip("/")
 
     def _prepare_auth_headers(
         self,
@@ -339,10 +349,7 @@ class WorkflowClient:
         Raises:
             click.ClickException: If conversion fails.
         """
-        if self.auth:
-            param_url = f"https://svc-workflow.{self.base_hostname}/v1/parameter/device-id"
-        else:
-            param_url = f"https://workflow.{self.base_hostname}/v1/parameter/device-id"
+        param_url = f"{self.api_root_url}/parameter/device-id"
 
         headers: dict[str, str] = {}
         if self.auth:
@@ -427,24 +434,93 @@ def _resolve_base_hostname(
     raise click.ClickException("Either --hostname or --environment is required.")
 
 
+def _default_workflow_url(base_hostname: str, auth_required: bool) -> str:
+    """Return the default workflow API URL for an auth mode."""
+    if not base_hostname:
+        return ""
+    prefix = "svc-workflow" if auth_required else "workflow"
+    return f"https://{prefix}.{base_hostname}/v1/workflow"
+
+
+def _auth_discovery_url(base_hostname: str) -> str:
+    """Return the base-host auth discovery URL."""
+    return f"https://{base_hostname}/auth/discovery"
+
+
+def _workflow_url_from_discovery(
+    discovery: AuthDiscovery | None,
+    base_hostname: str,
+    auth_required: bool,
+) -> str:
+    """Resolve workflow URL from discovery metadata or defaults."""
+    if discovery:
+        workflow_url = discovery.services.get("workflow")
+        if workflow_url:
+            return workflow_url.rstrip("/")
+    return _default_workflow_url(base_hostname, auth_required)
+
+
 def _build_auth(
     base_hostname: str,
     issuer: str | None,
     client_id: str | None,
     insecure: bool,
-) -> OIDCAuth | None:
+) -> tuple[OIDCAuth | None, str]:
     """Build an OIDCAuth instance, auto-discovering if needed.
 
-    Returns None if SSO is not enabled on the target environment (the gateway
-    returns a non-redirect response to an unauthenticated probe).
+    Returns an auth helper and the workflow API URL. The auth helper is None
+    when SSO is not enabled on the target environment.
     """
     if issuer and client_id:
         # Explicit config — always use SSO
-        return OIDCAuth(issuer_url=issuer, client_id=client_id)
+        return (
+            OIDCAuth(issuer_url=issuer, client_id=client_id, verify=not insecure),
+            _default_workflow_url(base_hostname, auth_required=True),
+        )
 
-    # Auto-discover from gateway
-    gateway_url = f"https://workflow.{base_hostname}/v1/workflow"
+    # Auto-discover from the public base-host metadata endpoint first.
+    discovery_url = _auth_discovery_url(base_hostname)
     click.echo(f"Auto-discovering OIDC configuration from {base_hostname}...")
+    try:
+        auth_discovery = OIDCAuth.discover_auth_config(discovery_url, verify=not insecure)
+    except RuntimeError as e:
+        raise click.ClickException(
+            f"OIDC auto-discovery failed: {e}\nPlease provide --issuer and --client-id manually."
+        ) from e
+
+    if auth_discovery is not None:
+        if not auth_discovery.auth_required:
+            click.echo("  SSO is not enabled — skipping authentication.")
+            return None, _workflow_url_from_discovery(
+                auth_discovery,
+                base_hostname,
+                auth_required=False,
+            )
+
+        discovered_issuer = auth_discovery.issuer_url
+        discovered_client_id = auth_discovery.client_id
+        issuer = issuer or discovered_issuer
+        client_id = client_id or discovered_client_id
+        if not issuer or not client_id:
+            raise click.ClickException("Auth discovery did not include complete OIDC settings.")
+        click.echo(f"  Discovered issuer: {issuer}")
+        click.echo(f"  Discovered client ID: {client_id}")
+        return (
+            OIDCAuth(
+                issuer_url=issuer,
+                client_id=client_id,
+                scopes=list(auth_discovery.scopes) or None,
+                verify=not insecure,
+            ),
+            _workflow_url_from_discovery(
+                auth_discovery,
+                base_hostname,
+                auth_required=True,
+            ),
+        )
+
+    # Fallback for older deployments that predate /auth/discovery.
+    gateway_url = f"https://workflow.{base_hostname}/v1/workflow"
     try:
         result = OIDCAuth.discover_oidc_config(gateway_url, verify=not insecure)
     except RuntimeError as e:
@@ -454,7 +530,7 @@ def _build_auth(
 
     if result is None:
         click.echo("  SSO is not enabled — skipping authentication.")
-        return None
+        return None, _default_workflow_url(base_hostname, auth_required=False)
 
     discovered_issuer, discovered_client_id = result
     issuer = issuer or discovered_issuer
@@ -462,7 +538,10 @@ def _build_auth(
     click.echo(f"  Discovered issuer: {issuer}")
     click.echo(f"  Discovered client ID: {client_id}")
 
-    return OIDCAuth(issuer_url=issuer, client_id=client_id)
+    return (
+        OIDCAuth(issuer_url=issuer, client_id=client_id, verify=not insecure),
+        _default_workflow_url(base_hostname, auth_required=True),
+    )
 
 
 # ── Global workflow discovery ────────────────────────────────────────────
@@ -488,7 +567,7 @@ def create_workflow_command(workflow_name: str, workflow_info: WorkflowInfo) -> 
         insecure = kwargs.pop("insecure", False)
 
         base_hostname = _resolve_base_hostname(hostname, environment, domain)
-        auth = _build_auth(base_hostname, issuer, client_id, insecure)
+        auth, workflow_api_url = _build_auth(base_hostname, issuer, client_id, insecure)
 
         # Handle device name to device ID conversion
         device_name = kwargs.pop("device_name", None)
@@ -514,7 +593,12 @@ def create_workflow_command(workflow_name: str, workflow_info: WorkflowInfo) -> 
                 if verbose:
                     click.echo(f"Converting device name '{device_name}' to device ID...")
                 try:
-                    client = WorkflowClient(base_hostname, auth=auth, insecure=insecure)
+                    client = WorkflowClient(
+                        base_hostname,
+                        auth=auth,
+                        insecure=insecure,
+                        base_url=workflow_api_url,
+                    )
                     device_id = client.get_device_id_by_name(
                         device_name, force_auth_refresh=force_auth_refresh, verbose=verbose
                     )
@@ -544,7 +628,12 @@ def create_workflow_command(workflow_name: str, workflow_info: WorkflowInfo) -> 
                     parameters[key] = value
 
         # Create client and invoke workflow
-        client = WorkflowClient(base_hostname, auth=auth, insecure=insecure)
+        client = WorkflowClient(
+            base_hostname,
+            auth=auth,
+            insecure=insecure,
+            base_url=workflow_api_url,
+        )
         client.invoke_workflow(
             workflow_info, parameters, verbose=verbose, force_auth_refresh=force_auth_refresh
         )
@@ -749,8 +838,6 @@ def login(
     them from the gateway using --hostname or --environment.
     """
     if insecure:
-        import urllib3
-
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # Allow fully manual config (no hostname needed if issuer+client_id given)
@@ -759,7 +846,7 @@ def login(
     else:
         base_hostname = _resolve_base_hostname(hostname, environment, domain)
 
-    auth = _build_auth(base_hostname or "", issuer, client_id, insecure)
+    auth, _workflow_api_url = _build_auth(base_hostname or "", issuer, client_id, insecure)
 
     if auth is None:
         click.echo("SSO is not enabled on this environment — no login required.")

--- a/src/nv_config_manager/temporal/client/nautobot.py
+++ b/src/nv_config_manager/temporal/client/nautobot.py
@@ -553,6 +553,7 @@ class NautobotClient(BaseNautobotClient):
         session = await self._ensure_session()
         async with session.get(
             f"{self.rest_endpoint}{CONFIG_MANAGER_BACKUP_CONFIG_PATH}/{device_id}/",
+            headers=self._resolve_headers(),
         ) as rsp:
             if rsp.status == 404:
                 # No existing backup to reference
@@ -589,6 +590,7 @@ class NautobotClient(BaseNautobotClient):
         async with session.post(
             f"{self.rest_endpoint}{CONFIG_MANAGER_BACKUP_CONFIG_PATH}/",
             json=data,
+            headers=self._resolve_headers(),
         ) as rsp:
             rsp.raise_for_status()
 

--- a/src/nv_config_manager/temporal/common/mixins/metadata.py
+++ b/src/nv_config_manager/temporal/common/mixins/metadata.py
@@ -28,6 +28,7 @@ class WorkflowMetadataMixin:
     workflow_input_class: type[BaseModel] | None = None
     workflow_api_endpoint: str | None = None
     workflow_namespace: str | None = None
+    workflow_mcp_enabled: bool = False
 
     @classmethod
     def get_workflow_name(cls) -> str:
@@ -76,6 +77,11 @@ class WorkflowMetadataMixin:
         s1 = re.sub("(.)([A-Z][a-z]+)", r"\1-\2", name)
         # Insert hyphens before uppercase letters that follow lowercase letters or numbers
         return re.sub("([a-z0-9])([A-Z])", r"\1-\2", s1).lower()
+
+    @classmethod
+    def get_workflow_mcp_enabled(cls) -> bool:
+        """Return whether this workflow can be exposed as an MCP tool."""
+        return cls.workflow_mcp_enabled
 
     @classmethod
     def has_complete_metadata(cls) -> bool:

--- a/src/nv_config_manager/temporal/ngc/workflows/backup.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/backup.py
@@ -92,6 +92,7 @@ class BackupWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, ArchiveMixi
     workflow_input_class = BackupInput
     workflow_api_endpoint = "/ngc/backup"
     workflow_namespace = "ngc"
+    workflow_mcp_enabled = True
 
     def __init__(self) -> None:
         """Initialize workflow."""

--- a/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
@@ -154,6 +154,7 @@ class SiteCableValidationWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixi
     workflow_input_class = SiteCableValidationInput
     workflow_api_endpoint = "/ngc/site_cable_validation"
     workflow_namespace = "ngc"
+    workflow_mcp_enabled = True
 
     def __init__(self) -> None:
         """Workflow Constructor."""
@@ -452,6 +453,7 @@ class DeviceCableValidationWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMix
     workflow_input_class = DeviceCableValidationInput
     workflow_api_endpoint = "/ngc/device_cable_validation"
     workflow_namespace = "ngc"
+    workflow_mcp_enabled = True
 
     def __init__(self) -> None:
         """Workflow constructor."""

--- a/src/nv_config_manager/temporal/ngc/workflows/connected_host.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/connected_host.py
@@ -114,6 +114,7 @@ class ConnectedHostMetadataWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMix
     workflow_input_class = ConnectedHostWorkflowInput
     workflow_api_endpoint = "/ngc/connected_host_metadata"
     workflow_namespace = "ngc"
+    workflow_mcp_enabled = True
 
     def __init__(self) -> None:
         """Initialize workflow."""

--- a/src/nv_config_manager/temporal/ngc/workflows/cumulus_hardware_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cumulus_hardware_validation.py
@@ -214,6 +214,7 @@ class ValidateHardwareWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, A
     workflow_input_class = ValidateHardwareInput
     workflow_api_endpoint = "/ngc/cumulus_hardware_validation"
     workflow_namespace = "ngc"
+    workflow_mcp_enabled = True
 
     def __init__(self) -> None:
         """Initialize workflow."""

--- a/src/nv_config_manager/temporal/ngc/workflows/infiniband_cable_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/infiniband_cable_validation.py
@@ -88,6 +88,7 @@ class InfinibandCableValidationWorkflow(WorkflowMetadataMixin, StageMixin):
     workflow_input_class = InfinibandCableValidationInput
     workflow_api_endpoint = "/ngc/infiniband_cable_validation"
     workflow_namespace = "ngc"
+    workflow_mcp_enabled = True
 
     def __init__(self) -> None:
         """Initialize workflow."""

--- a/src/nv_config_manager/temporal/ngc/workflows/infiniband_get_unhealthy_ports.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/infiniband_get_unhealthy_ports.py
@@ -63,6 +63,7 @@ class InfinibandGetUnhealthyPortsWorkflow(WorkflowMetadataMixin, StageMixin):
     workflow_input_class = InfinibandGetUnhealthyPortsInput
     workflow_api_endpoint = "/ngc/infiniband_get_unhealthy_ports"
     workflow_namespace = "ngc"
+    workflow_mcp_enabled = True
 
     def __init__(self) -> None:
         """Initialize workflow."""

--- a/src/nv_config_manager/temporal/ngc/workflows/lldp.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/lldp.py
@@ -66,6 +66,7 @@ class PortLLDPInfoWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
     workflow_input_class = PortLLDPInfoInput
     workflow_api_endpoint = "/ngc/port_lldp_info"
     workflow_namespace = "ngc"
+    workflow_mcp_enabled = True
 
     def __init__(self) -> None:
         """Initialize workflow."""

--- a/src/tests/common/test_dhcp_client.py
+++ b/src/tests/common/test_dhcp_client.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nv_config_manager.common.client.dhcp import _response_payload
+
+
+class InvalidJSONResponse:
+    async def json(self) -> Any:
+        raise json.JSONDecodeError("invalid", "not-json", 0)
+
+    async def text(self) -> str:
+        return "not-json"
+
+
+async def test_response_payload_falls_back_to_text_for_invalid_json() -> None:
+    assert await _response_payload(InvalidJSONResponse()) == "not-json"  # type: ignore[arg-type]

--- a/src/tests/common/test_oidc.py
+++ b/src/tests/common/test_oidc.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+
+from nv_config_manager.common.oidc import AuthDiscovery, OIDCAuth
+
+
+class MetadataResponse:
+    status_code = 200
+    headers: dict[str, str] = {}
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+class RedirectResponse:
+    status_code = 302
+
+    def __init__(self, location: str) -> None:
+        self.headers = {"Location": location}
+
+
+class StatusResponse:
+    headers: dict[str, str] = {}
+
+    def __init__(self, status_code: int, payload: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self.payload = payload or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            response = requests.Response()
+            response.status_code = self.status_code
+            raise requests.exceptions.HTTPError(response=response)
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+def test_provider_metadata_wins_for_endpoint_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_get(url: str, timeout: int, verify: bool | str) -> MetadataResponse:
+        calls.append({"url": url, "timeout": timeout, "verify": verify})
+        return MetadataResponse(
+            {
+                "authorization_endpoint": "https://idp.example.com/oauth2/auth",
+                "token_endpoint": "https://idp.example.com/oauth2/token",
+            }
+        )
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    auth = OIDCAuth(
+        issuer_url="https://idp.example.com/issuer",
+        client_id="client-id",
+        token_file=tmp_path / "token.json",
+        verify="/ca.pem",
+    )
+
+    assert auth._get_auth_endpoint() == "https://idp.example.com/oauth2/auth"
+    assert auth._get_token_endpoint() == "https://idp.example.com/oauth2/token"
+    assert calls == [
+        {
+            "url": "https://idp.example.com/issuer/.well-known/openid-configuration",
+            "timeout": 10,
+            "verify": "/ca.pem",
+        }
+    ]
+
+
+def test_auth_discovery_parses_public_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(
+        url: str,
+        allow_redirects: bool,
+        timeout: int,
+        verify: bool | str,
+    ) -> StatusResponse:
+        assert url == "https://config-manager.local/auth/discovery"
+        assert allow_redirects is False
+        assert timeout == 10
+        assert verify is False
+        return StatusResponse(
+            200,
+            {
+                "version": 1,
+                "authRequired": True,
+                "issuerUrl": "https://idp.example.com/realms/nvcm/",
+                "clientId": "nv-config-manager-cli",
+                "scopes": ["openid", "profile", "email"],
+                "services": {
+                    "mcp": "https://svc-mcp.config-manager.local/mcp/",
+                    "workflow": "https://svc-workflow.config-manager.local/v1/workflow/",
+                    "bad": "",
+                },
+            },
+        )
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert OIDCAuth.discover_auth_config(
+        "https://config-manager.local/auth/discovery",
+        verify=False,
+    ) == AuthDiscovery(
+        auth_required=True,
+        issuer_url="https://idp.example.com/realms/nvcm",
+        client_id="nv-config-manager-cli",
+        scopes=("openid", "profile", "email"),
+        services={
+            "mcp": "https://svc-mcp.config-manager.local/mcp",
+            "workflow": "https://svc-workflow.config-manager.local/v1/workflow",
+        },
+    )
+
+
+def test_auth_discovery_returns_none_when_endpoint_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(
+        url: str,
+        allow_redirects: bool,
+        timeout: int,
+        verify: bool | str,
+    ) -> StatusResponse:
+        return StatusResponse(404)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert OIDCAuth.discover_auth_config("https://config-manager.local/auth/discovery") is None
+
+
+def test_auth_discovery_requires_oidc_metadata_when_auth_is_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(
+        url: str,
+        allow_redirects: bool,
+        timeout: int,
+        verify: bool | str,
+    ) -> StatusResponse:
+        return StatusResponse(200, {"authRequired": True, "issuerUrl": "https://issuer"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    with pytest.raises(RuntimeError, match="clientId"):
+        OIDCAuth.discover_auth_config("https://config-manager.local/auth/discovery")
+
+
+def test_redirect_discovery_matches_keycloak_style_metadata_without_hostname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    redirect_url = (
+        "https://identity.example.test/realms/nv-config-manager/protocol/openid-connect/auth"
+        "?client_id=nv-config-manager&response_type=code"
+    )
+    metadata_url = (
+        "https://identity.example.test/realms/nv-config-manager/.well-known/openid-configuration"
+    )
+
+    def fake_get(
+        url: str,
+        allow_redirects: bool | None = None,
+        timeout: int = 10,
+        verify: bool | str = True,
+    ) -> object:
+        if url == "https://mcp.config-manager.local/mcp":
+            return RedirectResponse(redirect_url)
+        if url == metadata_url:
+            return MetadataResponse(
+                {
+                    "issuer": "https://identity.example.test/realms/nv-config-manager",
+                    "authorization_endpoint": (
+                        "https://identity.example.test/realms/nv-config-manager"
+                        "/protocol/openid-connect/auth"
+                    ),
+                    "token_endpoint": (
+                        "https://identity.example.test/realms/nv-config-manager"
+                        "/protocol/openid-connect/token"
+                    ),
+                }
+            )
+        raise requests.exceptions.ConnectionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert OIDCAuth.discover_oidc_config(
+        "https://mcp.config-manager.local/mcp",
+        verify=False,
+    ) == (
+        "https://identity.example.test/realms/nv-config-manager",
+        "nv-config-manager",
+    )
+
+
+def test_redirect_discovery_matches_azure_style_metadata_without_hostname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    redirect_url = (
+        "https://identity.example.test/tenant-id/oauth2/v2.0/authorize"
+        "?client_id=client-id&response_type=code"
+    )
+    metadata_url = "https://identity.example.test/tenant-id/v2.0/.well-known/openid-configuration"
+
+    def fake_get(
+        url: str,
+        allow_redirects: bool | None = None,
+        timeout: int = 10,
+        verify: bool | str = True,
+    ) -> object:
+        if url == "https://mcp.config-manager.local/mcp":
+            return RedirectResponse(redirect_url)
+        if url == metadata_url:
+            return MetadataResponse(
+                {
+                    "issuer": "https://identity.example.test/tenant-id/v2.0",
+                    "authorization_endpoint": (
+                        "https://identity.example.test/tenant-id/oauth2/v2.0/authorize"
+                    ),
+                    "token_endpoint": ("https://identity.example.test/tenant-id/oauth2/v2.0/token"),
+                }
+            )
+        raise requests.exceptions.ConnectionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert OIDCAuth.discover_oidc_config(
+        "https://mcp.config-manager.local/mcp",
+        verify=False,
+    ) == ("https://identity.example.test/tenant-id/v2.0", "client-id")
+
+
+def test_keycloak_fallback_uses_keycloak_oidc_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fail_metadata(url: str, timeout: int, verify: bool | str) -> MetadataResponse:
+        raise requests.exceptions.ConnectionError("metadata unavailable")
+
+    monkeypatch.setattr(requests, "get", fail_metadata)
+
+    auth = OIDCAuth(
+        issuer_url="https://keycloak.example.com/realms/nv-config-manager",
+        client_id="nv-config-manager",
+        token_file=tmp_path / "token.json",
+    )
+
+    assert (
+        auth._get_auth_endpoint()
+        == "https://keycloak.example.com/realms/nv-config-manager/protocol/openid-connect/auth"
+    )
+    assert (
+        auth._get_token_endpoint()
+        == "https://keycloak.example.com/realms/nv-config-manager/protocol/openid-connect/token"
+    )
+    assert auth.scopes == ["openid", "profile", "email"]
+
+
+def test_azure_fallback_keeps_azure_paths_and_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fail_metadata(url: str, timeout: int, verify: bool | str) -> MetadataResponse:
+        raise requests.exceptions.ConnectionError("metadata unavailable")
+
+    monkeypatch.setattr(requests, "get", fail_metadata)
+
+    auth = OIDCAuth(
+        issuer_url="https://login.microsoftonline.com/tenant-id/v2.0",
+        client_id="client-id",
+        token_file=tmp_path / "token.json",
+    )
+
+    assert auth._get_auth_endpoint() == (
+        "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/authorize"
+    )
+    assert auth._get_token_endpoint() == (
+        "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token"
+    )
+    assert auth.scopes == ["api://client-id/.default", "openid", "profile"]
+
+
+def test_generic_oidc_fallback_uses_issuer_relative_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fail_metadata(url: str, timeout: int, verify: bool | str) -> MetadataResponse:
+        raise requests.exceptions.ConnectionError("metadata unavailable")
+
+    monkeypatch.setattr(requests, "get", fail_metadata)
+
+    auth = OIDCAuth(
+        issuer_url="https://idp.example.com/oauth2/default",
+        client_id="client-id",
+        token_file=tmp_path / "token.json",
+    )
+
+    assert auth._get_auth_endpoint() == "https://idp.example.com/oauth2/default/authorize"
+    assert auth._get_token_endpoint() == "https://idp.example.com/oauth2/default/token"
+    assert auth.scopes == ["openid", "profile", "email"]

--- a/src/tests/common/test_temporal_client.py
+++ b/src/tests/common/test_temporal_client.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nv_config_manager.common.client.temporal import _response_payload
+
+
+class InvalidJSONResponse:
+    async def json(self) -> Any:
+        raise json.JSONDecodeError("invalid", "not-json", 0)
+
+    async def text(self) -> str:
+        return "not-json"
+
+
+async def test_response_payload_falls_back_to_text_for_invalid_json() -> None:
+    assert await _response_payload(InvalidJSONResponse()) == "not-json"  # type: ignore[arg-type]

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -86,6 +86,7 @@ user_domain = ztp.example.com
 grpc_service = temporal-frontend.example.local:7233
 api_service = http://temporal-api.example.local:9000
 api_url = https://temporal-api.example.com
+temporal_ui_url = https://temporal-ui.example.com
 ui_url = https://temporal-ui.example.com
 use_internal_endpoint = true
 

--- a/src/tests/mcp/__init__.py
+++ b/src/tests/mcp/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the MCP server."""

--- a/src/tests/mcp/test_auth.py
+++ b/src/tests/mcp/test_auth.py
@@ -67,13 +67,24 @@ async def test_downstream_clients_omit_auth_headers_when_auth_is_disabled(
 
 
 def test_nautobot_token_mode_uses_configured_token_without_bearer_token() -> None:
-    client = nautobot_client(_settings(nautobot_auth_mode="token", nautobot_token="ro-token"))
+    client = nautobot_client(
+        _settings(nautobot_auth_mode="token", nautobot_read_only_token="ro-token")
+    )
 
     assert client._resolve_headers() == {"Authorization": "Token ro-token"}
 
 
+def test_nautobot_token_mode_requires_read_only_token() -> None:
+    client = nautobot_client(_settings(nautobot_auth_mode="token"))
+
+    with pytest.raises(MCPAuthError, match="nautobot_read_only_token"):
+        client._resolve_headers()
+
+
 def test_nautobot_jwt_mode_does_not_fallback_to_configured_token() -> None:
-    client = nautobot_client(_settings(nautobot_auth_mode="jwt", nautobot_token="ro-token"))
+    client = nautobot_client(
+        _settings(nautobot_auth_mode="jwt", nautobot_read_only_token="ro-token")
+    )
 
     with pytest.raises(MCPAuthError, match="Bearer token"):
         client._resolve_headers()
@@ -83,7 +94,9 @@ def test_nautobot_jwt_mode_uses_configured_token_when_auth_is_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("nv_config_manager.mcp.clients.config_auth_required", lambda: False)
-    client = nautobot_client(_settings(nautobot_auth_mode="jwt", nautobot_token="ro-token"))
+    client = nautobot_client(
+        _settings(nautobot_auth_mode="jwt", nautobot_read_only_token="ro-token")
+    )
 
     assert client._resolve_headers() == {"Authorization": "Token ro-token"}
 
@@ -99,15 +112,16 @@ def test_nautobot_jwt_mode_omits_auth_when_auth_is_disabled_without_token(
 
 def _settings(
     nautobot_auth_mode: str,
-    nautobot_token: str = "",
+    nautobot_read_only_token: str = "",
     nautobot_token_fallback_enabled: bool = False,
 ) -> MCPSettings:
     return MCPSettings(
         workflow_api_url="http://workflow:9000",
+        workflow_ui_url="https://config-manager.example.test",
         config_store_api_url="http://config-store:9000",
         dhcp_api_url="http://dhcp:9000",
         nautobot_url="http://nautobot",
-        nautobot_token=nautobot_token,
+        nautobot_read_only_token=nautobot_read_only_token,
         nautobot_verify=True,
         nautobot_auth_mode=nautobot_auth_mode,
         nautobot_token_fallback_enabled=nautobot_token_fallback_enabled,

--- a/src/tests/mcp/test_auth.py
+++ b/src/tests/mcp/test_auth.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import pytest
+
+from nv_config_manager.mcp.auth import (
+    MissingBearerTokenError,
+    RequestAuth,
+    downstream_auth_headers,
+)
+from nv_config_manager.mcp.clients import (
+    MCPAuthError,
+    config_store_client,
+    dhcp_client,
+    fetch_workflows,
+    nautobot_client,
+    workflow_client,
+)
+from nv_config_manager.mcp.settings import MCPSettings
+
+
+def test_request_auth_extracts_bearer_header() -> None:
+    auth = RequestAuth.from_asgi_headers(
+        [(b"authorization", b"Bearer token-123"), (b"x-auth-request-email", b"user@example.com")]
+    )
+
+    assert auth.bearer_authorization == "Bearer token-123"
+    assert auth.identity_headers == {"X-Auth-Request-Email": "user@example.com"}
+
+
+def test_downstream_auth_headers_requires_incoming_bearer_token() -> None:
+    with pytest.raises(MissingBearerTokenError):
+        downstream_auth_headers()
+
+
+async def test_workflow_api_adapter_does_not_fallback_without_bearer_token() -> None:
+    with pytest.raises(MCPAuthError, match="Bearer token"):
+        await fetch_workflows(_settings(nautobot_auth_mode="jwt"), {})
+
+
+async def test_downstream_clients_omit_auth_headers_when_auth_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("nv_config_manager.mcp.clients.config_auth_required", lambda: False)
+    settings = _settings(nautobot_auth_mode="jwt")
+    store_client = config_store_client(settings)
+
+    assert workflow_client(settings)._resolve_headers() == {}
+    try:
+        assert store_client._resolve_headers() == {}
+    finally:
+        await store_client.close()
+    assert dhcp_client(settings)._resolve_headers() == {}
+
+
+def test_nautobot_token_mode_uses_configured_token_without_bearer_token() -> None:
+    client = nautobot_client(_settings(nautobot_auth_mode="token", nautobot_token="ro-token"))
+
+    assert client._resolve_headers() == {"Authorization": "Token ro-token"}
+
+
+def test_nautobot_jwt_mode_does_not_fallback_to_configured_token() -> None:
+    client = nautobot_client(_settings(nautobot_auth_mode="jwt", nautobot_token="ro-token"))
+
+    with pytest.raises(MCPAuthError, match="Bearer token"):
+        client._resolve_headers()
+
+
+def test_nautobot_jwt_mode_uses_configured_token_when_auth_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("nv_config_manager.mcp.clients.config_auth_required", lambda: False)
+    client = nautobot_client(_settings(nautobot_auth_mode="jwt", nautobot_token="ro-token"))
+
+    assert client._resolve_headers() == {"Authorization": "Token ro-token"}
+
+
+def test_nautobot_jwt_mode_omits_auth_when_auth_is_disabled_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("nv_config_manager.mcp.clients.config_auth_required", lambda: False)
+    client = nautobot_client(_settings(nautobot_auth_mode="jwt"))
+
+    assert client._resolve_headers() == {}
+
+
+def _settings(
+    nautobot_auth_mode: str,
+    nautobot_token: str = "",
+    nautobot_token_fallback_enabled: bool = False,
+) -> MCPSettings:
+    return MCPSettings(
+        workflow_api_url="http://workflow:9000",
+        config_store_api_url="http://config-store:9000",
+        dhcp_api_url="http://dhcp:9000",
+        nautobot_url="http://nautobot",
+        nautobot_token=nautobot_token,
+        nautobot_verify=True,
+        nautobot_auth_mode=nautobot_auth_mode,
+        nautobot_token_fallback_enabled=nautobot_token_fallback_enabled,
+        max_response_bytes=1000,
+    )

--- a/src/tests/mcp/test_cli.py
+++ b/src/tests/mcp/test_cli.py
@@ -147,6 +147,38 @@ def test_mcp_url_can_drive_endpoint_and_discovery() -> None:
     assert result.output == "access-token\n"
 
 
+def test_explicit_discovery_url_must_use_https() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        [
+            "token",
+            "-H",
+            "config-manager.example.com",
+            "--discovery-url",
+            "http://config-manager.example.com/auth/discovery",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Refusing non-HTTPS auth discovery URL" in result.output
+    assert FakeOIDCAuth.auth_discovered == []
+
+
+def test_mcp_derived_discovery_url_must_use_https() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        ["token", "--mcp-url", "http://svc-mcp.config-manager.example.com/mcp"],
+    )
+
+    assert result.exit_code != 0
+    assert "Refusing non-HTTPS auth discovery URL" in result.output
+    assert FakeOIDCAuth.auth_discovered == []
+
+
 def test_legacy_redirect_discovery_is_used_when_auth_discovery_is_unavailable() -> None:
     FakeOIDCAuth.auth_discovery_result = None
     runner = CliRunner()
@@ -307,6 +339,28 @@ def test_config_output_includes_insecure_in_token_command() -> None:
     assert (
         "nvcm-mcp-cli token --auth-mode sso "
         "--mcp-url https://svc-mcp.config-manager.example.com/mcp --insecure"
+    ) in result.output
+
+
+def test_config_output_preserves_explicit_discovery_url_in_token_command() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        [
+            "config",
+            "-H",
+            "config-manager.example.com",
+            "--discovery-url",
+            "https://gateway.example.com/auth/discovery/",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (
+        "nvcm-mcp-cli token --auth-mode sso "
+        "--mcp-url https://svc-mcp.config-manager.example.com/mcp "
+        "--discovery-url https://gateway.example.com/auth/discovery"
     ) in result.output
 
 

--- a/src/tests/mcp/test_cli.py
+++ b/src/tests/mcp/test_cli.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from nv_config_manager.mcp import cli as mcp_cli
+
+
+class FakeOIDCAuth:
+    discovered: list[tuple[str, bool]] = []
+    created: list[tuple[str, str]] = []
+    token_requests: list[bool] = []
+    discovery_result: tuple[str, str] | None = ("https://issuer.example.com", "client-id")
+
+    def __init__(self, issuer_url: str, client_id: str) -> None:
+        self.issuer_url = issuer_url
+        self.client_id = client_id
+        self.created.append((issuer_url, client_id))
+
+    @classmethod
+    def discover_oidc_config(cls, gateway_url: str, verify: bool = True) -> tuple[str, str] | None:
+        cls.discovered.append((gateway_url, verify))
+        return cls.discovery_result
+
+    def get_access_token(self, force_refresh: bool = False) -> str:
+        self.token_requests.append(force_refresh)
+        return "access-token"
+
+
+class FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_oidc(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeOIDCAuth.discovered = []
+    FakeOIDCAuth.created = []
+    FakeOIDCAuth.token_requests = []
+    FakeOIDCAuth.discovery_result = ("https://issuer.example.com", "client-id")
+    monkeypatch.setattr(mcp_cli, "OIDCAuth", FakeOIDCAuth)
+
+
+def test_endpoint_defaults_to_service_mcp_hostname() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["endpoint", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert result.output == "https://svc-mcp.config-manager.example.com/mcp\n"
+
+
+def test_discovery_defaults_to_oidc_mcp_hostname() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["token", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert result.output == "access-token\n"
+    assert FakeOIDCAuth.discovered == [("https://mcp.config-manager.example.com/mcp", True)]
+    assert FakeOIDCAuth.created == [("https://issuer.example.com", "client-id")]
+
+
+def test_mcp_url_can_drive_endpoint_and_discovery() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        ["token", "--mcp-url", "https://svc-mcp.custom.example.com/mcp/"],
+    )
+
+    assert result.exit_code == 0
+    assert FakeOIDCAuth.discovered == [("https://mcp.custom.example.com/mcp", True)]
+    assert result.output == "access-token\n"
+
+
+def test_explicit_issuer_and_client_id_skip_discovery() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        [
+            "token",
+            "-H",
+            "config-manager.example.com",
+            "--issuer",
+            "https://issuer.local",
+            "--client-id",
+            "client-local",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert FakeOIDCAuth.discovered == []
+    assert FakeOIDCAuth.created == [("https://issuer.local", "client-local")]
+
+
+def test_auto_endpoint_uses_mcp_hostname_when_sso_is_not_enabled() -> None:
+    FakeOIDCAuth.discovery_result = None
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["endpoint", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert result.output == "https://mcp.config-manager.example.com/mcp\n"
+
+
+def test_login_noops_when_sso_is_not_enabled() -> None:
+    FakeOIDCAuth.discovery_result = None
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["login", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert "no login is required" in result.output
+    assert FakeOIDCAuth.created == []
+
+
+def test_token_prints_no_secret_when_sso_is_not_enabled() -> None:
+    FakeOIDCAuth.discovery_result = None
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["token", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert (
+        result.output == "SSO is not enabled for this MCP endpoint; no bearer token is required.\n"
+    )
+    assert FakeOIDCAuth.created == []
+
+
+def test_token_force_refresh_passes_through() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        ["token", "-H", "config-manager.example.com", "--force-auth-refresh"],
+    )
+
+    assert result.exit_code == 0
+    assert FakeOIDCAuth.token_requests == [True]
+
+
+def test_config_output_is_generic() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        ["config", "-H", "config-manager.example.com", "--token-env-var", "TOKEN_ENV"],
+    )
+
+    assert result.exit_code == 0
+    assert "MCP transport: Streamable HTTP" in result.output
+    assert "MCP endpoint: https://svc-mcp.config-manager.example.com/mcp" in result.output
+    assert "Authorization: Bearer ${TOKEN_ENV}" in result.output
+    assert (
+        "nvcm-mcp-cli token --auth-mode sso "
+        "--mcp-url https://svc-mcp.config-manager.example.com/mcp"
+    ) in result.output
+    assert "agent" not in result.output.lower()
+    assert "model" not in result.output.lower()
+
+
+def test_config_output_omits_auth_when_sso_is_not_enabled() -> None:
+    FakeOIDCAuth.discovery_result = None
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["config", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert "MCP endpoint: https://mcp.config-manager.example.com/mcp" in result.output
+    assert "Authentication: none" in result.output
+    assert "No Authorization header is required." in result.output
+    assert "Bearer" not in result.output
+
+
+def test_check_validates_token_and_healthcheck(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_get(
+        url: str,
+        headers: dict[str, str],
+        timeout: int,
+        allow_redirects: bool,
+        verify: bool,
+    ) -> FakeResponse:
+        calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "timeout": timeout,
+                "allow_redirects": allow_redirects,
+                "verify": verify,
+            }
+        )
+        return FakeResponse()
+
+    monkeypatch.setattr(mcp_cli.requests, "get", fake_get)
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["check", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert calls == [
+        {
+            "url": "https://svc-mcp.config-manager.example.com/healthcheck",
+            "headers": {"Authorization": "Bearer access-token"},
+            "timeout": 10,
+            "allow_redirects": False,
+            "verify": True,
+        }
+    ]
+    assert "Healthcheck passed" in result.output

--- a/src/tests/mcp/test_cli.py
+++ b/src/tests/mcp/test_cli.py
@@ -41,7 +41,7 @@ class FakeOIDCAuth:
         issuer_url: str,
         client_id: str,
         scopes: list[str] | None = None,
-        verify: bool = True,
+        verify: bool | str = True,
     ) -> None:
         self.issuer_url = issuer_url
         self.client_id = client_id
@@ -53,13 +53,17 @@ class FakeOIDCAuth:
     def discover_auth_config(
         cls,
         discovery_url: str,
-        verify: bool = True,
+        verify: bool | str = True,
     ) -> AuthDiscovery | None:
         cls.auth_discovered.append((discovery_url, verify))
         return cls.auth_discovery_result
 
     @classmethod
-    def discover_oidc_config(cls, gateway_url: str, verify: bool = True) -> tuple[str, str] | None:
+    def discover_oidc_config(
+        cls,
+        gateway_url: str,
+        verify: bool | str = True,
+    ) -> tuple[str, str] | None:
         cls.discovered.append((gateway_url, verify))
         return cls.discovery_result
 
@@ -292,6 +296,38 @@ def test_config_output_is_generic() -> None:
     ) in result.output
     assert "agent" not in result.output.lower()
     assert "model" not in result.output.lower()
+
+
+def test_config_output_includes_insecure_in_token_command() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["config", "-H", "config-manager.example.com", "-k"])
+
+    assert result.exit_code == 0
+    assert (
+        "nvcm-mcp-cli token --auth-mode sso "
+        "--mcp-url https://svc-mcp.config-manager.example.com/mcp --insecure"
+    ) in result.output
+
+
+def test_token_rejects_http_mcp_url_when_bearer_auth_is_explicit() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        [
+            "token",
+            "--mcp-url",
+            "http://svc-mcp.config-manager.example.com/mcp",
+            "--issuer",
+            "https://issuer.example.com",
+            "--client-id",
+            "cli-client-id",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Refusing non-HTTPS MCP endpoint for bearer auth" in result.output
 
 
 def test_config_output_omits_auth_when_sso_is_not_enabled() -> None:

--- a/src/tests/mcp/test_cli.py
+++ b/src/tests/mcp/test_cli.py
@@ -19,19 +19,44 @@ from typing import Any
 import pytest
 from click.testing import CliRunner
 
+from nv_config_manager.common.oidc import AuthDiscovery
 from nv_config_manager.mcp import cli as mcp_cli
 
 
 class FakeOIDCAuth:
+    auth_discovered: list[tuple[str, bool]] = []
     discovered: list[tuple[str, bool]] = []
-    created: list[tuple[str, str]] = []
+    created: list[tuple[str, str, bool]] = []
     token_requests: list[bool] = []
+    auth_discovery_result: AuthDiscovery | None = AuthDiscovery(
+        auth_required=True,
+        issuer_url="https://issuer.example.com",
+        client_id="cli-client-id",
+        scopes=("openid", "profile", "email"),
+    )
     discovery_result: tuple[str, str] | None = ("https://issuer.example.com", "client-id")
 
-    def __init__(self, issuer_url: str, client_id: str) -> None:
+    def __init__(
+        self,
+        issuer_url: str,
+        client_id: str,
+        scopes: list[str] | None = None,
+        verify: bool = True,
+    ) -> None:
         self.issuer_url = issuer_url
         self.client_id = client_id
-        self.created.append((issuer_url, client_id))
+        self.scopes = scopes
+        self.verify = verify
+        self.created.append((issuer_url, client_id, verify))
+
+    @classmethod
+    def discover_auth_config(
+        cls,
+        discovery_url: str,
+        verify: bool = True,
+    ) -> AuthDiscovery | None:
+        cls.auth_discovered.append((discovery_url, verify))
+        return cls.auth_discovery_result
 
     @classmethod
     def discover_oidc_config(cls, gateway_url: str, verify: bool = True) -> tuple[str, str] | None:
@@ -52,9 +77,16 @@ class FakeResponse:
 
 @pytest.fixture(autouse=True)
 def reset_fake_oidc(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeOIDCAuth.auth_discovered = []
     FakeOIDCAuth.discovered = []
     FakeOIDCAuth.created = []
     FakeOIDCAuth.token_requests = []
+    FakeOIDCAuth.auth_discovery_result = AuthDiscovery(
+        auth_required=True,
+        issuer_url="https://issuer.example.com",
+        client_id="cli-client-id",
+        scopes=("openid", "profile", "email"),
+    )
     FakeOIDCAuth.discovery_result = ("https://issuer.example.com", "client-id")
     monkeypatch.setattr(mcp_cli, "OIDCAuth", FakeOIDCAuth)
 
@@ -68,6 +100,21 @@ def test_endpoint_defaults_to_service_mcp_hostname() -> None:
     assert result.output == "https://svc-mcp.config-manager.example.com/mcp\n"
 
 
+def test_endpoint_prefers_discovered_mcp_service_url() -> None:
+    FakeOIDCAuth.auth_discovery_result = AuthDiscovery(
+        auth_required=True,
+        issuer_url="https://issuer.example.com",
+        client_id="cli-client-id",
+        services={"mcp": "https://custom-svc.example.com/mcp/"},
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["endpoint", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert result.output == "https://custom-svc.example.com/mcp\n"
+
+
 def test_discovery_defaults_to_oidc_mcp_hostname() -> None:
     runner = CliRunner()
 
@@ -75,8 +122,11 @@ def test_discovery_defaults_to_oidc_mcp_hostname() -> None:
 
     assert result.exit_code == 0
     assert result.output == "access-token\n"
-    assert FakeOIDCAuth.discovered == [("https://mcp.config-manager.example.com/mcp", True)]
-    assert FakeOIDCAuth.created == [("https://issuer.example.com", "client-id")]
+    assert FakeOIDCAuth.auth_discovered == [
+        ("https://config-manager.example.com/auth/discovery", True)
+    ]
+    assert FakeOIDCAuth.discovered == []
+    assert FakeOIDCAuth.created == [("https://issuer.example.com", "cli-client-id", True)]
 
 
 def test_mcp_url_can_drive_endpoint_and_discovery() -> None:
@@ -88,8 +138,23 @@ def test_mcp_url_can_drive_endpoint_and_discovery() -> None:
     )
 
     assert result.exit_code == 0
-    assert FakeOIDCAuth.discovered == [("https://mcp.custom.example.com/mcp", True)]
+    assert FakeOIDCAuth.auth_discovered == [("https://custom.example.com/auth/discovery", True)]
+    assert FakeOIDCAuth.discovered == []
     assert result.output == "access-token\n"
+
+
+def test_legacy_redirect_discovery_is_used_when_auth_discovery_is_unavailable() -> None:
+    FakeOIDCAuth.auth_discovery_result = None
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["token", "-H", "config-manager.example.com"])
+
+    assert result.exit_code == 0
+    assert FakeOIDCAuth.auth_discovered == [
+        ("https://config-manager.example.com/auth/discovery", True)
+    ]
+    assert FakeOIDCAuth.discovered == [("https://mcp.config-manager.example.com/mcp", True)]
+    assert FakeOIDCAuth.created == [("https://issuer.example.com", "client-id", True)]
 
 
 def test_explicit_issuer_and_client_id_skip_discovery() -> None:
@@ -109,12 +174,49 @@ def test_explicit_issuer_and_client_id_skip_discovery() -> None:
     )
 
     assert result.exit_code == 0
+    assert FakeOIDCAuth.auth_discovered == []
     assert FakeOIDCAuth.discovered == []
-    assert FakeOIDCAuth.created == [("https://issuer.local", "client-local")]
+    assert FakeOIDCAuth.created == [("https://issuer.local", "client-local", True)]
+
+
+def test_client_id_can_override_discovered_gateway_client_id() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        ["token", "-H", "config-manager.example.com", "--client-id", "nv-config-manager-cli"],
+    )
+
+    assert result.exit_code == 0
+    assert FakeOIDCAuth.auth_discovered == [
+        ("https://config-manager.example.com/auth/discovery", True)
+    ]
+    assert FakeOIDCAuth.discovered == []
+    assert FakeOIDCAuth.created == [("https://issuer.example.com", "nv-config-manager-cli", True)]
+
+
+def test_sso_mode_token_discovers_oidc_for_service_mcp_url() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        mcp_cli.main,
+        [
+            "token",
+            "--auth-mode",
+            "sso",
+            "--mcp-url",
+            "https://svc-mcp.custom.example.com/mcp",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert FakeOIDCAuth.auth_discovered == [("https://custom.example.com/auth/discovery", True)]
+    assert FakeOIDCAuth.discovered == []
+    assert FakeOIDCAuth.created == [("https://issuer.example.com", "cli-client-id", True)]
 
 
 def test_auto_endpoint_uses_mcp_hostname_when_sso_is_not_enabled() -> None:
-    FakeOIDCAuth.discovery_result = None
+    FakeOIDCAuth.auth_discovery_result = AuthDiscovery(auth_required=False)
     runner = CliRunner()
 
     result = runner.invoke(mcp_cli.main, ["endpoint", "-H", "config-manager.example.com"])
@@ -124,7 +226,7 @@ def test_auto_endpoint_uses_mcp_hostname_when_sso_is_not_enabled() -> None:
 
 
 def test_login_noops_when_sso_is_not_enabled() -> None:
-    FakeOIDCAuth.discovery_result = None
+    FakeOIDCAuth.auth_discovery_result = AuthDiscovery(auth_required=False)
     runner = CliRunner()
 
     result = runner.invoke(mcp_cli.main, ["login", "-H", "config-manager.example.com"])
@@ -135,7 +237,7 @@ def test_login_noops_when_sso_is_not_enabled() -> None:
 
 
 def test_token_prints_no_secret_when_sso_is_not_enabled() -> None:
-    FakeOIDCAuth.discovery_result = None
+    FakeOIDCAuth.auth_discovery_result = AuthDiscovery(auth_required=False)
     runner = CliRunner()
 
     result = runner.invoke(mcp_cli.main, ["token", "-H", "config-manager.example.com"])
@@ -159,6 +261,19 @@ def test_token_force_refresh_passes_through() -> None:
     assert FakeOIDCAuth.token_requests == [True]
 
 
+def test_insecure_flag_applies_to_oidc_auth() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(mcp_cli.main, ["token", "-H", "config-manager.example.com", "-k"])
+
+    assert result.exit_code == 0
+    assert FakeOIDCAuth.auth_discovered == [
+        ("https://config-manager.example.com/auth/discovery", False)
+    ]
+    assert FakeOIDCAuth.discovered == []
+    assert FakeOIDCAuth.created == [("https://issuer.example.com", "cli-client-id", False)]
+
+
 def test_config_output_is_generic() -> None:
     runner = CliRunner()
 
@@ -180,7 +295,7 @@ def test_config_output_is_generic() -> None:
 
 
 def test_config_output_omits_auth_when_sso_is_not_enabled() -> None:
-    FakeOIDCAuth.discovery_result = None
+    FakeOIDCAuth.auth_discovery_result = AuthDiscovery(auth_required=False)
     runner = CliRunner()
 
     result = runner.invoke(mcp_cli.main, ["config", "-H", "config-manager.example.com"])

--- a/src/tests/mcp/test_clients.py
+++ b/src/tests/mcp/test_clients.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nv_config_manager.mcp import clients
+from nv_config_manager.mcp.settings import MCPSettings
+
+
+class FakeWorkflowClient:
+    async def __aenter__(self) -> FakeWorkflowClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def start_workflow(self, endpoint: str, payload: dict[str, Any]) -> dict[str, str]:
+        return {
+            "id": "workflow-123",
+            "href": "http://localhost:8080/namespaces/default/workflows/workflow-123",
+        }
+
+    async def get_workflow(self, workflow_id: str) -> dict[str, str]:
+        return {
+            "id": workflow_id,
+            "href": f"http://localhost:8080/namespaces/default/workflows/{workflow_id}",
+        }
+
+    async def list_workflows(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {
+            "workflows": [
+                {
+                    "id": "workflow-123",
+                    "href": "http://localhost:8080/namespaces/default/workflows/workflow-123",
+                }
+            ],
+            "next_page_token": None,
+        }
+
+
+@pytest.fixture
+def settings() -> MCPSettings:
+    return MCPSettings(
+        workflow_api_url="http://workflow:9000",
+        workflow_ui_url="https://config-manager.example.test",
+        config_store_api_url="http://config-store:9000",
+        dhcp_api_url="http://dhcp:9000",
+        nautobot_url="http://nautobot",
+        nautobot_read_only_token="token",
+        nautobot_verify=True,
+        nautobot_auth_mode="jwt",
+        nautobot_token_fallback_enabled=False,
+        max_response_bytes=10_000,
+    )
+
+
+@pytest.fixture(autouse=True)
+def fake_workflow_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(clients, "workflow_client", lambda settings: FakeWorkflowClient())
+
+
+async def test_start_workflow_adds_config_manager_ui_href(settings: MCPSettings) -> None:
+    result = await clients.start_workflow(settings, "/ngc/backup", {"device_id": "device-1"})
+
+    assert result["data"] == {
+        "id": "workflow-123",
+        "href": "http://localhost:8080/namespaces/default/workflows/workflow-123",
+        "temporal_href": "http://localhost:8080/namespaces/default/workflows/workflow-123",
+        "ui_href": "https://config-manager.example.test/workflows/workflow-123",
+    }
+
+
+async def test_workflow_detail_adds_config_manager_ui_href(settings: MCPSettings) -> None:
+    result = await clients.fetch_workflow_detail(settings, "workflow-456")
+
+    assert result["data"]["ui_href"] == "https://config-manager.example.test/workflows/workflow-456"
+    assert result["data"]["temporal_href"] == (
+        "http://localhost:8080/namespaces/default/workflows/workflow-456"
+    )
+
+
+async def test_workflow_list_adds_config_manager_ui_href(settings: MCPSettings) -> None:
+    result = await clients.fetch_workflows(settings, {})
+
+    workflow = result["data"]["workflows"][0]
+    assert workflow["ui_href"] == "https://config-manager.example.test/workflows/workflow-123"
+    assert workflow["temporal_href"] == (
+        "http://localhost:8080/namespaces/default/workflows/workflow-123"
+    )

--- a/src/tests/mcp/test_clients.py
+++ b/src/tests/mcp/test_clients.py
@@ -74,6 +74,10 @@ def fake_workflow_client(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(clients, "workflow_client", lambda settings: FakeWorkflowClient())
 
 
+def test_redact_text_handles_single_line_secret_assignments() -> None:
+    assert clients.redact_text("token = secret-value") == "token = <redacted>"
+
+
 async def test_start_workflow_adds_config_manager_ui_href(settings: MCPSettings) -> None:
     result = await clients.start_workflow(settings, "/ngc/backup", {"device_id": "device-1"})
 

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from nv_config_manager.mcp.main import create_app
+from nv_config_manager.mcp.settings import MCPSettings
+
+
+def test_healthcheck() -> None:
+    settings = _settings()
+
+    client = TestClient(create_app(settings))
+    response = client.get("/healthcheck")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+def test_mcp_endpoint_accepts_gateway_host_without_auth() -> None:
+    with TestClient(
+        create_app(_settings()),
+        base_url="http://mcp.config-manager.local",
+    ) as client:
+        response = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "0.0.0"},
+                },
+            },
+        )
+
+    assert response.status_code == 200
+
+
+def _settings() -> MCPSettings:
+    return MCPSettings(
+        workflow_api_url="http://workflow:9000",
+        config_store_api_url="http://config-store:9000",
+        dhcp_api_url="http://dhcp:9000",
+        nautobot_url="http://nautobot",
+        nautobot_token="token",
+        nautobot_verify=True,
+        nautobot_auth_mode="jwt",
+        nautobot_token_fallback_enabled=False,
+        max_response_bytes=1000,
+    )

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+import pytest
+from fastapi import HTTPException
 from starlette.testclient import TestClient
 
 from nv_config_manager.mcp.main import create_app
@@ -30,7 +32,9 @@ def test_healthcheck() -> None:
     assert response.json() == {"status": "healthy"}
 
 
-def test_mcp_endpoint_accepts_gateway_host_without_auth() -> None:
+def test_mcp_endpoint_accepts_gateway_host_without_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nv_config_manager.common.auth.auth_required", lambda: False)
+
     with TestClient(
         create_app(_settings()),
         base_url="http://mcp.config-manager.local",
@@ -56,13 +60,49 @@ def test_mcp_endpoint_accepts_gateway_host_without_auth() -> None:
     assert response.status_code == 200
 
 
+def test_mcp_endpoint_requires_auth_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def reject_identity(request: object) -> object:
+        raise HTTPException(status_code=403, detail="This endpoint requires SSO authentication.")
+
+    monkeypatch.setattr(
+        "nv_config_manager.mcp.auth.require_authenticated_identity",
+        reject_identity,
+    )
+
+    with TestClient(
+        create_app(_settings()),
+        base_url="http://svc-mcp.config-manager.local",
+    ) as client:
+        response = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "0.0.0"},
+                },
+            },
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "This endpoint requires SSO authentication."}
+
+
 def _settings() -> MCPSettings:
     return MCPSettings(
         workflow_api_url="http://workflow:9000",
+        workflow_ui_url="https://config-manager.example.test",
         config_store_api_url="http://config-store:9000",
         dhcp_api_url="http://dhcp:9000",
         nautobot_url="http://nautobot",
-        nautobot_token="token",
+        nautobot_read_only_token="token",
         nautobot_verify=True,
         nautobot_auth_mode="jwt",
         nautobot_token_fallback_enabled=False,

--- a/src/tests/mcp/test_settings.py
+++ b/src/tests/mcp/test_settings.py
@@ -24,10 +24,12 @@ def _config(nautobot_server: str, auth_mode: str = "auto") -> ConfigParser:
     config["mcp"] = {
         "use_internal_endpoints": "true",
         "nautobot_auth_mode": auth_mode,
+        "nautobot_read_only_token": "read-only-token",
     }
     config["temporal"] = {
         "api_service": "http://workflow:9000",
         "api_url": "https://workflow.example.test",
+        "ui_url": "https://config-manager.example.test",
     }
     config["config_store.client"] = {
         "api_service": "http://config-store:9000",
@@ -39,7 +41,7 @@ def _config(nautobot_server: str, auth_mode: str = "auto") -> ConfigParser:
     }
     config["nautobot"] = {
         "server": nautobot_server,
-        "token": "read-only-token",
+        "token": "rw-token",
         "verify": "true",
     }
     return config
@@ -49,15 +51,36 @@ def test_nautobot_auth_auto_uses_jwt_for_local_nautobot() -> None:
     settings = MCPSettings.from_config(_config("http://nv-config-manager-nautobot"))
 
     assert settings.nautobot_auth_mode == "jwt"
+    assert settings.workflow_ui_url == "https://config-manager.example.test"
 
 
 def test_nautobot_auth_auto_uses_token_for_external_nautobot() -> None:
     settings = MCPSettings.from_config(_config("https://nautobot.example.test"))
 
     assert settings.nautobot_auth_mode == "token"
+    assert settings.nautobot_read_only_token == "read-only-token"
+
+
+def test_nautobot_read_only_token_does_not_fallback_to_rw_token() -> None:
+    config = _config("https://nautobot.example.test")
+    del config["mcp"]["nautobot_read_only_token"]
+
+    settings = MCPSettings.from_config(config)
+
+    assert settings.nautobot_auth_mode == "token"
+    assert settings.nautobot_read_only_token == ""
 
 
 def test_nautobot_auth_explicit_override() -> None:
     settings = MCPSettings.from_config(_config("https://nautobot.example.test", auth_mode="jwt"))
 
     assert settings.nautobot_auth_mode == "jwt"
+
+
+def test_workflow_ui_url_falls_back_to_base_hostname() -> None:
+    config = _config("http://nv-config-manager-nautobot")
+    del config["temporal"]["ui_url"]
+
+    settings = MCPSettings.from_config(config)
+
+    assert settings.workflow_ui_url == "https://example.test"

--- a/src/tests/mcp/test_settings.py
+++ b/src/tests/mcp/test_settings.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from configparser import ConfigParser
+
+from nv_config_manager.mcp.settings import MCPSettings
+
+
+def _config(nautobot_server: str, auth_mode: str = "auto") -> ConfigParser:
+    config = ConfigParser()
+    config["mcp"] = {
+        "use_internal_endpoints": "true",
+        "nautobot_auth_mode": auth_mode,
+    }
+    config["temporal"] = {
+        "api_service": "http://workflow:9000",
+        "api_url": "https://workflow.example.test",
+    }
+    config["config_store.client"] = {
+        "api_service": "http://config-store:9000",
+        "api_url": "https://config-store.example.test",
+    }
+    config["dhcp"] = {
+        "api_service": "http://dhcp:9000",
+        "api_url": "https://dhcp.example.test",
+    }
+    config["nautobot"] = {
+        "server": nautobot_server,
+        "token": "read-only-token",
+        "verify": "true",
+    }
+    return config
+
+
+def test_nautobot_auth_auto_uses_jwt_for_local_nautobot() -> None:
+    settings = MCPSettings.from_config(_config("http://nv-config-manager-nautobot"))
+
+    assert settings.nautobot_auth_mode == "jwt"
+
+
+def test_nautobot_auth_auto_uses_token_for_external_nautobot() -> None:
+    settings = MCPSettings.from_config(_config("https://nautobot.example.test"))
+
+    assert settings.nautobot_auth_mode == "token"
+
+
+def test_nautobot_auth_explicit_override() -> None:
+    settings = MCPSettings.from_config(_config("https://nautobot.example.test", auth_mode="jwt"))
+
+    assert settings.nautobot_auth_mode == "jwt"

--- a/src/tests/mcp/test_tools.py
+++ b/src/tests/mcp/test_tools.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from nv_config_manager.mcp import tools
+from nv_config_manager.mcp.settings import MCPSettings
+from nv_config_manager.mcp.workflows import MCPWorkflow
+
+
+class FakeServer:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., Any]] = {}
+
+    def tool(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(function: Callable[..., Any]) -> Callable[..., Any]:
+            self.tools[name or function.__name__] = function
+            return function
+
+        return decorator
+
+
+class WorkflowInput(BaseModel):
+    device_id: str
+
+
+@pytest.fixture
+def settings() -> MCPSettings:
+    return MCPSettings(
+        workflow_api_url="http://workflow:9000",
+        workflow_ui_url="https://config-manager.example.test",
+        config_store_api_url="http://config-store:9000",
+        dhcp_api_url="http://dhcp:9000",
+        nautobot_url="http://nautobot",
+        nautobot_read_only_token="token",
+        nautobot_verify=True,
+        nautobot_auth_mode="jwt",
+        nautobot_token_fallback_enabled=False,
+        max_response_bytes=10_000,
+    )
+
+
+async def test_workflow_starter_promotes_config_manager_ui_href(
+    monkeypatch: pytest.MonkeyPatch,
+    settings: MCPSettings,
+) -> None:
+    async def fake_start_workflow(
+        settings: MCPSettings,
+        endpoint: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "truncated": False,
+            "data": {
+                "id": "workflow-123",
+                "ui_href": "https://config-manager.example.test/workflows/workflow-123",
+            },
+        }
+
+    monkeypatch.setattr(tools, "start_workflow", fake_start_workflow)
+    server = FakeServer()
+    workflow = MCPWorkflow(
+        tool_name="run_backup",
+        workflow_name="BackupWorkflow",
+        description="Run a backup.",
+        endpoint="/ngc/backup",
+        input_class=WorkflowInput,
+    )
+
+    tools._register_workflow_starter(server, settings, workflow)
+    result = await server.tools["run_backup"]({"device_id": "device-1"})
+
+    assert result["workflow_id"] == "workflow-123"
+    assert result["workflow_ui_href"] == (
+        "https://config-manager.example.test/workflows/workflow-123"
+    )
+    assert "workflow_ui_href" in (server.tools["run_backup"].__doc__ or "")
+
+
+async def test_related_mcp_servers_includes_public_docs(
+    monkeypatch: pytest.MonkeyPatch,
+    settings: MCPSettings,
+) -> None:
+    monkeypatch.setattr(tools, "discover_mcp_workflows", lambda: [])
+    server = FakeServer()
+
+    tools.register_tools(server, settings)
+    result = await server.tools["list_related_mcp_servers"]()
+
+    assert result["servers"] == [
+        {
+            "name": "nvidia-config-manager-public-docs",
+            "url": tools.PUBLIC_DOCS_MCP_SERVER_URL,
+            "purpose": (
+                "Public NVIDIA Config Manager documentation. Use this server for "
+                "product documentation, usage guidance, and conceptual reference."
+            ),
+            "authentication": "none",
+            "notes": (
+                "Connect the MCP-capable client directly to this URL; the operational "
+                "Config Manager MCP server does not proxy public documentation tools."
+            ),
+        }
+    ]

--- a/src/tests/mcp/test_tools.py
+++ b/src/tests/mcp/test_tools.py
@@ -123,3 +123,36 @@ async def test_related_mcp_servers_includes_public_docs(
             ),
         }
     ]
+
+
+async def test_list_nautobot_types_preserves_upstream_truncation(
+    monkeypatch: pytest.MonkeyPatch,
+    settings: MCPSettings,
+) -> None:
+    async def fake_nautobot_graphql_query(
+        settings: MCPSettings,
+        query: str,
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "truncated": True,
+            "data": {
+                "data": {
+                    "__schema": {
+                        "types": [
+                            {"name": "Device", "kind": "OBJECT", "description": "Device type"}
+                        ]
+                    }
+                }
+            },
+        }
+
+    monkeypatch.setattr(tools, "discover_mcp_workflows", lambda: [])
+    monkeypatch.setattr(tools, "nautobot_graphql_query", fake_nautobot_graphql_query)
+    server = FakeServer()
+
+    tools.register_tools(server, settings)
+    result = await server.tools["list_nautobot_types"]()
+
+    assert result["truncated"] is True
+    assert result["data"]["types"][0]["name"] == "Device"

--- a/src/tests/mcp/test_workflows.py
+++ b/src/tests/mcp/test_workflows.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from nv_config_manager.mcp.workflows import discover_mcp_workflows, normalize_workflow_parameters
+
+
+def test_only_safe_diagnostic_workflows_are_mcp_enabled() -> None:
+    workflows = discover_mcp_workflows()
+    tool_names = {workflow.tool_name for workflow in workflows}
+
+    assert {
+        "run_backup",
+        "run_port_lldp_info",
+        "run_connected_host_metadata",
+        "run_device_cable_validation",
+        "run_site_cable_validation",
+        "run_cumulus_hardware_validation",
+        "run_infiniband_cable_validation",
+        "run_infiniband_get_unhealthy_ports",
+    }.issubset(tool_names)
+    assert "run_deploy" not in tool_names
+    assert "run_reprovision" not in tool_names
+    assert "run_switch_os_upgrade" not in tool_names
+    assert "run_device_password_rotation" not in tool_names
+    assert "run_vpc_creation" not in tool_names
+
+
+def test_workflow_parameter_normalization_fills_existing_nullable_bookkeeping() -> None:
+    workflow = next(item for item in discover_mcp_workflows() if item.tool_name == "run_backup")
+
+    normalized = normalize_workflow_parameters(workflow, {"device_id": "device-1"})
+
+    assert normalized["device_id"] == "device-1"
+    assert normalized["trigger"] == "API"
+    assert normalized["user"] is None
+    assert normalized["user_domain"] is None
+    assert normalized["workflow_id"] is None
+    assert normalized["intended_config_commit_id"] is None

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from configparser import ConfigParser
 from datetime import datetime
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -54,8 +55,21 @@ def test_healthcheck():
 def test_temporal_ui_workflow_href_uses_ini(monkeypatch):
     """Verify Workflow API href generation reads the INI, not TEMPORAL_UI."""
     monkeypatch.setenv("TEMPORAL_UI", "http://localhost:8080")
+    config = ConfigParser()
+    config.read_dict({"temporal": {"temporal_ui_url": "https://temporal-ui.example.com"}})
 
-    assert temporal_ui_workflow_href("workflow-id") == f"{TEMPORAL_UI_WORKFLOW_BASE}/workflow-id"
+    assert (
+        temporal_ui_workflow_href("workflow-id", config=config)
+        == f"{TEMPORAL_UI_WORKFLOW_BASE}/workflow-id"
+    )
+
+
+def test_temporal_ui_workflow_href_returns_empty_without_ini_url():
+    """Verify missing Temporal UI URL does not raise after workflow start."""
+    config = ConfigParser()
+    config.read_dict({"temporal": {}})
+
+    assert temporal_ui_workflow_href("workflow-id", config=config) == ""
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -21,6 +21,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from temporalio.client import WorkflowExecutionStatus, WorkflowHandle
 
+from nv_config_manager.temporal.api.links import temporal_ui_workflow_href
 from nv_config_manager.temporal.api.main import app
 from nv_config_manager.temporal.api.workflow_v1 import (
     WorkflowSummaryResponse,
@@ -39,6 +40,8 @@ from nv_config_manager.temporal.hello_world.workflows.hello_world_workflow impor
 )
 from nv_config_manager.temporal.ngc.workflows.deploy import DeployInput, DeployWorkflow
 
+TEMPORAL_UI_WORKFLOW_BASE = "https://temporal-ui.example.com/namespaces/default/workflows"
+
 
 def test_healthcheck():
     """Verify healthcheck."""
@@ -46,6 +49,13 @@ def test_healthcheck():
     rsp = client.get("/healthcheck")
     assert rsp.status_code == 200
     assert rsp.json() == "OK"
+
+
+def test_temporal_ui_workflow_href_uses_ini(monkeypatch):
+    """Verify Workflow API href generation reads the INI, not TEMPORAL_UI."""
+    monkeypatch.setenv("TEMPORAL_UI", "http://localhost:8080")
+
+    assert temporal_ui_workflow_href("workflow-id") == f"{TEMPORAL_UI_WORKFLOW_BASE}/workflow-id"
 
 
 @pytest.mark.asyncio
@@ -164,7 +174,7 @@ async def test_hello_world_workflow(mock_rbac_config, mock_uuid, mock_get_client
     rsp = client.post("/v1/workflow/hello_world", json={"name": "test"})
     assert rsp.json() == {
         "id": "mockuuid",
-        "href": "http://localhost:8080/namespaces/default/workflows/mockuuid",
+        "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/mockuuid",
     }
 
 
@@ -191,7 +201,7 @@ async def test_hello_world_approval_workflow(mock_rbac_config, mock_uuid, mock_g
     rsp = client.post("/v1/workflow/hello_world_approval", json={"name": "test"})
     assert rsp.json() == {
         "id": "mockuuid",
-        "href": "http://localhost:8080/namespaces/default/workflows/mockuuid",
+        "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/mockuuid",
     }
 
 
@@ -205,7 +215,7 @@ async def test_approve(mock_signal):
     rsp = client.post(f"/v1/workflow/{workflow_id}/approve/prompt")
     assert rsp.json() == {
         "id": workflow_id,
-        "href": f"http://localhost:8080/namespaces/default/workflows/{workflow_id}",
+        "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/{workflow_id}",
     }
 
     mock_signal.assert_called_with(
@@ -226,7 +236,7 @@ async def test_reject(mock_signal):
     rsp = client.post(f"/v1/workflow/{workflow_id}/reject/prompt")
     assert rsp.json() == {
         "id": workflow_id,
-        "href": f"http://localhost:8080/namespaces/default/workflows/{workflow_id}",
+        "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/{workflow_id}",
     }
 
     mock_signal.assert_called_with(
@@ -247,7 +257,7 @@ async def test_retry(mock_signal):
     rsp = client.post(f"/v1/workflow/{workflow_id}/retry/prompt")
     assert rsp.json() == {
         "id": workflow_id,
-        "href": f"http://localhost:8080/namespaces/default/workflows/{workflow_id}",
+        "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/{workflow_id}",
     }
 
     mock_signal.assert_called_with(ANY, workflow_id, "retry", "prompt")
@@ -288,7 +298,7 @@ async def test_terminate_success(mock_client, mock_redis):
     assert rsp.status_code == 200
     assert rsp.json() == {
         "id": workflow_id,
-        "href": f"http://localhost:8080/namespaces/default/workflows/{workflow_id}",
+        "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/{workflow_id}",
     }
     mock_handle.terminate.assert_called_once()
     mock_redis.from_config.return_value.delete_cached_query.assert_any_await(
@@ -618,7 +628,7 @@ async def test_workflow_detail(mock_redis, mock_client):
             "ReadRoles": ["ngc-cfa"],
             "ExecuteRoles": ["ngc-cfa"],
         },
-        "href": "http://localhost:8080/namespaces/default/workflows/mockid",
+        "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/mockid",
     }
 
 
@@ -926,7 +936,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
                 "pending_approval": True,
                 "failed_stage": False,
                 "search_attributes": {"User": ["test"]},
-                "href": "http://localhost:8080/namespaces/default/workflows/mock_uuid1",
+                "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/mock_uuid1",
             },
             {
                 "id": "mock_uuid2",
@@ -939,7 +949,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
                 "pending_approval": True,
                 "failed_stage": False,
                 "search_attributes": {"User": ["test"]},
-                "href": "http://localhost:8080/namespaces/default/workflows/mock_uuid2",
+                "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/mock_uuid2",
             },
             {
                 "id": "mock_uuid3",
@@ -952,7 +962,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
                 "pending_approval": True,
                 "failed_stage": False,
                 "search_attributes": {"User": ["test"]},
-                "href": "http://localhost:8080/namespaces/default/workflows/mock_uuid3",
+                "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/mock_uuid3",
             },
         ],
         "next_page_token": None,
@@ -1320,6 +1330,7 @@ def test_cors_middleware_configured(custom_ini):
         grpc_service = temporal:7233
         api_service = http://temporal-api:9000
         api_url = https://temporal-api.example.com
+        temporal_ui_url = https://temporal-ui.example.com
         ui_url = https://temporal-ui.example.com
         use_internal_endpoint = true
         """
@@ -1360,6 +1371,7 @@ def test_cors_middleware_not_configured_when_section_missing(custom_ini):
         grpc_service = temporal:7233
         api_service = http://temporal-api:9000
         api_url = https://temporal-api.example.com
+        temporal_ui_url = https://temporal-ui.example.com
         ui_url = https://temporal-ui.example.com
         use_internal_endpoint = true
         """

--- a/src/tests/temporal/ngc/activities/test_nautobot.py
+++ b/src/tests/temporal/ngc/activities/test_nautobot.py
@@ -536,6 +536,8 @@ async def test_load_config_manager_plugin_backup_config():
             config = await client.load_config_manager_plugin_backup_config("device-1")
 
         assert config["commit_id"] == 12345
+        request_call = next(iter(m.requests.values()))[0]
+        assert request_call.kwargs["headers"] == {"Authorization": "Token DUMMY"}
 
 
 @pytest.mark.asyncio
@@ -576,6 +578,9 @@ async def test_update_config_manager_plugin_backup_config():
                 commit_message="Updated config",
                 workflow_id="workflow-1",
             )
+
+        request_call = next(iter(m.requests.values()))[0]
+        assert request_call.kwargs["headers"] == {"Authorization": "Token DUMMY"}
 
 
 def test_get_device_ui_url():

--- a/src/tests/temporal/test_cli_auth_discovery.py
+++ b/src/tests/temporal/test_cli_auth_discovery.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import pytest
+
+from nv_config_manager.common.oidc import AuthDiscovery
+from nv_config_manager.temporal import cli as temporal_cli
+
+
+class FakeOIDCAuth:
+    auth_discovered: list[tuple[str, bool]] = []
+    redirect_discovered: list[tuple[str, bool]] = []
+    created: list[dict[str, object]] = []
+    auth_discovery_result: AuthDiscovery | None = AuthDiscovery(
+        auth_required=True,
+        issuer_url="https://issuer.example.com",
+        client_id="workflow-cli-client",
+        scopes=("openid", "profile", "email"),
+        services={"workflow": "https://workflow-api.example.com/v1/workflow/"},
+    )
+    redirect_discovery_result: tuple[str, str] | None = (
+        "https://issuer.example.com",
+        "gateway-client",
+    )
+
+    def __init__(
+        self,
+        issuer_url: str,
+        client_id: str,
+        scopes: list[str] | None = None,
+        verify: bool = True,
+    ) -> None:
+        self.issuer_url = issuer_url
+        self.client_id = client_id
+        self.scopes = scopes
+        self.verify = verify
+        self.created.append(
+            {
+                "issuer_url": issuer_url,
+                "client_id": client_id,
+                "scopes": scopes,
+                "verify": verify,
+            }
+        )
+
+    @classmethod
+    def discover_auth_config(
+        cls,
+        discovery_url: str,
+        verify: bool = True,
+    ) -> AuthDiscovery | None:
+        cls.auth_discovered.append((discovery_url, verify))
+        return cls.auth_discovery_result
+
+    @classmethod
+    def discover_oidc_config(
+        cls,
+        gateway_url: str,
+        verify: bool = True,
+    ) -> tuple[str, str] | None:
+        cls.redirect_discovered.append((gateway_url, verify))
+        return cls.redirect_discovery_result
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_oidc(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeOIDCAuth.auth_discovered = []
+    FakeOIDCAuth.redirect_discovered = []
+    FakeOIDCAuth.created = []
+    FakeOIDCAuth.auth_discovery_result = AuthDiscovery(
+        auth_required=True,
+        issuer_url="https://issuer.example.com",
+        client_id="workflow-cli-client",
+        scopes=("openid", "profile", "email"),
+        services={"workflow": "https://workflow-api.example.com/v1/workflow/"},
+    )
+    FakeOIDCAuth.redirect_discovery_result = ("https://issuer.example.com", "gateway-client")
+    monkeypatch.setattr(temporal_cli, "OIDCAuth", FakeOIDCAuth)
+
+
+def test_build_auth_uses_base_auth_discovery() -> None:
+    auth, workflow_url = temporal_cli._build_auth(
+        base_hostname="config-manager.example.com",
+        issuer=None,
+        client_id=None,
+        insecure=True,
+    )
+
+    assert auth is not None
+    assert workflow_url == "https://workflow-api.example.com/v1/workflow"
+    assert FakeOIDCAuth.auth_discovered == [
+        ("https://config-manager.example.com/auth/discovery", False)
+    ]
+    assert FakeOIDCAuth.redirect_discovered == []
+    assert FakeOIDCAuth.created == [
+        {
+            "issuer_url": "https://issuer.example.com",
+            "client_id": "workflow-cli-client",
+            "scopes": ["openid", "profile", "email"],
+            "verify": False,
+        }
+    ]
+
+
+def test_build_auth_returns_regular_workflow_url_when_auth_is_disabled() -> None:
+    FakeOIDCAuth.auth_discovery_result = AuthDiscovery(
+        auth_required=False,
+        services={"workflow": "https://workflow.config-manager.example.com/v1/workflow/"},
+    )
+
+    auth, workflow_url = temporal_cli._build_auth(
+        base_hostname="config-manager.example.com",
+        issuer=None,
+        client_id=None,
+        insecure=False,
+    )
+
+    assert auth is None
+    assert workflow_url == "https://workflow.config-manager.example.com/v1/workflow"
+    assert FakeOIDCAuth.created == []
+
+
+def test_build_auth_falls_back_to_redirect_discovery() -> None:
+    FakeOIDCAuth.auth_discovery_result = None
+
+    auth, workflow_url = temporal_cli._build_auth(
+        base_hostname="config-manager.example.com",
+        issuer=None,
+        client_id=None,
+        insecure=False,
+    )
+
+    assert auth is not None
+    assert workflow_url == "https://svc-workflow.config-manager.example.com/v1/workflow"
+    assert FakeOIDCAuth.redirect_discovered == [
+        ("https://workflow.config-manager.example.com/v1/workflow", True)
+    ]
+    assert FakeOIDCAuth.created == [
+        {
+            "issuer_url": "https://issuer.example.com",
+            "client_id": "gateway-client",
+            "scopes": None,
+            "verify": True,
+        }
+    ]

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -6,7 +6,7 @@
 #
 # Notes:
 # - Variables WITHOUT `NEXT_PUBLIC_` are read server-side by /api/config (app/api/config/route.ts)
-#   and exposed to the client through that endpoint at runtime. No browser exposure.
+#   and are not inlined into the browser bundle. Values returned by /api/config are visible to clients.
 # - Variables WITH `NEXT_PUBLIC_` are inlined into the client bundle at build time.
 
 # ---------------------------------------------------------------------------

--- a/ui/src/app/auth/discovery/route.ts
+++ b/ui/src/app/auth/discovery/route.ts
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NextResponse } from "next/server";
+
+type AuthDiscovery = {
+  version: 1;
+  authRequired: boolean;
+  issuerUrl?: string;
+  clientId?: string;
+  scopes?: string[];
+  services: Record<string, string>;
+};
+
+const normalizeUrl = (value?: string): string => (value || "").replace(/\/+$/, "");
+
+const appendPath = (baseUrl: string, path: string): string => {
+  const normalizedBase = normalizeUrl(baseUrl);
+  if (!normalizedBase) {
+    return "";
+  }
+  return `${normalizedBase}${path}`;
+};
+
+const parseScopes = (value?: string): string[] => {
+  if (!value?.trim()) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((item) => String(item).trim())
+        .filter((item) => item.length > 0);
+    }
+  } catch {
+    // Fall through to delimiter parsing.
+  }
+
+  return value
+    .replace(/,/g, " ")
+    .split(/\s+/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+};
+
+const serviceUrls = (authRequired: boolean): Record<string, string> => {
+  const workflowUrl = authRequired
+    ? normalizeUrl(process.env.SVC_WORKFLOW_API_URL) ||
+      appendPath(process.env.WORKFLOW_API_URL || "", "/v1/workflow")
+    : appendPath(process.env.WORKFLOW_API_URL || "", "/v1/workflow");
+
+  const mcpUrl = authRequired
+    ? normalizeUrl(process.env.SVC_MCP_URL) || normalizeUrl(process.env.MCP_URL)
+    : normalizeUrl(process.env.MCP_URL);
+
+  return Object.fromEntries(
+    Object.entries({
+      workflow: workflowUrl,
+      mcp: mcpUrl,
+    }).filter(([, value]) => value.length > 0),
+  );
+};
+
+export async function GET() {
+  const authRequired = process.env.OIDC_ENABLED === "true";
+  const response: AuthDiscovery = {
+    version: 1,
+    authRequired,
+    services: serviceUrls(authRequired),
+  };
+
+  if (authRequired) {
+    response.issuerUrl = normalizeUrl(process.env.OIDC_ISSUER_URL);
+    response.clientId =
+      process.env.OIDC_CLI_CLIENT_ID || process.env.OIDC_CLIENT_ID || "";
+    response.scopes = parseScopes(process.env.OIDC_SCOPES);
+  }
+
+  return NextResponse.json(response, {
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export const dynamic = "force-dynamic";

--- a/ui/src/app/auth/discovery/route.ts
+++ b/ui/src/app/auth/discovery/route.ts
@@ -85,9 +85,25 @@ export async function GET() {
   };
 
   if (authRequired) {
-    response.issuerUrl = normalizeUrl(process.env.OIDC_ISSUER_URL);
-    response.clientId =
+    const issuerUrl = normalizeUrl(process.env.OIDC_ISSUER_URL);
+    const clientId =
       process.env.OIDC_CLI_CLIENT_ID || process.env.OIDC_CLIENT_ID || "";
+    if (!issuerUrl || !clientId) {
+      return NextResponse.json(
+        {
+          error:
+            "OIDC discovery misconfigured: missing OIDC_ISSUER_URL or OIDC_CLI_CLIENT_ID/OIDC_CLIENT_ID",
+        },
+        {
+          status: 500,
+          headers: {
+            "Cache-Control": "no-store",
+          },
+        },
+      );
+    }
+    response.issuerUrl = issuerUrl;
+    response.clientId = clientId;
     response.scopes = parseScopes(process.env.OIDC_SCOPES);
   }
 

--- a/ui/src/app/workflows/ibpkeycreationworkflow/form/ib-pkey-creation-form.tsx
+++ b/ui/src/app/workflows/ibpkeycreationworkflow/form/ib-pkey-creation-form.tsx
@@ -57,10 +57,11 @@ export const IBPKeyCreationWorkflowForm = () => {
   });
 
   const pkeyValue = form.watch("pkey");
+  const normalizedPkeyValue = pkeyValue?.trim() ?? "";
   const pkeyHint =
-    pkeyValue && !PKEY_HINT_PATTERN.test(pkeyValue)
+    normalizedPkeyValue && !PKEY_HINT_PATTERN.test(normalizedPkeyValue)
       ? "Expected format: 0x followed by 1-4 hex digits (e.g. 0x8001). Server will reject if invalid."
-      : pkeyValue
+      : normalizedPkeyValue
         ? "Will be canonicalized server-side to 0xNNNN."
         : "Leave blank to auto-assign the next free PKey.";
 

--- a/ui/src/mocks/handlers/ibPkeyCreationHandlers.ts
+++ b/ui/src/mocks/handlers/ibPkeyCreationHandlers.ts
@@ -30,6 +30,7 @@ export const ibPkeyCreationHandlers = [
     sanitizeUrl(`${apiURL}/v1/workflow/ngc/ib_pkey_creation`),
     async ({ request }) => {
       const body = (await request.json()) as IBPKeyCreationRequest;
+      const normalizedPkey = body.pkey?.trim();
 
       if (!body.host) {
         return HttpResponse.json(
@@ -38,7 +39,7 @@ export const ibPkeyCreationHandlers = [
         );
       }
 
-      if (body.pkey && !PKEY_PATTERN.test(body.pkey)) {
+      if (normalizedPkey && !PKEY_PATTERN.test(normalizedPkey)) {
         return HttpResponse.json(
           { error: "pkey must match /^0[xX][0-9a-fA-F]{1,4}$/" },
           { status: 400 },
@@ -48,11 +49,18 @@ export const ibPkeyCreationHandlers = [
       await delay(1500);
 
       const workflowId = `ib-pkey-creation-${Date.now()}`;
+      const submittedData: IBPKeyCreationRequest = { ...body };
+      if (normalizedPkey) {
+        submittedData.pkey = normalizedPkey;
+      } else {
+        delete submittedData.pkey;
+      }
+
       return HttpResponse.json(
         {
           id: workflowId,
           href: `https://url-to-temporal.com/namespaces/default/workflows/${workflowId}`,
-          submitted_data: body,
+          submitted_data: submittedData,
         },
         { status: 201 },
       );

--- a/uv.lock
+++ b/uv.lock
@@ -1252,6 +1252,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "hvac"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1375,6 +1384,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1620,6 +1656,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]
@@ -2096,6 +2157,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "macaddress" },
     { name = "mako" },
+    { name = "mcp" },
     { name = "mkdocs" },
     { name = "nats-py", extra = ["nkeys"] },
     { name = "netaddr" },
@@ -2200,6 +2262,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.2" },
     { name = "macaddress", specifier = ">=2.0.2" },
     { name = "mako", specifier = ">=1.3.12" },
+    { name = "mcp", specifier = ">=1.8.0" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "nats-py", extras = ["nkeys"], specifier = ">=2.8.0" },
     { name = "netaddr", specifier = ">=0.10.1" },
@@ -3295,6 +3358,19 @@ hiredis = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3346,6 +3422,101 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
 ]
 
 [[package]]
@@ -3493,6 +3664,19 @@ wheels = [
 [package.optional-dependencies]
 asyncio = [
     { name = "greenlet" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Implements the MCP server for agent communication with NV Config Manager for datacenter operators

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote MCP service (streaming HTTP tools), MCP CLI (discover/login/token/config/check), MCP `/mcp` endpoint, and MCP-aware clients/tools; Nautobot read-only token support and selectable Nautobot auth modes; /auth/discovery endpoint for OIDC discovery.

* **Configuration / Deployment**
  * Helm/values and local security examples updated to enable MCP, add MCP routing/monitoring, Vault/INI MCP settings, and Keycloak CLI client defaults.

* **Documentation**
  * New MCP docs, updated local endpoints, SSO/CLI guidance, and quick-start host mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->