### PR TITLE
fix azure logout and make unauthorized user clearer in the UI

### DIFF
--- a/ui/src/app/auth/logout/route.ts
+++ b/ui/src/app/auth/logout/route.ts
@@ -16,10 +16,12 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 
-const OIDC_COOKIE_NAMES = [
+const DEFAULT_AUTH_COOKIE_NAMES = [
   "NVConfigManagerAccessToken",
   "NVConfigManagerIdToken",
 ];
+
+const COOKIE_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 const expiredCookie = (name: string, domain?: string): string => {
   const domainPart = domain ? ` Domain=${domain};` : "";
@@ -54,6 +56,18 @@ const cookieDomains = (hostname: string): string[] => {
   return Array.from(domains);
 };
 
+const cookieNamesToClear = (request: NextRequest): string[] => {
+  const names = new Set(DEFAULT_AUTH_COOKIE_NAMES);
+
+  request.cookies.getAll().forEach((cookie) => {
+    if (COOKIE_NAME_PATTERN.test(cookie.name)) {
+      names.add(cookie.name);
+    }
+  });
+
+  return Array.from(names);
+};
+
 export async function GET(request: NextRequest) {
   const response = new NextResponse(null, {
     status: 302,
@@ -64,7 +78,7 @@ export async function GET(request: NextRequest) {
   const hostname = request.nextUrl.hostname;
   const domains = cookieDomains(hostname);
 
-  OIDC_COOKIE_NAMES.forEach((name) => {
+  cookieNamesToClear(request).forEach((name) => {
     response.headers.append("Set-Cookie", expiredCookie(name));
     domains.forEach((domain) => {
       response.headers.append("Set-Cookie", expiredCookie(name, domain));

--- a/ui/src/components/nav/site-header.tsx
+++ b/ui/src/components/nav/site-header.tsx
@@ -74,10 +74,15 @@ const canExecuteWorkflow = (
 
 const getDisabledWorkflowReason = (
   metadata: WorkflowMetadata | undefined,
-  isFormEnabled: boolean
+  isFormEnabled: boolean,
+  isUnauthorized: boolean
 ): string => {
   if (!isFormEnabled) {
     return "Form Coming Soon!";
+  }
+
+  if (isUnauthorized) {
+    return "Unauthorized";
   }
 
   if (!metadata) {
@@ -100,13 +105,15 @@ const NewWorkflowChooser = () => {
     apiURL ? sanitizeUrl(`${apiURL}/v1/workflow/metadata`) : null,
     fetcher
   );
-  const { data: userInfo } = useSWRImmutable<WhoamiResponse>(
-    apiURL ? sanitizeUrl(`${apiURL}/whoami`) : null,
-    fetcher
-  );
+  const { data: userInfo, error: whoamiError } =
+    useSWRImmutable<WhoamiResponse>(
+      apiURL ? sanitizeUrl(`${apiURL}/whoami`) : null,
+      fetcher
+    );
 
   const metadataBySlug = workflowMetadataBySlug(workflowMetadata?.workflows);
-  const userRoles = new Set(userInfo?.roles ?? []);
+  const isUnauthorized = Boolean(whoamiError);
+  const userRoles = new Set(isUnauthorized ? [] : (userInfo?.roles ?? []));
 
   return (
     <div className="relative inline-block text-left">
@@ -125,11 +132,13 @@ const NewWorkflowChooser = () => {
         <PopoverContent align="end" className="max-h-[70vh] overflow-y-auto">
           {siteConfig.workflows.map((item) => {
             const metadata = metadataBySlug.get(item.slug);
-            const hasPermission = canExecuteWorkflow(metadata, userRoles);
+            const hasPermission =
+              !isUnauthorized && canExecuteWorkflow(metadata, userRoles);
             const isEnabled = item.enabled && hasPermission;
             const disabledReason = getDisabledWorkflowReason(
               metadata,
-              item.enabled
+              item.enabled,
+              isUnauthorized
             );
 
             return isEnabled ? (
@@ -177,7 +186,11 @@ const UserRolesMenu = () => {
     fetcher
   );
 
-  const roles = (userInfo?.roles ?? []).filter(
+  const isUnauthorized = Boolean(error);
+  const username = isUnauthorized
+    ? "Unauthorized"
+    : userInfo?.user ?? "Unknown user";
+  const roles = (isUnauthorized ? [] : (userInfo?.roles ?? [])).filter(
     (role) => role.toLowerCase() !== "all"
   );
 
@@ -199,14 +212,7 @@ const UserRolesMenu = () => {
             <div className="text-xs font-medium text-muted-foreground">
               Username
             </div>
-            <div className="break-all text-sm font-medium">
-              {userInfo?.user ?? "Unknown user"}
-            </div>
-            {error && (
-              <div className="text-xs text-destructive">
-                Unable to load roles
-              </div>
-            )}
+            <div className="break-all text-sm font-medium">{username}</div>
           </div>
           <div className="space-y-2">
             <div className="text-xs font-medium text-muted-foreground">

--- a/ui/tests/e2e/workflowsPage.spec.ts
+++ b/ui/tests/e2e/workflowsPage.spec.ts
@@ -25,6 +25,37 @@ test.describe("Workflows Page", () => {
     expect(response.headers().location).toBe("/oauth2/logout");
   });
 
+  test("logout expires cookies sent by the site", async ({ request }) => {
+    const response = await request.get("/auth/logout", {
+      headers: {
+        Cookie:
+          "NVConfigManagerAccessToken=access; azureSession=session; appPreference=compact",
+      },
+      maxRedirects: 0,
+    });
+    const setCookieHeaders = response
+      .headersArray()
+      .filter((header) => header.name.toLowerCase() === "set-cookie")
+      .map((header) => header.value);
+
+    expect(
+      setCookieHeaders.some((header) =>
+        header.startsWith("NVConfigManagerAccessToken=;")
+      )
+    ).toBe(true);
+    expect(
+      setCookieHeaders.some((header) =>
+        header.startsWith("NVConfigManagerIdToken=;")
+      )
+    ).toBe(true);
+    expect(
+      setCookieHeaders.some((header) => header.startsWith("azureSession=;"))
+    ).toBe(true);
+    expect(
+      setCookieHeaders.some((header) => header.startsWith("appPreference=;"))
+    ).toBe(true);
+  });
+
   test("renders a unified metadata-backed workflow table", async ({ page }) => {
     await page.goto("/workflows?workflow_type=DeployWorkflow");
 
@@ -79,6 +110,40 @@ test.describe("Workflows Page", () => {
       page.getByRole("tooltip", {
         name: "Required execute roles: nvcm-admin",
       })
+    ).toBeVisible();
+  });
+
+  test("shows unauthorized when workflow whoami cannot be accessed", async ({
+    page,
+  }) => {
+    await page.unroute("**/whoami");
+    await page.route("**/whoami", async (route) => {
+      await route.fulfill({
+        status: 403,
+        json: { error: "Forbidden" },
+      });
+    });
+
+    await page.goto("/workflows?workflow_type=DeployWorkflow");
+
+    await page.getByRole("button", { name: "User roles" }).click();
+    await expect(page.getByText("Unauthorized", { exact: true })).toBeVisible();
+    await expect(page.getByText("Unknown user", { exact: true })).toHaveCount(0);
+    await expect(
+      page.getByText("Unable to load roles", { exact: true })
+    ).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Logout" })).toHaveAttribute(
+      "href",
+      "/auth/logout"
+    );
+
+    await page.getByRole("button", { name: "New workflow" }).click();
+    await expect(
+      page.getByRole("link", { name: "Config Deploy" })
+    ).toHaveCount(0);
+    await page.getByText("Multi-Deploy").hover();
+    await expect(
+      page.getByRole("tooltip", { name: "Unauthorized" }).first()
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Description

Clearing the NVCM tokens is insufficient for logging out of Azure SSO, this fixes the Azure logout flow.

Also adds a clearer Unauthorized message to the User popout in the header for users with no access to the workflow /whoami endpoint.

## Validation

- Ran locally with both Azure and Keycloak to confirm logout works with both SSO providers
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/27981571357/job/82812754089

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logout to properly clear additional authentication cookies.
  * Improved handling of authentication failures with clear "Unauthorized" status display.
  * Workflow execution now correctly blocks when user is unauthorized.
  * User interface displays appropriate status messages instead of unclear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->