### PR TITLE
fix(workflow): SpX namespace tag UI form Accuracy

### DIFF
--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -1566,6 +1566,25 @@
         "title": "SwitchOSUpgradeInput",
         "type": "object"
       },
+      "Tag": {
+        "description": "Tag data for dropdown population.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "Tag",
+        "type": "object"
+      },
       "Tenant": {
         "description": "Tenant data for dropdown population.",
         "properties": {
@@ -2676,6 +2695,62 @@
           }
         },
         "summary": "Get Locations",
+        "tags": [
+          "parameters"
+        ]
+      }
+    },
+    "/v1/parameter/namespace-tag": {
+      "get": {
+        "description": "Return a list of tags used by Nautobot namespaces.",
+        "operationId": "get_namespace_tags_v1_parameter_namespace_tag_get",
+        "parameters": [
+          {
+            "description": "Limit to namespace tags at this location",
+            "in": "query",
+            "name": "location",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Limit to namespace tags at this location",
+              "title": "Location"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Tag"
+                  },
+                  "title": "Response Get Namespace Tags V1 Parameter Namespace Tag Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Namespace Tags",
         "tags": [
           "parameters"
         ]

--- a/docs/user-guides/vpc-creation/index.mdx
+++ b/docs/user-guides/vpc-creation/index.mdx
@@ -16,7 +16,7 @@ This workflow is experimental and not intended for general use. Use it only in t
 
 Before running, confirm:
 
-- **Site exists in Nautobot** and is correctly tagged so RD allocation can find an available range.
+- **Site exists in Nautobot** and has at least one namespace tagged for SpX overlay creation.
 - **Tenant exists in Nautobot.** The tenant is used to scope the created Overlay object.
 - **overlay_id chosen.** Pick a unique identifier; if the same ID is reused, the workflow short-circuits and returns the existing VRFs without creating new ones.
 - **Route-distinguisher range has free entries** within the site's allocated `rd_min`..`rd_max` window. The workflow's RD allocator pulls the first available RD in that window.
@@ -32,7 +32,7 @@ Before running, confirm:
 | **Site** | The site the overlay belongs to. | Yes |
 | **Overlay ID** | Unique identifier for the overlay. Idempotency key — re-running with the same ID returns existing VRFs. | Yes |
 | **Tenant** | The Nautobot tenant to associate with the created Overlay. | Yes |
-| **Namespace** | Tag used to identify the overlay namespace in Nautobot. | Yes |
+| **Namespace Tag** | Nautobot namespace tag used to identify the overlay namespaces for this site. The form lists tags from Nautobot namespaces. | Yes |
 | **RD Min** | Lower bound of the route-distinguisher allocation range (0-65535). | No (default: 60000) |
 | **RD Max** | Upper bound of the route-distinguisher allocation range (0-65535). | No (default: 65000) |
 

--- a/src/nv_config_manager/temporal/api/parameter_v1.py
+++ b/src/nv_config_manager/temporal/api/parameter_v1.py
@@ -271,15 +271,44 @@ async def get_namespace_tags(
     """
     variables = {"location": location}
 
-    async with client:
-        data = await client.graphql_query(query, variables=variables)
+    try:
+        async with client:
+            data = await client.graphql_query(query, variables=variables)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to query Nautobot namespace tags.",
+        ) from exc
 
-    tag_names = {
-        tag["name"]
-        for namespace in data["data"]["namespaces"]
-        for tag in namespace.get("tags", [])
-        if tag.get("name")
-    }
+    namespaces = data.get("data", {}).get("namespaces") if isinstance(data, dict) else None
+    if not isinstance(namespaces, list):
+        raise HTTPException(
+            status_code=500,
+            detail="Malformed Nautobot namespace tag response.",
+        )
+
+    tag_names: set[str] = set()
+    for namespace in namespaces:
+        if not isinstance(namespace, dict):
+            raise HTTPException(
+                status_code=500,
+                detail="Malformed Nautobot namespace tag response.",
+            )
+        tags = namespace.get("tags", [])
+        if not isinstance(tags, list):
+            raise HTTPException(
+                status_code=500,
+                detail="Malformed Nautobot namespace tag response.",
+            )
+        for tag in tags:
+            if not isinstance(tag, dict):
+                raise HTTPException(
+                    status_code=500,
+                    detail="Malformed Nautobot namespace tag response.",
+                )
+            tag_name = tag.get("name")
+            if isinstance(tag_name, str) and tag_name:
+                tag_names.add(tag_name)
     return [Tag(id=name, name=name) for name in sorted(tag_names)]
 
 

--- a/src/nv_config_manager/temporal/api/parameter_v1.py
+++ b/src/nv_config_manager/temporal/api/parameter_v1.py
@@ -104,6 +104,13 @@ class Role(BaseModel):
     name: str
 
 
+class Tag(BaseModel):
+    """Tag data for dropdown population."""
+
+    id: str
+    name: str
+
+
 # Minimal managed-device query for unique tenants only
 NV_CONFIG_MANAGER_DEVICES_TENANTS_QUERY = """
     query ($limit: Int!, $offset: Int!) {
@@ -243,6 +250,37 @@ async def get_roles(
         roles = [{"id": r["id"], "name": r["name"]} for r in data["data"]["roles"]]
 
     return [Role(id=r["id"], name=r["name"]) for r in roles]
+
+
+@router.get("/namespace-tag")
+async def get_namespace_tags(
+    location: Annotated[
+        str | None, Query(description="Limit to namespace tags at this location")
+    ] = None,
+) -> list[Tag]:
+    """Return a list of tags used by Nautobot namespaces."""
+    client = NautobotClient()
+    query = """
+        query ($location: String) {
+            namespaces(location: $location) {
+                tags {
+                    name
+                }
+            }
+        }
+    """
+    variables = {"location": location}
+
+    async with client:
+        data = await client.graphql_query(query, variables=variables)
+
+    tag_names = {
+        tag["name"]
+        for namespace in data["data"]["namespaces"]
+        for tag in namespace.get("tags", [])
+        if tag.get("name")
+    }
+    return [Tag(id=name, name=name) for name in sorted(tag_names)]
 
 
 class Status(BaseModel):

--- a/src/tests/temporal/api/test_parameter.py
+++ b/src/tests/temporal/api/test_parameter.py
@@ -216,6 +216,34 @@ def test_namespace_tag():
         ]
 
 
+def test_namespace_tag_graphql_error():
+    """Test the namespace tag endpoint handles Nautobot GraphQL errors."""
+    with aioresponses() as m:
+        m.post(
+            "https://nautobot.example.com/api/graphql/",
+            payload={"errors": [{"message": "boom"}]},
+        )
+
+        client = TestClient(app)
+        rsp = client.get("/v1/parameter/namespace-tag")
+        assert rsp.status_code == 500
+        assert rsp.json() == {"detail": "Failed to query Nautobot namespace tags."}
+
+
+def test_namespace_tag_malformed_response():
+    """Test the namespace tag endpoint handles malformed Nautobot responses."""
+    with aioresponses() as m:
+        m.post(
+            "https://nautobot.example.com/api/graphql/",
+            payload={"data": {"namespaces": {}}},
+        )
+
+        client = TestClient(app)
+        rsp = client.get("/v1/parameter/namespace-tag")
+        assert rsp.status_code == 500
+        assert rsp.json() == {"detail": "Malformed Nautobot namespace tag response."}
+
+
 def test_status_with_content_type():
     """Test the status parameter endpoint with content_type filter."""
     with aioresponses() as m:

--- a/src/tests/temporal/api/test_parameter.py
+++ b/src/tests/temporal/api/test_parameter.py
@@ -86,6 +86,16 @@ STATUSES = {
     }
 }
 
+NAMESPACE_TAGS = {
+    "data": {
+        "namespaces": [
+            {"tags": [{"name": "spectrumx"}, {"name": "tenant-a"}]},
+            {"tags": [{"name": "spectrumx"}]},
+            {"tags": []},
+        ]
+    }
+}
+
 
 def test_site_v2():
     with aioresponses() as m:
@@ -191,6 +201,19 @@ def test_role_managed_only():
         assert len(result) == 2
         names = {r["name"] for r in result}
         assert names == {"leaf", "spine"}
+
+
+def test_namespace_tag():
+    """Test the namespace tag parameter endpoint."""
+    with aioresponses() as m:
+        m.post("https://nautobot.example.com/api/graphql/", payload=NAMESPACE_TAGS)
+
+        client = TestClient(app)
+        rsp = client.get("/v1/parameter/namespace-tag?location=RNO1")
+        assert rsp.json() == [
+            {"id": "spectrumx", "name": "spectrumx"},
+            {"id": "tenant-a", "name": "tenant-a"},
+        ]
 
 
 def test_status_with_content_type():

--- a/ui/src/app/workflows/spxoverlaycreationworkflow/form/spx-overlay-creation-workflow-form.tsx
+++ b/ui/src/app/workflows/spxoverlaycreationworkflow/form/spx-overlay-creation-workflow-form.tsx
@@ -25,7 +25,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form } from "@/components/ui/form";
 import { useToast } from "@/components/ui/use-toast";
-import { useEnvData } from "@/hooks";
+import { useEnvData, useNamespaceTags } from "@/hooks";
 import { WorkflowFormField } from "@/components/forms/formfield";
 import { startWorkflow } from "@/lib/utils";
 import { SpXOverlayCreationWorkflowInput } from "@/types/data-table.types";
@@ -35,7 +35,7 @@ const SpXOverlayCreationFormSchema = z
     site: z.string().trim().min(1, { message: "Site is required" }),
     overlay_id: z.string().trim().min(1, { message: "Overlay ID is required" }),
     tenant: z.string().trim().min(1, { message: "Tenant is required" }),
-    namespace: z.string().trim().min(1, {message: "Namespace is required"}),
+    namespace_tag: z.string().trim().min(1, { message: "Namespace Tag is required" }),
     rd_min: z.number().min(0).max(65535),
     rd_max: z.number().min(0).max(65535),
   })
@@ -51,8 +51,10 @@ export const SpXOverlayCreationWorkflowForm = () => {
   const querySite = (searchParams && searchParams.get("site")) || "";
   const queryOverlayId = (searchParams && searchParams.get("overlay_id")) || "";
   const queryTenant = (searchParams && searchParams.get("tenant")) || "";
-  const queryNamespace =
-    (searchParams && searchParams.get("namespace")) || "spectrumx";
+  const queryNamespaceTag =
+    (searchParams &&
+      (searchParams.get("namespace_tag") || searchParams.get("namespace"))) ||
+    "spectrumx";
   const queryRDMin =
     (searchParams && Number(searchParams.get("rd_min"))) || 60000;
   const queryRDMax =
@@ -68,11 +70,17 @@ export const SpXOverlayCreationWorkflowForm = () => {
       site: querySite,
       overlay_id: queryOverlayId,
       tenant: queryTenant,
-      namespace: queryNamespace,
+      namespace_tag: queryNamespaceTag,
       rd_min: queryRDMin,
       rd_max: queryRDMax,
     },
   });
+  const selectedSite = form.watch("site");
+  const {
+    namespaceTags,
+    hasLoaded: namespaceTagsHasLoaded,
+    isLoading: namespaceTagsIsLoading,
+  } = useNamespaceTags(selectedSite);
 
   useEffect(() => {
     if (!siteIsLoading && sites && querySite) {
@@ -88,13 +96,25 @@ export const SpXOverlayCreationWorkflowForm = () => {
     }
   }, [sites, querySite, siteIsLoading, form]);
 
+  useEffect(() => {
+    if (!namespaceTagsHasLoaded || namespaceTagsIsLoading) return;
+
+    const namespaceTag = form.getValues("namespace_tag");
+    const namespaceTagExists = namespaceTags.some(
+      (tag) => tag.value === namespaceTag
+    );
+    if (namespaceTag && !namespaceTagExists) {
+      form.setValue("namespace_tag", "", { shouldValidate: true });
+    }
+  }, [namespaceTags, namespaceTagsHasLoaded, namespaceTagsIsLoading, form]);
+
   const onSubmit = async (data: z.infer<typeof SpXOverlayCreationFormSchema>) => {
     setIsSubmitting(true);
     const submissionData: SpXOverlayCreationWorkflowInput = {
       site: data.site,
       overlay_id: data.overlay_id,
       tenant: data.tenant,
-      namespace_tag: data.namespace,
+      namespace_tag: data.namespace_tag,
       rd_min: data.rd_min,
       rd_max: data.rd_max,
     };
@@ -144,11 +164,14 @@ export const SpXOverlayCreationWorkflowForm = () => {
                 isSubmitting={isSubmitting}
               />
               <WorkflowFormField
-                type="input"
+                type="select"
                 control={form.control}
-                name="namespace"
-                label="Namespace"
+                name="namespace_tag"
+                label="Namespace Tag"
+                options={namespaceTags}
+                isLoading={namespaceTagsIsLoading}
                 isSubmitting={isSubmitting}
+                searchable
               />
               <WorkflowFormField
                 type="number"

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -16,6 +16,7 @@
  */
 export { default as useEnvData } from "./useEnvData";
 export { default as useDevices } from "./useDevices";
+export { default as useNamespaceTags } from "./useNamespaceTags";
 export { default as useCommandCatalog } from "./useCommandCatalog";
 export { default as useCommandCatalogGrouped } from "./useCommandCatalogGrouped";
 export type { CommandGroup } from "./useCommandCatalogGrouped";

--- a/ui/src/hooks/useNamespaceTags.ts
+++ b/ui/src/hooks/useNamespaceTags.ts
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
+import { useRuntimeConfig } from "@/config/runtime";
+import { mapRoles, sanitizeUrl } from "@/lib/utils";
+import { Option } from "@/types/workflow-form.types";
+
+interface UseNamespaceTagsReturn {
+  namespaceTags: Option[];
+  error: Error | null;
+  hasLoaded: boolean;
+  isLoading: boolean;
+}
+
+const useNamespaceTags = (location?: string): UseNamespaceTagsReturn => {
+  const { config } = useRuntimeConfig();
+  const apiURL = config?.workflowApiUrl;
+  const params = new URLSearchParams();
+
+  if (location) {
+    params.set("location", location);
+  }
+
+  const queryString = params.toString();
+  const url = apiURL
+    ? sanitizeUrl(
+        `${apiURL}/v1/parameter/namespace-tag${queryString ? `?${queryString}` : ""}`
+      )
+    : null;
+
+  const { data, error, isLoading } = useSWR(url, fetcher);
+
+  return {
+    namespaceTags: data && !error ? mapRoles(data, "name", "name") : [],
+    error,
+    hasLoaded: data !== undefined || Boolean(error),
+    isLoading,
+  };
+};
+
+export default useNamespaceTags;

--- a/ui/src/mocks/data/formData.ts
+++ b/ui/src/mocks/data/formData.ts
@@ -97,6 +97,17 @@ export const TENANT_LIST_API_RESPONSE = [
   },
 ];
 
+export const NAMESPACE_TAGS_LIST_API_RESPONSE = [
+  {
+    id: "spectrumx",
+    name: "spectrumx",
+  },
+  {
+    id: "tenant-a",
+    name: "tenant-a",
+  },
+];
+
 export const DEVICE_TYPES_LIST = [
   "a28b0c1f-2ca9-53cf-ab24-7acc0008e7e4",
   "ce01ade9-ed54-5ae2-8b9d-1d3859233cfe",

--- a/ui/src/mocks/handlers/useEnvHandlers.ts
+++ b/ui/src/mocks/handlers/useEnvHandlers.ts
@@ -19,6 +19,7 @@ import { sanitizeUrl } from "@/lib/utils";
 import { mockApiURL as apiURL } from "@/config/mockApiUrl";
 import {
   DEVICE_TYPES_LIST_API_RESPONSE,
+  NAMESPACE_TAGS_LIST_API_RESPONSE,
   ROLES_LIST_API_RESPONSE,
   SITES_LIST_API_RESPONSE,
   STATUS_LIST_API_RESPONSE,
@@ -48,6 +49,9 @@ export const useEnvDataHandlers = [
   }),
   http.get(sanitizeUrl(`${apiURL}/v1/parameter/tenant`), async () => {
     return HttpResponse.json(TENANT_LIST_API_RESPONSE, { status: 200 });
+  }),
+  http.get(sanitizeUrl(`${apiURL}/v1/parameter/namespace-tag`), async () => {
+    return HttpResponse.json(NAMESPACE_TAGS_LIST_API_RESPONSE, { status: 200 });
   }),
   http.get(sanitizeUrl(`${apiURL}/v1/parameter/devicetypeid`), async () => {
     return HttpResponse.json(DEVICE_TYPES_LIST_API_RESPONSE, { status: 200 });

--- a/ui/tests/e2e/shared/apiMocks.ts
+++ b/ui/tests/e2e/shared/apiMocks.ts
@@ -24,6 +24,7 @@ import {
   ROLES_LIST_API_RESPONSE,
   STATUS_LIST_API_RESPONSE,
   TENANT_LIST_API_RESPONSE,
+  NAMESPACE_TAGS_LIST_API_RESPONSE,
   DEVICE_TYPES_LIST_API_RESPONSE,
   FORBIDDEN_WORKFLOW_ID,
   FORBIDDEN_SITE_ID,
@@ -90,6 +91,7 @@ export async function setupApiMocks(page: Page) {
   await mockRolesEndpoint(page);
   await mockStatusEndpoint(page);
   await mockTenantsEndpoint(page);
+  await mockNamespaceTagsEndpoint(page);
   await mockDeviceTypesEndpoint(page);
   await mockDevicesEndpoint(page);
   await mockPasswordUsersEndpoint(page);
@@ -989,6 +991,15 @@ export async function mockTenantsEndpoint(page: Page) {
     await route.fulfill({
       status: 200,
       json: TENANT_LIST_API_RESPONSE,
+    });
+  });
+}
+
+export async function mockNamespaceTagsEndpoint(page: Page) {
+  await page.route(/.*\/v1\/parameter\/namespace-tag/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      json: NAMESPACE_TAGS_LIST_API_RESPONSE,
     });
   });
 }

--- a/ui/tests/e2e/spxOverlayCreationForm.spec.ts
+++ b/ui/tests/e2e/spxOverlayCreationForm.spec.ts
@@ -41,7 +41,6 @@ test.describe("SpX Overlay Creation Workflow Form", () => {
 
   test("displays validation errors for empty submission", async ({ page }) => {
     // Clear the default values that are auto-populated
-    await page.getByLabel("Namespace").fill("");
     await page.getByLabel("RD Min").fill("");
     await page.getByLabel("RD Max").fill("");
 
@@ -55,9 +54,6 @@ test.describe("SpX Overlay Creation Workflow Form", () => {
       timeout: TEST_TIMEOUT,
     });
     await expect(page.getByText("Tenant is required")).toBeVisible({
-      timeout: TEST_TIMEOUT,
-    });
-    await expect(page.getByText("Namespace is required")).toBeVisible({
       timeout: TEST_TIMEOUT,
     });
 
@@ -81,7 +77,6 @@ test.describe("SpX Overlay Creation Workflow Form", () => {
 
     await page.getByLabel("Overlay ID").fill("test-overlay");
     await page.getByLabel("Tenant").fill("test-tenant");
-    await page.getByLabel("Namespace").fill("spectrumx");
 
     // Set RD Min greater than RD Max
     await page.getByLabel("RD Min").fill("65000");
@@ -118,9 +113,9 @@ test.describe("SpX Overlay Creation Workflow Form - URL Parameters", () => {
     ).toBeVisible({ timeout: TEST_TIMEOUT });
     await expect(page.getByLabel("Overlay ID")).toHaveValue(VPC_DATA.overlay_id);
     await expect(page.getByLabel("Tenant")).toHaveValue(VPC_DATA.tenant);
-    await expect(page.getByLabel("Namespace")).toHaveValue(
-      VPC_DATA.namespace_tag
-    );
+    await expect(
+      page.getByRole("button", { name: VPC_DATA.namespace_tag, exact: true })
+    ).toBeVisible({ timeout: TEST_TIMEOUT });
     await expect(page.getByLabel("RD Min")).toHaveValue(
       VPC_DATA.rd_min.toString()
     );
@@ -189,8 +184,9 @@ test.describe("SpX Overlay Creation Workflow Form - URL Parameters", () => {
     // Change the tenant
     await page.getByLabel("Tenant").fill("modified-tenant");
 
-    // Change the namespace
-    await page.getByLabel("Namespace").fill("modified-namespace");
+    // Change the namespace tag
+    await page.getByRole("button", { name: VPC_DATA.namespace_tag }).click();
+    await page.getByRole("dialog").getByText("tenant-a").click();
 
     // Change RD Min and RD Max
     await page.getByLabel("RD Min").fill("61000");
@@ -213,7 +209,7 @@ test.describe("SpX Overlay Creation Workflow Form - URL Parameters", () => {
       site: SITES_LIST.rno1,
       overlay_id: "modified-vpc",
       tenant: "modified-tenant",
-      namespace_tag: "modified-namespace",
+      namespace_tag: "tenant-a",
       rd_min: 61000,
       rd_max: 64000,
     });
@@ -290,7 +286,6 @@ test.describe("SpX Overlay Creation Workflow Form - Standard Tests", () => {
 
     await page.getByLabel("Overlay ID").fill("test-overlay-submission");
     await page.getByLabel("Tenant").fill("test-tenant");
-    await page.getByLabel("Namespace").fill("test-namespace");
     await page.getByLabel("RD Min").fill("62000");
     await page.getByLabel("RD Max").fill("63000");
 
@@ -302,7 +297,9 @@ test.describe("SpX Overlay Creation Workflow Form - Standard Tests", () => {
     ).toBeDisabled();
     await expect(page.getByLabel("Overlay ID")).toBeDisabled();
     await expect(page.getByLabel("Tenant")).toBeDisabled();
-    await expect(page.getByLabel("Namespace")).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: VPC_DATA.namespace_tag, exact: true })
+    ).toBeDisabled();
     await expect(page.getByLabel("RD Min")).toBeDisabled();
     await expect(page.getByLabel("RD Max")).toBeDisabled();
     await expect(
@@ -310,14 +307,16 @@ test.describe("SpX Overlay Creation Workflow Form - Standard Tests", () => {
     ).toBeDisabled();
   });
 
-  test("populates default values for namespace, rd_min, and rd_max", async ({
+  test("populates default values for namespace tag, rd_min, and rd_max", async ({
     page,
   }) => {
     // Navigate to the form without any URL parameters
     await page.goto("/workflows/spxoverlaycreationworkflow/form");
 
-    // Verify that namespace has the default value "spectrumx"
-    await expect(page.getByLabel("Namespace")).toHaveValue("spectrumx");
+    // Verify that namespace tag has the default value "spectrumx"
+    await expect(
+      page.getByRole("button", { name: VPC_DATA.namespace_tag, exact: true })
+    ).toBeVisible({ timeout: TEST_TIMEOUT });
 
     // Verify that RD Min has the default value "60000"
     await expect(page.getByLabel("RD Min")).toHaveValue("60000");
@@ -342,7 +341,6 @@ test.describe("SpX Overlay Creation Workflow Form - Standard Tests", () => {
 
     await page.getByLabel("Overlay ID").fill("test-overlay");
     await page.getByLabel("Tenant").fill("test-tenant");
-    await page.getByLabel("Namespace").fill("test-namespace");
     await page.getByLabel("RD Min").fill("60000");
     await page.getByLabel("RD Max").fill("65000");
 


### PR DESCRIPTION
## Description

Update the SpX Overlay Creation workflow form so the namespace input is labeled and handled as a namespace tag rather than the misleadingly-named 'namespace'. The form now uses a searchable Nautobot namespace-tag selector.

The SpX Overlay Creation user guide and generated Temporal OpenAPI spec are updated for the new selector/endpoint.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/27984793541

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced namespace tag selection for SpX Overlay Creation workflow—users now select from available tags via dropdown instead of entering free text.
  * Added new namespace tag API endpoint with optional location filtering.

* **Documentation**
  * Updated VPC/SpX Overlay Creation guide to reflect namespace tag selection requirements and updated field naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->