### PR TITLE
fix(ui): rename SpX overlay tenant label

### DIFF
--- a/ui/src/app/workflows/spxoverlaytenantchangeworkflow/form/spx-overlay-tenant-change-workflow-form.tsx
+++ b/ui/src/app/workflows/spxoverlaytenantchangeworkflow/form/spx-overlay-tenant-change-workflow-form.tsx
@@ -159,7 +159,7 @@ export const SpXOverlayTenantChangeWorkflowForm = () => {
                 type="input"
                 control={form.control}
                 name="overlay_id"
-                label="VPC ID"
+                label="Overlay ID"
                 isSubmitting={isSubmitting}
               />
               <WorkflowFormField


### PR DESCRIPTION
## Description

Fix naming to remove outdated reference to VPC

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run: N/A, just a UI cosmetic change

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a form field label from "VPC ID" to "Overlay ID" for improved accuracy and clarity in the tenant change workflow form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->