### PR TITLE
mark core team as trustees for ci

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,6 +1,14 @@
 enabled: true
 auto_sync_draft: false
 auto_sync_ready: true
+trustees_override:
+  - dmathur0
+  - jojung1
+  - polarweasel
+  - ryanheffernan
+  - spidercensus
+  - susanhooks
+  - zsblevins
 vetters_override:
   - dmathur0
   - jojung1


### PR DESCRIPTION
## Description

Mark core team as trustees for ci

## Validation


- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the repository’s bot configuration to include an expanded trustee approval list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->