### PR TITLE
pull in the latest distroless base images

### DIFF
--- a/build/nats-ready.Dockerfile
+++ b/build/nats-ready.Dockerfile
@@ -47,7 +47,7 @@ RUN go build -ldflags="-s -w" -o bin/nats-ready ./cmd/nats-ready
 # =============================================================================
 # Runtime stage - NVIDIA distroless Go image (minimal, no shell)
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/go:v4.0.6
+FROM nvcr.io/nvidia/distroless/go:v4.0.7
 
 COPY --from=builder /build/bin/nats-ready /nats-ready
 ENTRYPOINT ["/nats-ready"]

--- a/build/nautobot.Dockerfile
+++ b/build/nautobot.Dockerfile
@@ -72,7 +72,7 @@ RUN mkdir -p /opt/nautobot/static \
 # =============================================================================
 # Runtime stage - NVIDIA distroless Python
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/python:3.11-v4.0.6
+FROM nvcr.io/nvidia/distroless/python:3.11-v4.0.7
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/build/nv-config-manager.Dockerfile
+++ b/build/nv-config-manager.Dockerfile
@@ -74,7 +74,7 @@ RUN --mount=type=cache,id=nvcm-uv-cache,target=/root/.cache/uv \
 # =============================================================================
 # Runtime stage - NVIDIA distroless Python
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.6
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.7
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/build/ui.Dockerfile
+++ b/build/ui.Dockerfile
@@ -52,7 +52,7 @@ RUN npm run build
 # =============================================================================
 # Runtime stage - NVIDIA distroless Node.js
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/node:24-v4.0.7 AS runner
+FROM nvcr.io/nvidia/distroless/node:24-v4.0.8 AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

Update base distroless images

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/27366919034/job/80868783066

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker runtime base images across application containers to latest NVIDIA distroless versions: Go runtime updated from v4.0.6 to v4.0.7, Python 3.11 from v4.0.6 to v4.0.7, Python 3.13 from v4.0.6 to v4.0.7, and Node.js 24 from v4.0.7 to v4.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->