### PR TITLE
handle shared gateway class in TUI

### DIFF
--- a/docs/install/troubleshooting.mdx
+++ b/docs/install/troubleshooting.mdx
@@ -57,7 +57,10 @@ kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets
 
 ## GatewayClass Already Exists
 
-Use the `--skip-gateway-class` flag with the deploy script to skip the creation of the GatewayClass.
+Set `infrastructure.create_gateway_class: false` in `nv-config-manager-install.yaml`,
+or disable **Create GatewayClass** on the Infrastructure screen in the installer TUI.
+This makes NVIDIA Config Manager reuse the existing GatewayClass instead of trying
+to take Helm ownership of it.
 
 ```text title="Sample error message" wordWrap
 Error: INSTALLATION FAILED: Unable to continue with install: GatewayClass "envoy-gateway" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "config-manager": current value is "config-manager-qa"

--- a/docs/install/tui-wizard-reference.mdx
+++ b/docs/install/tui-wizard-reference.mdx
@@ -265,6 +265,7 @@ Configure gateway behavior, TLS, database backups, monitoring resources, and loa
 
 | Field | Description |
 | :---- | :---------- |
+| Create GatewayClass | Create the cluster-scoped `envoy-gateway` GatewayClass. Disable when a shared Envoy Gateway installation already owns it. |
 | Enable TLS | Use self-signed TLS certificates for public endpoints |
 | CNPG S3 Backup | CloudNativePG PostgreSQL backups to S3 |
 | Monitoring | PodMonitors and monitoring resources |

--- a/installer/README.md
+++ b/installer/README.md
@@ -505,6 +505,7 @@ Gateway, TLS, database backups, monitoring, and load balancer configuration.
 
 | Field | Description |
 |-------|-------------|
+| Create GatewayClass | Create the cluster-scoped `envoy-gateway` GatewayClass; disable when reusing a shared Envoy Gateway installation |
 | Enable TLS | Self-signed TLS certificates for public endpoints |
 | CNPG S3 Backup | Enable CloudNativePG Postgres backups to S3 |
 | Monitoring | Enable PodMonitors and monitoring resources |

--- a/installer/src/nv_config_manager_installer/deployer.py
+++ b/installer/src/nv_config_manager_installer/deployer.py
@@ -64,6 +64,9 @@ from nv_config_manager_installer.schema import (
 from nv_config_manager_installer.secrets import generate_secrets
 
 _PROJECT_ROOT_MARKERS = ("deploy", "Makefile", ".git")
+_DEFAULT_GATEWAY_CLASS_NAME = "envoy-gateway"
+_HELM_RELEASE_NAME_ANNOTATION = "meta.helm.sh/release-name"
+_HELM_RELEASE_NAMESPACE_ANNOTATION = "meta.helm.sh/release-namespace"
 
 
 def find_project_root(start: Path | None = None) -> Path:
@@ -269,6 +272,27 @@ def _run(
         capture_output=capture,
         text=True,
         timeout=timeout,
+    )
+
+
+def _gateway_class_helm_owner(name: str = _DEFAULT_GATEWAY_CLASS_NAME) -> tuple[str, str] | None:
+    """Return the Helm release owner for an existing GatewayClass, if one exists."""
+    result = _run(["kubectl", "get", "gatewayclass", name, "-o", "json"], check=False)
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return ("", "")
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict):
+        return ("", "")
+    annotations = metadata.get("annotations") or {}
+    if not isinstance(annotations, dict):
+        return ("", "")
+    return (
+        str(annotations.get(_HELM_RELEASE_NAME_ANNOTATION, "")),
+        str(annotations.get(_HELM_RELEASE_NAMESPACE_ANNOTATION, "")),
     )
 
 
@@ -2551,6 +2575,9 @@ class Deployer:
         if size_values.exists():
             helm_args.extend(["-f", str(size_values)])
 
+        if self._should_reuse_existing_gateway_class():
+            helm_args.extend(["--set", "gateway.createGatewayClass=false"])
+
         # Local-dev metrics overlay (Prometheus + Alloy).
         # See deploy/helm/values-observability.yaml for the LOCAL-DEV-ONLY warning.
         if self.config.infrastructure.monitoring.observability_enabled:
@@ -2579,6 +2606,29 @@ class Deployer:
         else:
             _run_logged(helm_args, step, self.callback, timeout=1200)
         self._finish_step(step)
+
+    def _should_reuse_existing_gateway_class(self) -> bool:
+        """Return True when an existing GatewayClass is owned by another Helm release."""
+        if not self.config.infrastructure.create_gateway_class:
+            return False
+
+        owner = _gateway_class_helm_owner()
+        if owner is None:
+            return False
+
+        release_name, release_namespace = owner
+        expected = (self.config.cluster.release_name, self.config.cluster.namespace)
+        if owner == expected:
+            return False
+
+        self.callback.on_log(
+            "GatewayClass "
+            f"{_DEFAULT_GATEWAY_CLASS_NAME!r} already exists"
+            f" and is owned by Helm release {release_name or '<unowned>'!r}"
+            f" in namespace {release_namespace or '<unowned>'!r};"
+            " reusing it by setting gateway.createGatewayClass=false"
+        )
+        return True
 
     def _patch_gateway(self) -> None:
         lb = self.config.infrastructure.load_balancer

--- a/installer/src/nv_config_manager_installer/helm_values.py
+++ b/installer/src/nv_config_manager_installer/helm_values.py
@@ -444,7 +444,7 @@ def _build_gateway(config: NVConfigManagerInstallConfig) -> dict[str, Any]:
     gateway: dict[str, Any] = {
         "enabled": True,
         "baseHostname": config.cluster.hostname,
-        "createGatewayClass": True,
+        "createGatewayClass": config.infrastructure.create_gateway_class,
         "certificates": {"enabled": config.infrastructure.tls},
     }
     if config.infrastructure.tls:

--- a/installer/src/nv_config_manager_installer/schema.py
+++ b/installer/src/nv_config_manager_installer/schema.py
@@ -550,6 +550,7 @@ class InfrastructureConfig(BaseModel):
     """Infrastructure and gateway settings."""
 
     gateway: GatewayType = GatewayType.ENVOY_GATEWAY
+    create_gateway_class: bool = True
     tls: bool = True
     cnpg_s3_backup: CNPGBackupConfig = Field(default_factory=CNPGBackupConfig)
     monitoring: MonitoringConfig = Field(default_factory=MonitoringConfig)

--- a/installer/src/nv_config_manager_installer/tui/screens/infrastructure.py
+++ b/installer/src/nv_config_manager_installer/tui/screens/infrastructure.py
@@ -77,6 +77,11 @@ class InfraScreen(Container):
         yield Label("Infrastructure", classes="section-title")
         yield Label("─" * 40, classes="section-divider")
 
+        yield LabeledSwitch(
+            "Create GatewayClass",
+            value=infra.create_gateway_class,
+            id="infra-create-gateway-class",
+        )
         yield LabeledSwitch("Enable TLS", value=infra.tls, id="infra-tls")
 
         yield Label("CNPG S3 Backup", classes="field-label")
@@ -242,6 +247,9 @@ class InfraScreen(Container):
 
     def write_to_config(self, config: NVConfigManagerInstallConfig) -> None:
         infra = config.infrastructure
+        infra.create_gateway_class = self.query_one(
+            "#infra-create-gateway-class", LabeledSwitch
+        ).value
         infra.tls = self.query_one("#infra-tls", LabeledSwitch).value
         infra.cnpg_s3_backup.enabled = self.query_one(_W_CNPG_BACKUP, LabeledSwitch).value
         infra.cnpg_s3_backup.bucket = self.query_one("#cnpg-bucket", Input).value
@@ -277,6 +285,9 @@ class InfraScreen(Container):
 
     def sync_from_config(self, config: NVConfigManagerInstallConfig) -> None:
         infra = config.infrastructure
+        self.query_one(
+            "#infra-create-gateway-class", LabeledSwitch
+        ).value = infra.create_gateway_class
         self.query_one("#infra-tls", LabeledSwitch).value = infra.tls
         self.query_one(_W_CNPG_BACKUP, LabeledSwitch).value = infra.cnpg_s3_backup.enabled
         self.query_one("#cnpg-bucket", Input).value = infra.cnpg_s3_backup.bucket

--- a/installer/tests/test_deployer.py
+++ b/installer/tests/test_deployer.py
@@ -50,6 +50,7 @@ from nv_config_manager_installer.schema import (
     ImagePullSecret,
     ImagesConfig,
     ImageSource,
+    InfrastructureConfig,
     JobPath,
     JobsConfig,
     K8sSecretGroup,
@@ -186,6 +187,58 @@ class TestDeployerInit:
         deployer = Deployer(config, DeployOptions())
         ids = [s.id for s in deployer.steps]
         assert len(ids) == len(set(ids))
+
+
+class TestGatewayClassReuse:
+    @patch(
+        "nv_config_manager_installer.deployer._gateway_class_helm_owner",
+        return_value=("kiwi-platform", "kiwi"),
+    )
+    def test_reuses_gateway_class_owned_by_another_release(self, mock_owner):
+        config = _make_config()
+        callback = RecordingCallback()
+        deployer = Deployer(config, DeployOptions(), callback)
+
+        assert deployer._should_reuse_existing_gateway_class() is True
+        assert any("gateway.createGatewayClass=false" in line for line in callback.logs)
+        mock_owner.assert_called_once_with()
+
+    @patch(
+        "nv_config_manager_installer.deployer._gateway_class_helm_owner",
+        return_value=("nv-config-manager", "nv-config-manager"),
+    )
+    def test_keeps_gateway_class_when_owned_by_current_release(self, mock_owner):
+        config = _make_config()
+        callback = RecordingCallback()
+        deployer = Deployer(config, DeployOptions(), callback)
+
+        assert deployer._should_reuse_existing_gateway_class() is False
+        assert callback.logs == []
+        mock_owner.assert_called_once_with()
+
+    @patch("nv_config_manager_installer.deployer._gateway_class_helm_owner", return_value=None)
+    def test_keeps_gateway_class_when_absent(self, mock_owner):
+        config = _make_config()
+        callback = RecordingCallback()
+        deployer = Deployer(config, DeployOptions(), callback)
+
+        assert deployer._should_reuse_existing_gateway_class() is False
+        assert callback.logs == []
+        mock_owner.assert_called_once_with()
+
+    @patch(
+        "nv_config_manager_installer.deployer._gateway_class_helm_owner",
+        return_value=("kiwi-platform", "kiwi"),
+    )
+    def test_keeps_gateway_class_when_creation_disabled_in_config(self, mock_owner):
+        config = _make_config()
+        config.infrastructure = InfrastructureConfig(create_gateway_class=False)
+        callback = RecordingCallback()
+        deployer = Deployer(config, DeployOptions(), callback)
+
+        assert deployer._should_reuse_existing_gateway_class() is False
+        assert callback.logs == []
+        mock_owner.assert_not_called()
 
 
 class TestStepSequencing:

--- a/installer/tests/test_helm_values.py
+++ b/installer/tests/test_helm_values.py
@@ -536,6 +536,13 @@ class TestGenerateHelmValues:
         values = _gen(config)
         assert values["gateway"]["nodePort"]["enabled"] is True
 
+    def test_gateway_class_creation_can_be_disabled(self):
+        config = _make_config(
+            infrastructure=InfrastructureConfig(create_gateway_class=False),
+        )
+        values = _gen(config)
+        assert values["gateway"]["createGatewayClass"] is False
+
     def test_custom_jobs_in_values(self):
         config = _make_config(
             content=ContentConfig(


### PR DESCRIPTION
## Description

While the helm chart supports pre-existing gateway classes, the TUI doesn't expose that setting and therefore doesn't work if the gateway class already exists. This resolves that issue.

## Validation

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Create GatewayClass" configuration option allowing reuse of existing shared Envoy Gateway installations.

* **Documentation**
  * Updated troubleshooting guides and Infrastructure section reference with the new configuration option.

* **Tests**
  * Added test coverage for gateway class reuse detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->