### PR TITLE
feat(nautobot): add nico interface id custom field

### DIFF
--- a/components/nautobot/nv_config_manager_jobs/data/custom_fields.yaml
+++ b/components/nautobot/nv_config_manager_jobs/data/custom_fields.yaml
@@ -25,3 +25,13 @@
   content_types:
     - dcim.device
   deployment_types: [all, superpod]
+
+# Scalar field so interfaces are filterable by NICo machine interface ID.
+- key: nico_interface_id
+  label: NICo Interface ID
+  type: text
+  description: NICo machine interface ID.
+  filter_logic: exact
+  content_types:
+    - dcim.interface
+  deployment_types: [all, superpod]


### PR DESCRIPTION
## Description

Adding a custom exact text field to nautobot interface objects to NICo syncing.

## Validation

- [x] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run: https://github.com/NVIDIA/nv-config-manager/actions/runs/27370318755

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new custom field for interface configurations in NVIDIA Config Manager deployments. The text field includes exact filtering capabilities and is available for all deployment types and superpod configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->