### PR TITLE
add standard mcp auth endpoints

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -928,6 +928,62 @@ Common secret names
 {{- include "nv-config-manager.componentName" (dict "root" . "component" "ini") -}}
 {{- end }}
 
+{{- define "nv-config-manager.mcpAuthConfigMapName" -}}
+{{- include "nv-config-manager.componentName" (dict "root" . "component" "mcp-auth") -}}
+{{- end }}
+
+{{/*
+Public MCP OAuth metadata ConfigMap data.
+*/}}
+{{- define "nv-config-manager.configmap.mcp-auth" -}}
+{{- $oauth := dig "auth" "oauth" (dict) .Values.mcp -}}
+{{- $enabled := .Values.oidc.enabled -}}
+{{- if hasKey $oauth "enabled" -}}
+{{- $enabled = $oauth.enabled -}}
+{{- end -}}
+mcp-auth.ini: |
+  [mcp.oauth]
+  enabled = {{ $enabled }}
+  {{- if $enabled }}
+  {{- $resourceUrl := get $oauth "resourceUrl" | default (printf "https://%s/mcp" (tpl (.Values.mcp.gateway.svcHostname | default "") .)) -}}
+  {{- $resourceUrl = trimSuffix "/" (tpl $resourceUrl .) -}}
+  {{- $issuerUrl := get $oauth "issuerUrl" | default .Values.oidc.issuerUrl -}}
+  {{- $issuerUrl = required "mcp.auth.oauth.issuerUrl or oidc.issuerUrl is required when MCP OAuth metadata is enabled" $issuerUrl -}}
+  {{- $issuerUrl = trimSuffix "/" (tpl $issuerUrl .) -}}
+  {{- $clientId := get $oauth "clientId" | default .Values.oidc.cliClientId | default .Values.oidc.clientId -}}
+  {{- $clientId = required "mcp.auth.oauth.clientId or oidc.cliClientId/clientId is required when MCP OAuth metadata is enabled" $clientId -}}
+  {{- $authorizationEndpoint := get $oauth "authorizationEndpoint" | default .Values.oidc.authorizationEndpoint -}}
+  {{- if $authorizationEndpoint -}}
+  {{- $authorizationEndpoint = trimSuffix "/" (tpl $authorizationEndpoint .) -}}
+  {{- else -}}
+  {{- $authorizationEndpoint = printf "%s/protocol/openid-connect/auth" $issuerUrl -}}
+  {{- end -}}
+  {{- $tokenEndpoint := get $oauth "tokenEndpoint" | default .Values.oidc.tokenEndpoint -}}
+  {{- if $tokenEndpoint -}}
+  {{- $tokenEndpoint = trimSuffix "/" (tpl $tokenEndpoint .) -}}
+  {{- else -}}
+  {{- $tokenEndpoint = printf "%s/protocol/openid-connect/token" $issuerUrl -}}
+  {{- end -}}
+  {{- $jwksUri := get $oauth "jwksUri" | default .Values.oidc.jwksUri -}}
+  {{- if $jwksUri -}}
+  {{- $jwksUri = trimSuffix "/" (tpl $jwksUri .) -}}
+  {{- end -}}
+  {{- $scopes := get $oauth "scopes" | default .Values.oidc.scopes -}}
+  {{- if not $scopes -}}
+  {{- $scopes = list "openid" "email" "profile" -}}
+  {{- end }}
+  resource_url = {{ $resourceUrl }}
+  issuer_url = {{ $issuerUrl }}
+  client_id = {{ $clientId }}
+  scopes = {{ if kindIs "string" $scopes }}{{ $scopes }}{{ else }}{{ join " " $scopes }}{{ end }}
+  authorization_endpoint = {{ $authorizationEndpoint }}
+  token_endpoint = {{ $tokenEndpoint }}
+  {{- if $jwksUri }}
+  jwks_uri = {{ $jwksUri }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- define "nv-config-manager.networkSecretsName" -}}
 {{- include "nv-config-manager.componentName" (dict "root" . "component" "network-secrets") -}}
 {{- end }}

--- a/deploy/helm/templates/mcp-auth-configmap.yaml
+++ b/deploy/helm/templates/mcp-auth-configmap.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+{{- if .Values.mcp.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nv-config-manager.mcpAuthConfigMapName" . }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "nv-config-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp
+data:
+{{- include "nv-config-manager.configmap.mcp-auth" . | nindent 2 }}
+{{- end }}

--- a/deploy/helm/templates/mcp.yaml
+++ b/deploy/helm/templates/mcp.yaml
@@ -28,6 +28,7 @@ spec:
         {{- include "nv-config-manager.customPodLabels" . | nindent 8 }}
       annotations:
         {{- include "nv-config-manager.authIniChecksum" . | nindent 8 }}
+        checksum/mcp-auth: {{ include "nv-config-manager.configmap.mcp-auth" . | sha256sum }}
         {{- if eq .Values.secrets.method "vault-agent" }}
         {{- include "nv-config-manager.vaultAgent.injectorAnnotations" . | nindent 8 }}
         {{- end }}
@@ -56,6 +57,8 @@ spec:
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         - name: NV_CONFIG_MANAGER_INI
           value: {{ include "nv-config-manager.vaultAgent.configManagerIniPathApp" . | quote }}
+        - name: NV_CONFIG_MANAGER_MCP_AUTH_INI
+          value: "/etc/nv-config-manager-mcp-auth/mcp-auth.ini"
         - name: NV_CONFIG_MANAGER_SERVICE
           value: "mcp"
         ports:
@@ -65,6 +68,9 @@ spec:
           {{- toYaml .Values.mcp.api.resources | nindent 10 }}
         volumeMounts:
         {{- include "nv-config-manager.vaultAgent.configManagerIniVolumeMount" . | nindent 8 }}
+        - name: mcp-auth-config
+          mountPath: /etc/nv-config-manager-mcp-auth
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /healthcheck
@@ -82,6 +88,9 @@ spec:
       volumes:
       {{- include "nv-config-manager.vaultAgent.projectedSATokenVolume" . | nindent 6 }}
       {{- include "nv-config-manager.vaultAgent.configManagerIniVolume" . | nindent 6 }}
+      - name: mcp-auth-config
+        configMap:
+          name: {{ include "nv-config-manager.mcpAuthConfigMapName" . }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1895,6 +1895,28 @@ mcp:
       paths:
         - /healthcheck
         - /metrics
+        - /.well-known/oauth-protected-resource
+        - /.well-known/oauth-protected-resource/mcp
+        - /.well-known/oauth-authorization-server
+  auth:
+    oauth:
+      # Defaults to oidc.enabled when unset. Set false to disable MCP OAuth
+      # discovery metadata even when OIDC is enabled.
+      # enabled: true
+      # Defaults to https://<svc-mcp-hostname>/mcp
+      resourceUrl: ""
+      # Defaults to oidc.issuerUrl.
+      issuerUrl: ""
+      # Defaults to oidc.cliClientId, then oidc.clientId.
+      clientId: ""
+      # Defaults to oidc.scopes, or openid email profile when oidc.scopes is empty.
+      scopes: []
+      # Defaults to oidc.authorizationEndpoint, or {issuerUrl}/protocol/openid-connect/auth.
+      authorizationEndpoint: ""
+      # Defaults to oidc.tokenEndpoint, or {issuerUrl}/protocol/openid-connect/token.
+      tokenEndpoint: ""
+      # Defaults to oidc.jwksUri when set. Optional for OAuth discovery clients.
+      jwksUri: ""
   api:
     replicas: 2
     resources:

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -10,7 +10,7 @@ Use MCP when you want an assistant or other MCP-capable client to answer operati
 
 ## Quick Setup
 
-There are two supported ways to discover the MCP connection details.
+There are three supported ways to connect to the MCP server.
 
 ### Use the helper CLI
 
@@ -37,6 +37,79 @@ nvcm-mcp-cli token -H config-manager.example.com
 
 For local development environments that use a self-signed certificate, add `-k`.
 
+### Use client-native OAuth
+
+Remote MCP clients with native OAuth support can authenticate directly against the MCP endpoint when SSO is enabled. The MCP service exposes standard OAuth discovery metadata at the MCP host under `/.well-known/`.
+
+The OAuth client ID is required. Config Manager does not support OAuth Dynamic Client Registration, so the client must be configured with the public/native OIDC client ID from the Config Manager auth discovery endpoint.
+
+Get the client ID, MCP URL, and scopes from `/auth/discovery`:
+
+```sh
+DISCOVERY_JSON=$(curl -fsS https://config-manager.example.com/auth/discovery)
+
+CLIENT_ID=$(printf '%s' "$DISCOVERY_JSON" | jq -r '.clientId')
+MCP_URL=$(printf '%s' "$DISCOVERY_JSON" | jq -r '.services.mcp')
+SCOPES=$(printf '%s' "$DISCOVERY_JSON" | jq -r '.scopes | join(",")')
+```
+
+The response includes the same fields directly:
+
+```json
+{
+  "authRequired": true,
+  "issuerUrl": "https://idp.example.com/realms/nv-config-manager",
+  "clientId": "nv-config-manager-cli",
+  "scopes": ["openid", "profile", "email"],
+  "services": {
+    "mcp": "https://svc-mcp.config-manager.example.com/mcp"
+  }
+}
+```
+
+For Codex, add the Streamable HTTP MCP server with the client ID, then log in:
+
+```sh
+codex mcp add nv-config-manager \
+  --url "$MCP_URL" \
+  --oauth-client-id "$CLIENT_ID"
+
+codex mcp login nv-config-manager --scopes "$SCOPES"
+```
+
+If your deployment requires an OAuth resource parameter, include the MCP endpoint as the resource:
+
+```sh
+codex mcp add nv-config-manager \
+  --url "$MCP_URL" \
+  --oauth-client-id "$CLIENT_ID" \
+  --oauth-resource "$MCP_URL"
+```
+
+For Claude Code, add the HTTP MCP server with the same client ID:
+
+```sh
+claude mcp add --transport http \
+  --client-id "$CLIENT_ID" \
+  nv-config-manager "$MCP_URL"
+```
+
+If your identity provider requires a pre-registered localhost callback URI, also pass `--callback-port <port>` and register `http://localhost:<port>/callback` with the client.
+
+After adding the server, run `/mcp` in Claude Code and select Authenticate. Claude Code should discover the MCP OAuth metadata from the remote endpoint and print or open the browser login URL.
+
+For other MCP clients, configure:
+
+| Setting | Value |
+| :------ | :---- |
+| Transport | Streamable HTTP |
+| URL | `https://svc-mcp.<hostname>/mcp`, or the endpoint from `/auth/discovery` |
+| OAuth flow | Authorization Code with PKCE |
+| Client ID | Required; use `clientId` from `/auth/discovery` |
+| Scopes | Use the scopes in the OAuth metadata; the default is `openid email profile` |
+
+Clients that expect OAuth Dynamic Client Registration and do not let you provide a client ID cannot complete the native OAuth flow. Use the `nvcm-mcp-cli` helper and bearer-token configuration for those clients.
+
 ### Use discovery directly
 
 You can also tell an MCP-capable assistant or client to discover the server details from:
@@ -61,7 +134,8 @@ Use these settings when configuring a client manually:
 | :------ | :---- |
 | Transport | Streamable HTTP |
 | URL | Use `nvcm-mcp-cli endpoint -H <hostname>` or the endpoint from `/auth/discovery` |
-| Authentication | Use bearer authentication only when discovery or the helper says it is required |
+| Authentication | Use client-native OAuth with an explicit client ID, or use bearer authentication when discovery or the helper says it is required |
+| OAuth client ID | Required for client-native OAuth; use `clientId` from `/auth/discovery` |
 
 When bearer authentication is required, prefer an environment variable or the client's secret storage instead of writing tokens into static configuration files.
 
@@ -109,4 +183,6 @@ For the best results, connect both MCP servers: use the deployment MCP server fo
 - The bearer token represents the signed-in user.
 - MCP tools use the caller's access for Config Manager APIs.
 - External Nautobot deployments may use a configured read-only Nautobot token for MCP Nautobot queries.
+- OAuth discovery metadata does not register clients. Native OAuth MCP clients must use a preconfigured public/native OIDC client ID.
+- Native OAuth MCP clients should not use an OIDC client secret.
 - Token values should be treated as secrets and kept out of documentation, logs, and committed configuration.

--- a/installer/tests/test_deployer.py
+++ b/installer/tests/test_deployer.py
@@ -119,10 +119,15 @@ def _stub_kube_context_helpers():
     * ``pin_kubeconfig_to_current_context()`` — Deployer.run() calls this
       first thing to materialize a single-context kubeconfig under /tmp. We
       don't want tests touching the host filesystem or invoking kubectl.
+    * ``_gateway_class_helm_owner()`` — helm install checks whether an
+      existing GatewayClass belongs to another Helm release. Most deployer
+      tests are not exercising that cluster probe and should not require
+      kubectl to be installed.
 
-    Pin both: the context helper returns the same value the mock K8sClient
-    advertises; the pinning helper is a no-op (returns None, deployer just
-    logs a warning and proceeds).
+    Pin these boundaries: the context helper returns the same value the mock
+    K8sClient advertises; the pinning helper is a no-op (returns None,
+    deployer just logs a warning and proceeds); the GatewayClass helper
+    behaves as though the resource is absent.
     """
     with (
         patch(
@@ -131,6 +136,10 @@ def _stub_kube_context_helpers():
         ),
         patch(
             "nv_config_manager_installer.deployer.pin_kubeconfig_to_current_context",
+            return_value=None,
+        ),
+        patch(
+            "nv_config_manager_installer.deployer._gateway_class_helm_owner",
             return_value=None,
         ),
     ):

--- a/src/nv_config_manager/mcp/auth.py
+++ b/src/nv_config_manager/mcp/auth.py
@@ -38,6 +38,14 @@ AUTH_CONTEXT_HEADERS = {
     "x-auth-request-groups": "X-Auth-Request-Groups",
     "x-auth-request-subject": "X-Auth-Request-Subject",
 }
+OAUTH_METADATA_PATHS = frozenset(
+    {
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource/mcp",
+        "/.well-known/oauth-authorization-server",
+    }
+)
+DEFAULT_MCP_UNAUTHENTICATED_PATHS = DEFAULT_UNAUTHENTICATED_PATHS | OAUTH_METADATA_PATHS
 
 
 class MissingBearerTokenError(Exception):
@@ -102,10 +110,12 @@ class ServiceAuthMiddleware:
     def __init__(
         self,
         app: ASGIApp,
-        unauthenticated_paths: frozenset[str] = DEFAULT_UNAUTHENTICATED_PATHS,
+        unauthenticated_paths: frozenset[str] = DEFAULT_MCP_UNAUTHENTICATED_PATHS,
+        resource_metadata_url: str = "",
     ) -> None:
         self.app = app
         self.unauthenticated_paths = unauthenticated_paths
+        self.resource_metadata_url = resource_metadata_url
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Any:
         if scope["type"] != "http":
@@ -120,7 +130,12 @@ class ServiceAuthMiddleware:
         try:
             await require_authenticated_identity(request)
         except HTTPException as exc:
-            response = JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+            headers = _auth_failure_headers(exc, self.resource_metadata_url)
+            response = JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=headers,
+            )
             return await response(scope, receive, send)
 
         return await self.app(scope, receive, send)
@@ -153,3 +168,19 @@ def user_bearer_authorization() -> str | None:
     if not auth:
         return None
     return auth.bearer_authorization
+
+
+def _auth_failure_headers(exc: HTTPException, resource_metadata_url: str) -> dict[str, str]:
+    if not resource_metadata_url or exc.status_code not in (401, 403):
+        return {}
+    detail = str(exc.detail or "Authentication required")
+    www_authenticate = (
+        'Bearer error="invalid_token", '
+        f'error_description="{_escape_www_authenticate_value(detail)}", '
+        f'resource_metadata="{_escape_www_authenticate_value(resource_metadata_url)}"'
+    )
+    return {"WWW-Authenticate": www_authenticate}
+
+
+def _escape_www_authenticate_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/nv_config_manager/mcp/main.py
+++ b/src/nv_config_manager/mcp/main.py
@@ -26,16 +26,28 @@ from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
 from nv_config_manager.common.log import configure_logging
-from nv_config_manager.mcp.auth import RequestAuthMiddleware, ServiceAuthMiddleware
-from nv_config_manager.mcp.settings import MCPSettings
+from nv_config_manager.mcp.auth import (
+    DEFAULT_MCP_UNAUTHENTICATED_PATHS,
+    RequestAuthMiddleware,
+    ServiceAuthMiddleware,
+)
+from nv_config_manager.mcp.oauth_metadata import (
+    authorization_server_metadata,
+    protected_resource_metadata,
+)
+from nv_config_manager.mcp.settings import MCPOAuthSettings, MCPSettings
 from nv_config_manager.mcp.tools import register_tools
 
 configure_logging(service="mcp")
 
 
-def create_mcp_server(settings: MCPSettings | None = None) -> FastMCP:
+def create_mcp_server(
+    settings: MCPSettings | None = None,
+    oauth_settings: MCPOAuthSettings | None = None,
+) -> FastMCP:
     """Create the FastMCP server and register tools."""
     resolved_settings = settings or MCPSettings.from_config()
+    resolved_oauth_settings = oauth_settings or MCPOAuthSettings.from_config()
     server = FastMCP(
         "nvidia-config-manager-mcp",
         instructions=(
@@ -60,15 +72,73 @@ def create_mcp_server(settings: MCPSettings | None = None) -> FastMCP:
     async def metrics(request: Request) -> Response:
         return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
+    if resolved_oauth_settings.enabled:
+        _register_oauth_metadata_routes(server, resolved_oauth_settings)
+
     register_tools(server, resolved_settings)
     return server
 
 
-def create_app(settings: MCPSettings | None = None) -> ASGIApp:
+def create_app(
+    settings: MCPSettings | None = None,
+    oauth_settings: MCPOAuthSettings | None = None,
+) -> ASGIApp:
     """Create the ASGI application for Streamable HTTP MCP."""
+    resolved_oauth_settings = oauth_settings or MCPOAuthSettings.from_config()
+    unauthenticated_paths = DEFAULT_MCP_UNAUTHENTICATED_PATHS
+    resource_metadata_url = ""
+    if resolved_oauth_settings.enabled:
+        resource_metadata_url = resolved_oauth_settings.resource_metadata_url
     return ServiceAuthMiddleware(
-        RequestAuthMiddleware(create_mcp_server(settings).streamable_http_app())
+        RequestAuthMiddleware(
+            create_mcp_server(settings, resolved_oauth_settings).streamable_http_app()
+        ),
+        unauthenticated_paths=unauthenticated_paths,
+        resource_metadata_url=resource_metadata_url,
     )
+
+
+def _register_oauth_metadata_routes(server: FastMCP, settings: MCPOAuthSettings) -> None:
+    @server.custom_route(
+        "/.well-known/oauth-protected-resource",
+        methods=["GET", "OPTIONS"],
+        include_in_schema=False,
+    )
+    async def protected_resource_metadata_root(request: Request) -> JSONResponse | Response:
+        if request.method == "OPTIONS":
+            return Response(status_code=204)
+        return JSONResponse(
+            protected_resource_metadata(settings),
+            headers={"Cache-Control": "no-store"},
+        )
+
+    @server.custom_route(
+        "/.well-known/oauth-protected-resource/mcp",
+        methods=["GET", "OPTIONS"],
+        include_in_schema=False,
+    )
+    async def protected_resource_metadata_mcp(request: Request) -> JSONResponse | Response:
+        if request.method == "OPTIONS":
+            return Response(status_code=204)
+        return JSONResponse(
+            protected_resource_metadata(settings),
+            headers={"Cache-Control": "no-store"},
+        )
+
+    @server.custom_route(
+        "/.well-known/oauth-authorization-server",
+        methods=["GET", "OPTIONS"],
+        include_in_schema=False,
+    )
+    async def oauth_authorization_server_metadata(
+        request: Request,
+    ) -> JSONResponse | Response:
+        if request.method == "OPTIONS":
+            return Response(status_code=204)
+        return JSONResponse(
+            authorization_server_metadata(settings),
+            headers={"Cache-Control": "no-store"},
+        )
 
 
 def main() -> None:

--- a/src/nv_config_manager/mcp/main.py
+++ b/src/nv_config_manager/mcp/main.py
@@ -35,7 +35,11 @@ from nv_config_manager.mcp.oauth_metadata import (
     authorization_server_metadata,
     protected_resource_metadata,
 )
-from nv_config_manager.mcp.settings import MCPOAuthSettings, MCPSettings
+from nv_config_manager.mcp.settings import (
+    AUTHORIZATION_SERVER_METADATA_PATH,
+    MCPOAuthSettings,
+    MCPSettings,
+)
 from nv_config_manager.mcp.tools import register_tools
 
 configure_logging(service="mcp")
@@ -89,6 +93,7 @@ def create_app(
     resource_metadata_url = ""
     if resolved_oauth_settings.enabled:
         resource_metadata_url = resolved_oauth_settings.resource_metadata_url
+        unauthenticated_paths = unauthenticated_paths | resolved_oauth_settings.well_known_paths
     return ServiceAuthMiddleware(
         RequestAuthMiddleware(
             create_mcp_server(settings, resolved_oauth_settings).streamable_http_app()
@@ -99,12 +104,9 @@ def create_app(
 
 
 def _register_oauth_metadata_routes(server: FastMCP, settings: MCPOAuthSettings) -> None:
-    @server.custom_route(
-        "/.well-known/oauth-protected-resource",
-        methods=["GET", "OPTIONS"],
-        include_in_schema=False,
-    )
-    async def protected_resource_metadata_root(request: Request) -> JSONResponse | Response:
+    async def oauth_protected_resource_metadata(
+        request: Request,
+    ) -> JSONResponse | Response:
         if request.method == "OPTIONS":
             return Response(status_code=204)
         return JSONResponse(
@@ -112,21 +114,15 @@ def _register_oauth_metadata_routes(server: FastMCP, settings: MCPOAuthSettings)
             headers={"Cache-Control": "no-store"},
         )
 
-    @server.custom_route(
-        "/.well-known/oauth-protected-resource/mcp",
-        methods=["GET", "OPTIONS"],
-        include_in_schema=False,
-    )
-    async def protected_resource_metadata_mcp(request: Request) -> JSONResponse | Response:
-        if request.method == "OPTIONS":
-            return Response(status_code=204)
-        return JSONResponse(
-            protected_resource_metadata(settings),
-            headers={"Cache-Control": "no-store"},
-        )
+    for metadata_path in settings.well_known_paths - {AUTHORIZATION_SERVER_METADATA_PATH}:
+        server.custom_route(
+            metadata_path,
+            methods=["GET", "OPTIONS"],
+            include_in_schema=False,
+        )(oauth_protected_resource_metadata)
 
     @server.custom_route(
-        "/.well-known/oauth-authorization-server",
+        AUTHORIZATION_SERVER_METADATA_PATH,
         methods=["GET", "OPTIONS"],
         include_in_schema=False,
     )

--- a/src/nv_config_manager/mcp/oauth_metadata.py
+++ b/src/nv_config_manager/mcp/oauth_metadata.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OAuth metadata advertised by the remote MCP resource server."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nv_config_manager.mcp.settings import MCPOAuthSettings
+
+
+def protected_resource_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:
+    """Build RFC 9728 protected resource metadata for the MCP endpoint."""
+    authorization_servers = _unique_urls([settings.authorization_server_url, settings.issuer_url])
+    metadata: dict[str, Any] = {
+        "resource": settings.resource_url,
+        "authorization_servers": authorization_servers,
+        "bearer_methods_supported": ["header"],
+        "resource_name": "NVIDIA Config Manager MCP",
+    }
+    if settings.scopes:
+        metadata["scopes_supported"] = list(settings.scopes)
+    if settings.jwks_uri:
+        metadata["jwks_uri"] = settings.jwks_uri
+    return metadata
+
+
+def _unique_urls(values: list[str]) -> list[str]:
+    unique_values: list[str] = []
+    for value in values:
+        if value and value not in unique_values:
+            unique_values.append(value)
+    return unique_values
+
+
+def authorization_server_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:
+    """Build OAuth authorization server metadata backed by the configured IdP."""
+    metadata: dict[str, Any] = {
+        "issuer": settings.issuer_url,
+        "authorization_endpoint": settings.authorization_endpoint,
+        "token_endpoint": settings.token_endpoint,
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "code_challenge_methods_supported": ["S256"],
+        "client_id_metadata_document_supported": False,
+    }
+    if settings.scopes:
+        metadata["scopes_supported"] = list(settings.scopes)
+    if settings.jwks_uri:
+        metadata["jwks_uri"] = settings.jwks_uri
+    return metadata

--- a/src/nv_config_manager/mcp/oauth_metadata.py
+++ b/src/nv_config_manager/mcp/oauth_metadata.py
@@ -23,10 +23,9 @@ from nv_config_manager.mcp.settings import MCPOAuthSettings
 
 def protected_resource_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:
     """Build RFC 9728 protected resource metadata for the MCP endpoint."""
-    authorization_servers = _unique_urls([settings.authorization_server_url, settings.issuer_url])
     metadata: dict[str, Any] = {
         "resource": settings.resource_url,
-        "authorization_servers": authorization_servers,
+        "authorization_servers": [settings.issuer_url],
         "bearer_methods_supported": ["header"],
         "resource_name": "NVIDIA Config Manager MCP",
     }
@@ -35,14 +34,6 @@ def protected_resource_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:
     if settings.jwks_uri:
         metadata["jwks_uri"] = settings.jwks_uri
     return metadata
-
-
-def _unique_urls(values: list[str]) -> list[str]:
-    unique_values: list[str] = []
-    for value in values:
-        if value and value not in unique_values:
-            unique_values.append(value)
-    return unique_values
 
 
 def authorization_server_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:

--- a/src/nv_config_manager/mcp/settings.py
+++ b/src/nv_config_manager/mcp/settings.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 from configparser import ConfigParser
 from dataclasses import dataclass
 from urllib.parse import urlparse
@@ -23,6 +24,8 @@ from urllib.parse import urlparse
 from nv_config_manager.common.config import load_config, parse_verify_param
 
 NAUTOBOT_AUTH_MODES = {"auto", "jwt", "token"}
+MCP_AUTH_CONFIG_ENV_VAR = "NV_CONFIG_MANAGER_MCP_AUTH_INI"
+DEFAULT_MCP_AUTH_CONFIG_PATH = "/etc/nv-config-manager/mcp-auth.ini"
 
 
 @dataclass(frozen=True)
@@ -67,6 +70,81 @@ class MCPSettings:
             ),
             max_response_bytes=_get_int(config, "mcp", "max_response_bytes", 100_000),
         )
+
+
+@dataclass(frozen=True)
+class MCPOAuthSettings:
+    """Public OAuth metadata advertised for remote MCP clients."""
+
+    enabled: bool
+    resource_url: str = ""
+    issuer_url: str = ""
+    client_id: str = ""
+    scopes: tuple[str, ...] = ()
+    authorization_endpoint: str = ""
+    token_endpoint: str = ""
+    jwks_uri: str = ""
+
+    @classmethod
+    def from_config(cls, config: ConfigParser | None = None) -> MCPOAuthSettings:
+        """Resolve MCP OAuth discovery metadata from mcp-auth.ini."""
+        if config is None:
+            config = load_mcp_auth_config()
+        enabled = _get_bool(config, "mcp.oauth", "enabled", False)
+        if not enabled:
+            return cls(enabled=False)
+
+        settings = cls(
+            enabled=True,
+            resource_url=_normalized_required_url(config, "resource_url"),
+            issuer_url=_normalized_required_url(config, "issuer_url"),
+            client_id=_get_required(config, "mcp.oauth", "client_id").strip(),
+            scopes=_parse_scopes(_get_value(config, "mcp.oauth", "scopes", "")),
+            authorization_endpoint=_normalized_required_url(config, "authorization_endpoint"),
+            token_endpoint=_normalized_required_url(config, "token_endpoint"),
+            jwks_uri=_normalize_url(_get_value(config, "mcp.oauth", "jwks_uri", "")),
+        )
+        if not settings.client_id:
+            raise ValueError("Missing required MCP OAuth config value [mcp.oauth] client_id")
+        return settings
+
+    @property
+    def resource_metadata_url(self) -> str:
+        """Return the RFC 9728 protected resource metadata URL for this MCP resource."""
+        if not self.enabled or not self.resource_url:
+            return ""
+        parsed = urlparse(self.resource_url)
+        resource_path = parsed.path.rstrip("/")
+        return (
+            f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-protected-resource{resource_path}"
+        )
+
+    @property
+    def authorization_server_url(self) -> str:
+        """Return the MCP-origin authorization metadata bridge URL."""
+        if not self.enabled or not self.resource_url:
+            return ""
+        parsed = urlparse(self.resource_url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    @property
+    def well_known_paths(self) -> frozenset[str]:
+        """Return unauthenticated well-known metadata paths served by MCP."""
+        return frozenset(
+            {
+                "/.well-known/oauth-protected-resource",
+                "/.well-known/oauth-protected-resource/mcp",
+                "/.well-known/oauth-authorization-server",
+            }
+        )
+
+
+def load_mcp_auth_config() -> ConfigParser:
+    """Load public MCP OAuth metadata from a dedicated ConfigMap-backed INI."""
+    config = ConfigParser(interpolation=None, delimiters=("=",))
+    config_path = os.getenv(MCP_AUTH_CONFIG_ENV_VAR, DEFAULT_MCP_AUTH_CONFIG_PATH)
+    config.read(config_path)
+    return config
 
 
 def _get_value(config: ConfigParser, section: str, key: str, fallback: str) -> str:
@@ -138,3 +216,21 @@ def _looks_like_local_nautobot(nautobot_url: str) -> bool:
         or ".svc." in hostname
         or hostname.endswith(".svc.cluster.local")
     )
+
+
+def _normalize_url(value: str) -> str:
+    return value.strip().rstrip("/")
+
+
+def _normalized_required_url(config: ConfigParser, key: str) -> str:
+    value = _normalize_url(_get_required(config, "mcp.oauth", key))
+    if not value:
+        raise ValueError(f"Missing required MCP OAuth config value [mcp.oauth] {key}")
+    parsed = urlparse(value)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Invalid MCP OAuth URL value [mcp.oauth] {key}: {value}")
+    return value
+
+
+def _parse_scopes(value: str) -> tuple[str, ...]:
+    return tuple(scope for scope in value.replace(",", " ").split() if scope)

--- a/src/nv_config_manager/mcp/settings.py
+++ b/src/nv_config_manager/mcp/settings.py
@@ -26,6 +26,8 @@ from nv_config_manager.common.config import load_config, parse_verify_param
 NAUTOBOT_AUTH_MODES = {"auto", "jwt", "token"}
 MCP_AUTH_CONFIG_ENV_VAR = "NV_CONFIG_MANAGER_MCP_AUTH_INI"
 DEFAULT_MCP_AUTH_CONFIG_PATH = "/etc/nv-config-manager/mcp-auth.ini"
+PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource"
+AUTHORIZATION_SERVER_METADATA_PATH = "/.well-known/oauth-authorization-server"
 
 
 @dataclass(frozen=True)
@@ -130,13 +132,14 @@ class MCPOAuthSettings:
     @property
     def well_known_paths(self) -> frozenset[str]:
         """Return unauthenticated well-known metadata paths served by MCP."""
-        return frozenset(
-            {
-                "/.well-known/oauth-protected-resource",
-                "/.well-known/oauth-protected-resource/mcp",
-                "/.well-known/oauth-authorization-server",
-            }
-        )
+        paths = {
+            PROTECTED_RESOURCE_METADATA_PATH,
+            AUTHORIZATION_SERVER_METADATA_PATH,
+        }
+        if self.enabled and self.resource_metadata_url:
+            metadata_path = urlparse(self.resource_metadata_url).path.rstrip("/") or "/"
+            paths.add(metadata_path)
+        return frozenset(paths)
 
 
 def load_mcp_auth_config() -> ConfigParser:

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -141,6 +141,28 @@ def test_oauth_metadata_endpoints_bypass_service_auth(monkeypatch: pytest.Monkey
     }
 
 
+def test_configured_oauth_metadata_path_bypasses_service_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def reject_identity(request: object) -> object:
+        raise HTTPException(status_code=403, detail="This endpoint requires SSO authentication.")
+
+    monkeypatch.setattr(
+        "nv_config_manager.mcp.auth.require_authenticated_identity",
+        reject_identity,
+    )
+    oauth_settings = _oauth_settings(resource_url="https://svc-mcp.config-manager.local/custom/mcp")
+
+    with TestClient(
+        create_app(_settings(), oauth_settings),
+        base_url="https://svc-mcp.config-manager.local",
+    ) as client:
+        response = client.get("/.well-known/oauth-protected-resource/custom/mcp")
+
+    assert response.status_code == 200
+    assert response.json()["resource"] == "https://svc-mcp.config-manager.local/custom/mcp"
+
+
 def test_oauth_metadata_endpoints_not_registered_when_disabled() -> None:
     client = TestClient(create_app(_settings(), MCPOAuthSettings(enabled=False)))
 
@@ -206,10 +228,12 @@ def _settings() -> MCPSettings:
     )
 
 
-def _oauth_settings() -> MCPOAuthSettings:
+def _oauth_settings(
+    resource_url: str = "https://svc-mcp.config-manager.local/mcp",
+) -> MCPOAuthSettings:
     return MCPOAuthSettings(
         enabled=True,
-        resource_url="https://svc-mcp.config-manager.local/mcp",
+        resource_url=resource_url,
         issuer_url="https://idp.example.test/realms/nvcm",
         client_id="nvcm-cli",
         scopes=("openid", "email", "profile"),

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -116,10 +116,7 @@ def test_oauth_metadata_endpoints_bypass_service_auth(monkeypatch: pytest.Monkey
     assert root_protected_resource_response.status_code == 200
     assert protected_resource_response.json() == {
         "resource": "https://svc-mcp.config-manager.local/mcp",
-        "authorization_servers": [
-            "https://svc-mcp.config-manager.local",
-            "https://idp.example.test/realms/nvcm",
-        ],
+        "authorization_servers": ["https://idp.example.test/realms/nvcm"],
         "bearer_methods_supported": ["header"],
         "resource_name": "NVIDIA Config Manager MCP",
         "scopes_supported": ["openid", "email", "profile"],

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -19,7 +19,7 @@ from fastapi import HTTPException
 from starlette.testclient import TestClient
 
 from nv_config_manager.mcp.main import create_app
-from nv_config_manager.mcp.settings import MCPSettings
+from nv_config_manager.mcp.settings import MCPOAuthSettings, MCPSettings
 
 
 def test_healthcheck() -> None:
@@ -95,6 +95,102 @@ def test_mcp_endpoint_requires_auth_when_enabled(monkeypatch: pytest.MonkeyPatch
     assert response.json() == {"detail": "This endpoint requires SSO authentication."}
 
 
+def test_oauth_metadata_endpoints_bypass_service_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def reject_identity(request: object) -> object:
+        raise HTTPException(status_code=403, detail="This endpoint requires SSO authentication.")
+
+    monkeypatch.setattr(
+        "nv_config_manager.mcp.auth.require_authenticated_identity",
+        reject_identity,
+    )
+
+    with TestClient(
+        create_app(_settings(), _oauth_settings()),
+        base_url="https://svc-mcp.config-manager.local",
+    ) as client:
+        protected_resource_response = client.get("/.well-known/oauth-protected-resource/mcp")
+        root_protected_resource_response = client.get("/.well-known/oauth-protected-resource")
+        auth_server_response = client.get("/.well-known/oauth-authorization-server")
+
+    assert protected_resource_response.status_code == 200
+    assert root_protected_resource_response.status_code == 200
+    assert protected_resource_response.json() == {
+        "resource": "https://svc-mcp.config-manager.local/mcp",
+        "authorization_servers": [
+            "https://svc-mcp.config-manager.local",
+            "https://idp.example.test/realms/nvcm",
+        ],
+        "bearer_methods_supported": ["header"],
+        "resource_name": "NVIDIA Config Manager MCP",
+        "scopes_supported": ["openid", "email", "profile"],
+        "jwks_uri": "https://idp.example.test/realms/nvcm/certs",
+    }
+    assert root_protected_resource_response.json() == protected_resource_response.json()
+    assert auth_server_response.status_code == 200
+    assert auth_server_response.json() == {
+        "issuer": "https://idp.example.test/realms/nvcm",
+        "authorization_endpoint": "https://idp.example.test/realms/nvcm/auth",
+        "token_endpoint": "https://idp.example.test/realms/nvcm/token",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "code_challenge_methods_supported": ["S256"],
+        "client_id_metadata_document_supported": False,
+        "scopes_supported": ["openid", "email", "profile"],
+        "jwks_uri": "https://idp.example.test/realms/nvcm/certs",
+    }
+
+
+def test_oauth_metadata_endpoints_not_registered_when_disabled() -> None:
+    client = TestClient(create_app(_settings(), MCPOAuthSettings(enabled=False)))
+
+    response = client.get("/.well-known/oauth-protected-resource/mcp")
+
+    assert response.status_code == 404
+
+
+def test_mcp_auth_failure_includes_resource_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def reject_identity(request: object) -> object:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    monkeypatch.setattr(
+        "nv_config_manager.mcp.auth.require_authenticated_identity",
+        reject_identity,
+    )
+
+    with TestClient(
+        create_app(_settings(), _oauth_settings()),
+        base_url="https://svc-mcp.config-manager.local",
+    ) as client:
+        response = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "0.0.0"},
+                },
+            },
+        )
+
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == (
+        'Bearer error="invalid_token", '
+        'error_description="Authentication required", '
+        'resource_metadata="https://svc-mcp.config-manager.local'
+        '/.well-known/oauth-protected-resource/mcp"'
+    )
+
+
 def _settings() -> MCPSettings:
     return MCPSettings(
         workflow_api_url="http://workflow:9000",
@@ -107,4 +203,17 @@ def _settings() -> MCPSettings:
         nautobot_auth_mode="jwt",
         nautobot_token_fallback_enabled=False,
         max_response_bytes=1000,
+    )
+
+
+def _oauth_settings() -> MCPOAuthSettings:
+    return MCPOAuthSettings(
+        enabled=True,
+        resource_url="https://svc-mcp.config-manager.local/mcp",
+        issuer_url="https://idp.example.test/realms/nvcm",
+        client_id="nvcm-cli",
+        scopes=("openid", "email", "profile"),
+        authorization_endpoint="https://idp.example.test/realms/nvcm/auth",
+        token_endpoint="https://idp.example.test/realms/nvcm/token",
+        jwks_uri="https://idp.example.test/realms/nvcm/certs",
     )

--- a/src/tests/mcp/test_settings.py
+++ b/src/tests/mcp/test_settings.py
@@ -114,6 +114,23 @@ def test_mcp_oauth_settings_parse_metadata_config() -> None:
     }
 
 
+def test_mcp_oauth_well_known_paths_follow_resource_url_path() -> None:
+    config = _oauth_config()
+    config["mcp.oauth"]["resource_url"] = "https://svc-mcp.example.test/custom/mcp/"
+
+    settings = MCPOAuthSettings.from_config(config)
+
+    assert (
+        settings.resource_metadata_url
+        == "https://svc-mcp.example.test/.well-known/oauth-protected-resource/custom/mcp"
+    )
+    assert settings.well_known_paths == {
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource/custom/mcp",
+        "/.well-known/oauth-authorization-server",
+    }
+
+
 def test_mcp_oauth_settings_requires_valid_urls_when_enabled() -> None:
     config = _oauth_config()
     config["mcp.oauth"]["resource_url"] = "svc-mcp.example.test/mcp"

--- a/src/tests/mcp/test_settings.py
+++ b/src/tests/mcp/test_settings.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 from configparser import ConfigParser
 
-from nv_config_manager.mcp.settings import MCPSettings
+import pytest
+
+from nv_config_manager.mcp.settings import MCPOAuthSettings, MCPSettings
 
 
 def _config(nautobot_server: str, auth_mode: str = "auto") -> ConfigParser:
@@ -84,3 +86,52 @@ def test_workflow_ui_url_falls_back_to_base_hostname() -> None:
     settings = MCPSettings.from_config(config)
 
     assert settings.workflow_ui_url == "https://example.test"
+
+
+def test_mcp_oauth_settings_disabled_without_section() -> None:
+    settings = MCPOAuthSettings.from_config(ConfigParser())
+
+    assert settings.enabled is False
+
+
+def test_mcp_oauth_settings_parse_metadata_config() -> None:
+    settings = MCPOAuthSettings.from_config(_oauth_config())
+
+    assert settings.enabled is True
+    assert settings.resource_url == "https://svc-mcp.example.test/mcp"
+    assert settings.issuer_url == "https://idp.example.test/realms/nvcm"
+    assert settings.client_id == "nvcm-cli"
+    assert settings.scopes == ("openid", "email", "profile")
+    assert (
+        settings.resource_metadata_url
+        == "https://svc-mcp.example.test/.well-known/oauth-protected-resource/mcp"
+    )
+    assert settings.authorization_server_url == "https://svc-mcp.example.test"
+    assert settings.well_known_paths == {
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource/mcp",
+        "/.well-known/oauth-authorization-server",
+    }
+
+
+def test_mcp_oauth_settings_requires_valid_urls_when_enabled() -> None:
+    config = _oauth_config()
+    config["mcp.oauth"]["resource_url"] = "svc-mcp.example.test/mcp"
+
+    with pytest.raises(ValueError, match="resource_url"):
+        MCPOAuthSettings.from_config(config)
+
+
+def _oauth_config() -> ConfigParser:
+    config = ConfigParser()
+    config["mcp.oauth"] = {
+        "enabled": "true",
+        "resource_url": "https://svc-mcp.example.test/mcp/",
+        "issuer_url": "https://idp.example.test/realms/nvcm/",
+        "client_id": "nvcm-cli",
+        "scopes": "openid,email profile",
+        "authorization_endpoint": "https://idp.example.test/realms/nvcm/auth",
+        "token_endpoint": "https://idp.example.test/realms/nvcm/token",
+        "jwks_uri": "https://idp.example.test/realms/nvcm/certs/",
+    }
+    return config


### PR DESCRIPTION
## Description

Implement standard MCP server endpoints as an alternative to the MCP login CLI already shipped

https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/27991671941/job/82845228463

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added MCP OAuth discovery metadata endpoints under `/.well-known` (protected-resource and authorization-server) when OAuth is enabled.
  * Added OAuth/OIDC discovery configuration via Helm, rendered into a ConfigMap and automatically triggering MCP rollouts when it changes.
* **Security & Auth Improvements**
  * Expanded authentication bypass for OAuth metadata discovery paths and enhanced auth failures to return `WWW-Authenticate` details pointing to the relevant discovery resource.
* **Documentation**
  * Updated MCP docs with “client-native OAuth” setup guidance and clarified security notes.
* **Tests**
  * Expanded OAuth endpoint, settings parsing/validation, and `WWW-Authenticate` header coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->