### PR TITLE
fix(workflow): use namespace IDs for SpX overlay creation

### DIFF
--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -299,6 +299,7 @@ async def get_available_route_distinguishers(
     namespace_query = """
         query ($tag: String, $location: String) {
             namespaces(location: $location, tags: [$tag]) {
+                id
                 name
                 vrfs {
                     rd
@@ -315,7 +316,7 @@ async def get_available_route_distinguishers(
                 "location": activity_input.site,
             },
         )
-        namespaces = [namespace["name"] for namespace in results["data"]["namespaces"]]
+        namespaces = [namespace["id"] for namespace in results["data"]["namespaces"]]
         if not namespaces:
             raise ApplicationError(
                 f"No namespaces for site {activity_input.site} and "

--- a/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
+++ b/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
@@ -24,11 +24,13 @@ from nv_config_manager.common.client.nautobot import NautobotException
 from nv_config_manager.temporal.client.nautobot import NautobotClient
 from nv_config_manager.temporal.ngc.activities.nautobot import (
     DeleteOverlayInput,
+    GetAvailableRouteDistinguishersInput,
     ProvisionVrfInput,
     VrfDeletionActivityInput,
     _vni_from_rd,
     delete_overlay,
     delete_vrf,
+    get_available_route_distinguishers,
     provision_vrf,
 )
 
@@ -54,6 +56,20 @@ def _lookup(id_):
     return {"results": [{"id": id_}]}
 
 
+def _namespace_graphql_response(namespace_id=NS_ID, namespace_name="spectrumx_rno1", rds=None):
+    return {
+        "data": {
+            "namespaces": [
+                {
+                    "id": namespace_id,
+                    "name": namespace_name,
+                    "vrfs": [{"rd": rd} for rd in rds or []],
+                }
+            ]
+        }
+    }
+
+
 # ---------------------------------------------------------------------------
 # _vni_from_rd
 # ---------------------------------------------------------------------------
@@ -76,6 +92,32 @@ def test_vni_from_rd_non_numeric():
 def test_vni_from_rd_extra_colons():
     with pytest.raises(ValueError, match="Invalid route distinguisher"):
         _vni_from_rd("1:2:3")
+
+
+# ---------------------------------------------------------------------------
+# get_available_route_distinguishers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_available_route_distinguishers_returns_namespace_ids():
+    with aioresponses() as m:
+        m.post(
+            f"{NAUTOBOT}/api/graphql/",
+            payload=_namespace_graphql_response(rds=["*:60000"]),
+        )
+
+        result = await get_available_route_distinguishers(
+            GetAvailableRouteDistinguishersInput(
+                site=LOCATION_ID,
+                namespace_tag="spectrumx",
+                rd_min=60000,
+                rd_max=65000,
+            )
+        )
+
+    assert result.namespaces == [NS_ID]
+    assert result.route_distinguisher == "*:60001"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fix SpX Overlay Creation provisioning to always track namespaces by ID so we don't end up pulling the wrong namespace when creating an overlay.

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test was not run locally; this change is covered by focused activity unit tests and should run through the standard PR workflow when ready.

Passing Kind Integration run: https://github.com/NVIDIA/nv-config-manager/actions/runs/27967665105

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the values returned for available namespace distinguishers by using Nautobot namespace identifiers from the GraphQL response, ensuring route distinguisher selection works as expected.

* **Tests**
  * Added unit test coverage for available route distinguisher discovery, including mocked Nautobot GraphQL responses and verification of the returned namespace and route distinguisher output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->