### PR TITLE
fix(helm): add backstop livenessProbe to DHCP config-sync sidecar

### DIFF
--- a/deploy/helm/templates/dhcp.yaml
+++ b/deploy/helm/templates/dhcp.yaml
@@ -182,6 +182,30 @@ spec:
         - name: NV_CONFIG_MANAGER_INI
           value: {{ include "nv-config-manager.vaultAgent.configManagerIniPathDhcp" . | quote }}
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
+        # Backstop livenessProbe for the case where the in-loop divergence
+        # check in _sync_kea_configuration_async can't recover (e.g. the
+        # asyncio loop wedges or the kea control socket is unresponsive long
+        # enough that get_config() keeps raising). On failure, kubelet
+        # recycles this container, which restarts the Python process and
+        # runs the unconditional "Run once" set_config() at startup --
+        # heals the deadlock even if the in-loop check is broken.
+        #
+        # Probes the healthcheck sidecar's endpoint (same pod, same network
+        # namespace, so kubelet reaches port 9090 regardless of which
+        # container serves it -- same pattern as the kea container's probe).
+        #
+        # Thresholds are deliberately looser than the kea/healthcheck/api
+        # probes (failureThreshold * periodSeconds = 300s of failure) so the
+        # in-loop check (~10s recovery) wins under normal conditions and we
+        # only recycle the sidecar if the loop itself is the problem.
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 9090
+          initialDelaySeconds: 180
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 10
         resources:
           {{- toYaml .Values.networkDhcp.resources.confgen | nindent 10 }}
         volumeMounts:


### PR DESCRIPTION
## Description

Split out of #23 so this low-risk, **Helm-only** change can ship independently while the KEA bootstrap-drift detection/re-apply **application logic in #23 waits for QA**.

Adds a conservative backstop `livenessProbe` to the `config-sync-v4` container in `deploy/helm/templates/dhcp.yaml`. If the in-loop KEA divergence check ever wedges (asyncio loop stalls, or the kea control socket stays unresponsive long enough that `get_config()` keeps raising), kubelet recycles the sidecar. On restart the container re-runs the unconditional "Run once" `set_config()` and heals the deadlock — even if the in-loop check itself is broken.

- Probes the healthcheck endpoint (`/healthcheck` on port `9090`) in the same pod/network namespace, matching the pattern used by the kea container's probe.
- Thresholds are deliberately looser than the other probes (`failureThreshold * periodSeconds = 300s` of failure) so the in-loop recovery (~10s) wins under normal conditions and we only recycle the sidecar when the loop itself is the problem.

This contains **no application code** — it's purely the Kubernetes safety net, so it carries minimal risk and does not need to wait on QA of the drift-recovery logic.

## Validation

- [x] `helm template test . --values values-ci.yaml` renders cleanly with the new probe on the config-sync container.
- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.
https://github.com/NVIDIA/nv-config-manager/actions/runs/28194950934/job/83519142880
## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed. (Helm-only probe addition; covered by Kind integration rendering.)
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an additional health check to improve recovery for DHCP config synchronization.
  * Helps the service restart more reliably if the sync process becomes unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->