### PR TITLE
fix(helm): align PodMonitor port names with deployment ports

### DIFF
--- a/deploy/helm/templates/monitoring.yaml
+++ b/deploy/helm/templates/monitoring.yaml
@@ -369,7 +369,7 @@ spec:
     matchLabels:
       app: {{ $ztpName }}
   podMetricsEndpoints:
-    - port: http-api
+    - port: http
       path: /metrics
       interval: {{ $scrapeInterval }}
       scrapeTimeout: {{ $scrapeTimeout }}
@@ -613,6 +613,7 @@ spec:
     matchLabels:
       app: {{ $temporalName }}
       component: worker
+      app.kubernetes.io/component: temporal
   podMetricsEndpoints:
     - port: metrics
       path: /metrics
@@ -648,41 +649,7 @@ spec:
       app: {{ $temporalName }}
       component: api
   podMetricsEndpoints:
-    - port: metrics
-      path: /metrics
-      interval: {{ $scrapeInterval }}
-      scrapeTimeout: {{ $scrapeTimeout }}
-      {{- if .Values.global.customLabels }}
-      metricRelabelings:
-        {{- include "nv-config-manager.podMonitorMetricRelabelings" . | nindent 8 }}
-      {{- end }}
-{{- end }}
-
-{{- /* Temporal Scheduler PodMonitor */}}
-{{- if and .Values.monitoring.podMonitors.enabled .Values.temporal.enabled }}
----
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: {{ $temporalName }}-scheduler
-  namespace: {{ $namespace }}
-  labels:
-    {{- include "nv-config-manager.labels" . | nindent 4 }}
-    app.kubernetes.io/component: temporal-scheduler
-    {{- with $monitoringCRLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  {{- include "nv-config-manager.podTargetLabels" . | nindent 2 }}
-  namespaceSelector:
-    matchNames:
-      - {{ $namespace }}
-  selector:
-    matchLabels:
-      app: {{ $temporalName }}
-      component: scheduler
-  podMetricsEndpoints:
-    - port: metrics
+    - port: http
       path: /metrics
       interval: {{ $scrapeInterval }}
       scrapeTimeout: {{ $scrapeTimeout }}

--- a/deploy/helm/templates/temporal.yaml
+++ b/deploy/helm/templates/temporal.yaml
@@ -56,6 +56,8 @@ spec:
       labels:
         app: {{ $temporalName }}
         component: {{ $service }}
+        app.kubernetes.io/name: nv-config-manager
+        app.kubernetes.io/component: temporal
         {{- include "nv-config-manager.spiffe.podLabels" $ | nindent 8 }}
         {{- include "nv-config-manager.customPodLabels" $ | nindent 8 }}
       annotations:

--- a/src/nv_config_manager/temporal/api/main.py
+++ b/src/nv_config_manager/temporal/api/main.py
@@ -20,6 +20,8 @@ from typing import Literal
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_fastapi_instrumentator import metrics as instrumentator_metrics
 from pydantic import BaseModel
 
 from nv_config_manager.common.auth import install_identity_probe
@@ -59,6 +61,16 @@ if config.has_section("temporal.api"):
 app.include_router(parameter_v1.router, prefix="/v1")
 app.include_router(workflow_v1.router, prefix="/v1")
 app.include_router(codec_server.router, prefix="/v1")
+
+instrumentator = Instrumentator(excluded_handlers=["/healthcheck", "/metrics"])
+instrumentator.add(
+    instrumentator_metrics.default(
+        metric_namespace="nv-config-manager",
+        metric_subsystem="temporal_api",
+    )
+)
+instrumentator.instrument(app)
+instrumentator.expose(app, include_in_schema=False)
 
 
 @app.get("/healthcheck")

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -52,6 +52,14 @@ def test_healthcheck():
     assert rsp.json() == "OK"
 
 
+def test_metrics():
+    """Verify /metrics returns Prometheus metrics without auth."""
+    client = TestClient(app)
+    rsp = client.get("/metrics")
+    assert rsp.status_code == 200
+    assert "nv_config_manager_temporal_api" in rsp.text
+
+
 def test_temporal_ui_workflow_href_uses_ini(monkeypatch):
     """Verify Workflow API href generation reads the INI, not TEMPORAL_UI."""
     monkeypatch.setenv("TEMPORAL_UI", "http://localhost:8080")


### PR DESCRIPTION


## Description

We audited the podmonitor scrape targets and identified a couple of inconsistencies which we will correct here.

- Correct ZTP scrape port (http, not container name http-api)
- Drop PodMonitor for and scheduler which exposes no metrics port
- Scope the Temporal server worker PodMonitor away from the config-manager worker via app.kubernetes.io/component: temporal pod labels.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores / Monitoring & Observability**
  * Updated Prometheus PodMonitor scrape port mappings for Network ZTP and Temporal components (metrics path and scrape timing unchanged).
  * Expanded Kubernetes labels on Temporal pods to improve component discovery.
  * Added Prometheus metrics instrumentation to the Temporal API and exposed `/metrics` with the expected metric namespace.
* **Tests**
  * Added an integration test verifying `/metrics` returns HTTP 200 and includes the expected Prometheus namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->