### PR TITLE
fix template with stale plugin name

### DIFF
--- a/deploy/helm/templates/_nautobot-configmap-data.tpl
+++ b/deploy/helm/templates/_nautobot-configmap-data.tpl
@@ -46,7 +46,7 @@ NAUTOBOT_SUPERUSER_EMAIL: "{{ ((.Values.nautobot).admin).email | default "admin@
 NATS_HOST: "{{ include "nv-config-manager.natsServer" . }}"
 NV_CONFIG_MANAGER_DEPLOYMENT_TYPE: "all"
 NV_CONFIG_MANAGER_TEMPORAL_URL: "https://{{ .Values.gateway.baseHostname }}"
-NAUTOBOT_PLUGINS: "nautobot_fsus,nautobot_kiwi,nautobot_broker_nats,nautobot_firewall_models,nautobot_design_builder,nautobot_bgp_models"
+NAUTOBOT_PLUGINS: "nautobot_fsus,nv_config_manager,nautobot_firewall_models,nautobot_design_builder,nautobot_nvdatamodels,nautobot_bgp_models,nautobot_app_overlays"
 # Ensure Python uses UTF-8 encoding for file I/O
 PYTHONIOENCODING: "utf-8"
 LC_ALL: "C.UTF-8"


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the set of enabled plugins to include new configuration and data model capabilities.
  * Removed two plugins no longer included, while keeping existing core plugins enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->