### PR TITLE
fix(helm): Allow Temporal codec endpoints without auth

### DIFF
--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -123,6 +123,8 @@ DEFAULT_UNAUTHENTICATED_PATHS = frozenset(
         "/ping",
         "/healthcheck",
         "/metrics",
+        "/v1/codec/decode",
+        "/v1/codec/encode",
     }
 )
 


### PR DESCRIPTION
## Description

Allow Temporal codec encode/decode requests through the shared unauthenticated path defaults.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run: https://github.com/NVIDIA/nv-config-manager/actions/runs/28183943835


## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. N/A - no user-facing docs change.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs. N/A - no generated artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Allowed the codec encode/decode endpoints to be accessed without default authentication enforcement in supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->