### PR TITLE
fix(workflow) Overlay creation RD gap allocation

### DIFF
--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -332,17 +332,16 @@ async def get_available_route_distinguishers(
         }
         logger.info("Found RDs: %s", route_distinguishers)
 
-        assigned_numbers = sorted(
-            [int(rd.split(":")[1]) for rd in route_distinguishers if re.match(r"\*:\d+", rd)]
-        )
+        assigned_numbers = {
+            int(rd.split(":")[1]) for rd in route_distinguishers if re.match(r"\*:\d+", rd)
+        }
 
-        if not assigned_numbers or assigned_numbers[-1] < activity_input.rd_min:
-            route_distinguisher = f"*:{activity_input.rd_min}"
-        elif assigned_numbers[-1] >= activity_input.rd_max:
-            # TODO: Reclaim any gaps in the range
+        available_numbers = (
+            set(range(activity_input.rd_min, activity_input.rd_max + 1)) - assigned_numbers
+        )
+        if not available_numbers:
             raise ApplicationError(f"Namespaces {namespaces} out of space for new RDs")
-        else:
-            route_distinguisher = f"*:{assigned_numbers[-1] + 1}"
+        route_distinguisher = f"*:{min(available_numbers)}"
     return GetAvailableRouteDistinguishersOutput(
         route_distinguisher=route_distinguisher,
         namespaces=namespaces,

--- a/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
+++ b/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
@@ -56,14 +56,14 @@ def _lookup(id_):
     return {"results": [{"id": id_}]}
 
 
-def _namespace_graphql_response(namespace_id=NS_ID, namespace_name="spectrumx_rno1", rds=None):
+def _namespace_graphql_response(*rds, namespace_id=NS_ID, namespace_name="spectrumx_rno1"):
     return {
         "data": {
             "namespaces": [
                 {
                     "id": namespace_id,
                     "name": namespace_name,
-                    "vrfs": [{"rd": rd} for rd in rds or []],
+                    "vrfs": [{"rd": rd} for rd in rds],
                 }
             ]
         }
@@ -104,7 +104,7 @@ async def test_get_available_route_distinguishers_returns_namespace_ids():
     with aioresponses() as m:
         m.post(
             f"{NAUTOBOT}/api/graphql/",
-            payload=_namespace_graphql_response(rds=["*:60000"]),
+            payload=_namespace_graphql_response("*:60000"),
         )
 
         result = await get_available_route_distinguishers(
@@ -118,6 +118,46 @@ async def test_get_available_route_distinguishers_returns_namespace_ids():
 
     assert result.namespaces == [NS_ID]
     assert result.route_distinguisher == "*:60001"
+
+
+@pytest.mark.asyncio
+async def test_get_available_route_distinguishers_reuses_gap_below_max():
+    with aioresponses() as m:
+        m.post(
+            f"{NAUTOBOT}/api/graphql/",
+            payload=_namespace_graphql_response("*:60000", "*:60002", "*:65000"),
+        )
+
+        result = await get_available_route_distinguishers(
+            GetAvailableRouteDistinguishersInput(
+                site=LOCATION_ID,
+                namespace_tag="tenant-a",
+                rd_min=60000,
+                rd_max=65000,
+            )
+        )
+
+    assert result.route_distinguisher == "*:60001"
+    assert result.namespaces == [NS_ID]
+
+
+@pytest.mark.asyncio
+async def test_get_available_route_distinguishers_raises_when_range_full():
+    with aioresponses() as m:
+        m.post(
+            f"{NAUTOBOT}/api/graphql/",
+            payload=_namespace_graphql_response("*:60000", "*:60001", "*:60002"),
+        )
+
+        with pytest.raises(ApplicationError, match="out of space for new RDs"):
+            await get_available_route_distinguishers(
+                GetAvailableRouteDistinguishersInput(
+                    site=LOCATION_ID,
+                    namespace_tag="tenant-a",
+                    rd_min=60000,
+                    rd_max=60002,
+                )
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

RD allocation fails when the max RD has been taken - fix the allocation to allow any free RD within the range.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.
Passing Kind Integration run: https://github.com/NVIDIA/nv-config-manager/actions/runs/27964819731


## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route distinguisher (RD) allocation to reuse the earliest available gap within the configured RD range, selecting the smallest unused value.
  * Updated behavior to fail gracefully when the RD range is fully occupied, returning an “out of space” error.

* **Tests**
  * Expanded unit tests with richer fixture data to validate gap reuse and to confirm the correct error is raised when no RD values remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->