### PR TITLE
resolve issue with replayability after new search attrs added

### DIFF
--- a/src/nv_config_manager/temporal/api/workflow_v1.py
+++ b/src/nv_config_manager/temporal/api/workflow_v1.py
@@ -289,7 +289,7 @@ class WorkflowSummaryResponse(WorkflowResponse):
                 results[query] = data
             except WorkflowQueryFailedError:
                 logger.exception(
-                    "Workflow %s of type %s has not implemented the %s query.",
+                    "Workflow %s of type %s failed the %s query.",
                     handle.id,
                     description.workflow_type,
                     query,

--- a/src/nv_config_manager/temporal/common/mixins/stage.py
+++ b/src/nv_config_manager/temporal/common/mixins/stage.py
@@ -46,6 +46,7 @@ from nv_config_manager.temporal.common.search_attributes import (
 )
 
 F = TypeVar("F", bound=Callable[..., Any])
+STAGE_STATE_SEARCH_ATTRIBUTES_PATCH = "stage-state-search-attributes-v1"
 
 
 def stage_executor(stage_name: str) -> Callable[[F], F]:
@@ -415,6 +416,9 @@ class StageMixin(BaseMixin):
 
     def _upsert_stage_state_search_attributes(self) -> None:
         """Index workflow stage state summary flags."""
+        # Keep histories from before stage-state search attributes replayable.
+        if not workflow.patched(STAGE_STATE_SEARCH_ATTRIBUTES_PATCH):
+            return
         workflow.upsert_search_attributes(
             {
                 FAILED_STAGE_SEARCH_ATTRIBUTE: [self.failed_stage()],

--- a/src/tests/temporal/hello_world/workflows/test_hello_world_workflow.py
+++ b/src/tests/temporal/hello_world/workflows/test_hello_world_workflow.py
@@ -52,8 +52,9 @@ from nv_config_manager.temporal.ngc.activities.slack import SlackMessageInput, S
 
 
 @patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.patched", return_value=True)
 @patch("nv_config_manager.temporal.common.mixins.stage.workflow.upsert_search_attributes")
-def test_unreachable_stage_cascades_to_direct_dependents(mock_upsert, mock_time):
+def test_unreachable_stage_cascades_to_direct_dependents(mock_upsert, mock_patched, mock_time):
     workflow_state = StageMixin()
     workflow_state.define_stage(
         name="source",
@@ -80,7 +81,28 @@ def test_unreachable_stage_cascades_to_direct_dependents(mock_upsert, mock_time)
     assert workflow_state.get_stage_state("dependent") == StateEnum.UNREACHABLE
     assert workflow_state.get_stage_state("unrelated") == StateEnum.NOT_STARTED
     assert mock_time.called
+    assert mock_patched.called
     assert mock_upsert.called
+
+
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.patched", return_value=False)
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.upsert_search_attributes")
+def test_stage_state_search_attributes_skip_old_histories(mock_upsert, mock_patched, mock_time):
+    workflow_state = StageMixin()
+    workflow_state.define_stage(
+        name="test",
+        description="test",
+        depends_on=[],
+        requires_approval=False,
+    )
+
+    workflow_state.set_stage_state("test", StateEnum.IN_PROGRESS)
+
+    assert workflow_state.get_stage_state("test") == StateEnum.IN_PROGRESS
+    assert mock_time.called
+    assert mock_patched.called
+    mock_upsert.assert_not_called()
 
 
 @activity.defn(name="send_slack_message")
@@ -814,9 +836,10 @@ class MockHelloWorldRunActivityTimeout(StageMixin):
 
 @pytest.mark.asyncio
 @patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.patched", return_value=True)
 @patch("nv_config_manager.temporal.common.mixins.stage.workflow.upsert_search_attributes")
 @patch("nv_config_manager.temporal.common.mixins.stage.traceback.format_exc", return_value="exists")
-async def test_workflow_activity_timeout(mock_tb, mock_upsert, mock_time):
+async def test_workflow_activity_timeout(mock_tb, mock_upsert, mock_patched, mock_time):
     task_queue_name = str(uuid.uuid4())
 
     async with await WorkflowEnvironment.start_time_skipping() as env:


### PR DESCRIPTION
## Description

Upserting the PendingApproval and Failed attributes broke the history for all existing workflows, this moves those behind a patched marker which allows the workflow to skip activities that were not executed on the original run during replay.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/27383123059/job/80924275392

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Temporal workflow query failure messaging to accurately report when queries fail.
  * Optimized search attribute indexing during workflow history replay, preventing unnecessary indexing operations in unpatched scenarios.

* **Tests**
  * Updated test suite to verify proper behavior of workflow history patching and search attribute operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->