### PR TITLE
fix(workflow): Overlay Assignment Workflow Bugs for 1.3

### DIFF
--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -1635,6 +1635,16 @@
         "description": "Tenant Config Deployment Workflow Input Definiton.",
         "oneOf": [
           {
+            "properties": {
+              "intended_config_commit_id": {
+                "pattern": "^\\d+$",
+                "type": "string"
+              },
+              "tenant_config_commit_id": {
+                "pattern": "^\\d+$",
+                "type": "string"
+              }
+            },
             "required": [
               "tenant_config_commit_id",
               "intended_config_commit_id"

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -1637,10 +1637,12 @@
           {
             "properties": {
               "intended_config_commit_id": {
+                "description": "Optional config-store commit ID for the intended startup configuration from the same render snapshot as tenant_config_commit_id. Must be supplied with tenant_config_commit_id; omit both to deploy the latest tenant and intended configurations.",
                 "pattern": "^\\d+$",
                 "type": "string"
               },
               "tenant_config_commit_id": {
+                "description": "Optional config-store commit ID for the tenant configuration. Must be supplied with intended_config_commit_id; omit both to deploy the latest tenant and intended configurations.",
                 "pattern": "^\\d+$",
                 "type": "string"
               }
@@ -1689,6 +1691,7 @@
                 "type": "null"
               }
             ],
+            "description": "Optional config-store commit ID for the intended startup configuration from the same render snapshot as tenant_config_commit_id. Must be supplied with tenant_config_commit_id; omit both to deploy the latest tenant and intended configurations.",
             "title": "Intended Config Commit Id"
           },
           "tenant_config_commit_id": {
@@ -1701,6 +1704,7 @@
                 "type": "null"
               }
             ],
+            "description": "Optional config-store commit ID for the tenant configuration. Must be supplied with intended_config_commit_id; omit both to deploy the latest tenant and intended configurations.",
             "title": "Tenant Config Commit Id"
           }
         },

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -1644,6 +1644,28 @@
               }
             ],
             "title": "Device"
+          },
+          "intended_config_commit_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Intended Config Commit Id"
+          },
+          "tenant_config_commit_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tenant Config Commit Id"
           }
         },
         "required": [

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -1633,6 +1633,30 @@
       },
       "TenantDeployInput": {
         "description": "Tenant Config Deployment Workflow Input Definiton.",
+        "oneOf": [
+          {
+            "required": [
+              "tenant_config_commit_id",
+              "intended_config_commit_id"
+            ]
+          },
+          {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "tenant_config_commit_id"
+                  ]
+                },
+                {
+                  "required": [
+                    "intended_config_commit_id"
+                  ]
+                }
+              ]
+            }
+          }
+        ],
         "properties": {
           "device": {
             "anyOf": [
@@ -1648,6 +1672,7 @@
           "intended_config_commit_id": {
             "anyOf": [
               {
+                "pattern": "^\\d+$",
                 "type": "string"
               },
               {
@@ -1659,6 +1684,7 @@
           "tenant_config_commit_id": {
             "anyOf": [
               {
+                "pattern": "^\\d+$",
                 "type": "string"
               },
               {

--- a/docs/user-guides/vpc-assignment/index.mdx
+++ b/docs/user-guides/vpc-assignment/index.mdx
@@ -4,7 +4,7 @@ sidebar-title: SpX Overlay Assignment
 position: 30
 ---
 
-The SpX Overlay Assignment workflow binds an existing overlay's VRF to a specific device and to a specific set of ports on that device. It updates Nautobot's intent — the model of which VRF terminates on which port — without touching the device itself; the device-side change happens when a subsequent deploy applies the resulting intended configuration. Assignment is the second step in the SpX Overlay lifecycle, after [SpX Overlay Creation](../vpc-creation/index.mdx) provisions the VRF and Overlay objects.
+The SpX Overlay Assignment workflow binds an existing overlay's VRF to a specific device and to a specific set of ports on that device. It updates Nautobot's IPAM intent and records matching device and interface `OverlayAssignment` entries in the overlays plugin without touching the device itself; the device-side change happens when a subsequent deploy applies the resulting intended configuration. Assignment is the second step in the SpX Overlay lifecycle, after [SpX Overlay Creation](../vpc-creation/index.mdx) provisions the VRF and Overlay objects.
 
 For the end-to-end assign + render + deploy lifecycle, use [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx) — it calls this workflow as a child plus the render and deploy steps.
 
@@ -40,7 +40,7 @@ The workflow runs three stages in order. None require manual approval.
 
 1. **`assign_vrf_to_ports` — Bind the VRF to each named port.**
 
-   For each port in `port_names`, assigns the VRF to the interface in Nautobot, running all per-port writes in parallel. Ports that already have this VRF assigned are skipped and recorded in `already_assigned_ports`. The final `assigned_ports` list contains the ports actually changed by this run.
+   For each port in `port_names`, assigns the VRF to the interface in Nautobot, running all per-port writes in parallel. It then reconciles the overlays plugin so the device and every named interface have an `OverlayAssignment` for the target overlay. When a port moves between Spectrum-X overlays, its stale assignment is removed; assignments for other overlay types are preserved. Ports that already have this VRF assigned are recorded in `already_assigned_ports`, but their overlay-plugin records are still reconciled so an earlier incomplete run can be repaired. The final `assigned_ports` list contains the ports whose VRF changed during this run.
 
 ## Verifying outcomes
 
@@ -49,6 +49,7 @@ After the workflow reports success, confirm:
 - **All three stages green** on the Config Manager run page.
 - **Result shape** — `assigned_ports` lists the ports actually changed; `vrf_assigned=true` means the device-level binding was new this run; `vrf` carries the bound VRF record.
 - **Nautobot** shows the VRF on the device and on each named interface.
+- **Nautobot overlays plugin** shows `OverlayAssignment` entries for the device and each named interface under the target overlay.
 - **Run a deploy** to push the resulting intended-config change to the device. The simplest path is [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx), which combines assignment with the subsequent re-render and deploy.
 
 ## Common issues

--- a/docs/user-guides/vpc-tenant-change/index.mdx
+++ b/docs/user-guides/vpc-tenant-change/index.mdx
@@ -68,7 +68,7 @@ After the workflow reports success, confirm:
 - **`vrf_assigned`, `assigned_ports`, and `vrf`** in the result reflect the change you intended.
 - **`device_deployed`** is the device name when a deploy actually ran; `null` when the no-op short-circuit fired.
 - **Nautobot shows the VRF on the device and ports.**
-- **Nautobot overlays plugin** shows the Overlay with the device assignment recorded.
+- **Nautobot overlays plugin** shows the Overlay with assignments for the device and each named interface.
 
 ## Common issues
 

--- a/src/nv_config_manager/common/client/config_store.py
+++ b/src/nv_config_manager/common/client/config_store.py
@@ -262,7 +262,7 @@ class ConfigStoreClient(_WhoamiViaRetryClientMixin):
         self,
         device_uuid: str,
         file_type: str | None | object = _FILE_TYPE_UNSET,
-    ) -> dict[str, object]:
+    ) -> list[dict[str, object]]:
         """List latest configuration files for a device."""
         try:
             async with self._new_session() as session:
@@ -271,7 +271,7 @@ class ConfigStoreClient(_WhoamiViaRetryClientMixin):
                     params=self._file_type_params(file_type),
                 ) as rsp:
                     rsp.raise_for_status()
-                    data: dict[str, object] = await rsp.json()
+                    data: list[dict[str, object]] = await rsp.json()
                     return data
         except aiohttp.ClientResponseError as exc:
             raise ConfigStoreException(

--- a/src/nv_config_manager/mcp/clients.py
+++ b/src/nv_config_manager/mcp/clients.py
@@ -145,9 +145,9 @@ async def fetch_device_configs(
     device_id: str,
     file_type: str | None = "intended",
 ) -> dict[str, Any]:
-    """List bounded Config Store files for a device."""
+    """Return a bounded response containing a list of Config Store files."""
 
-    async def call() -> Any:
+    async def call() -> list[dict[str, object]]:
         async with config_store_client(settings, file_type or "intended") as client:
             return await client.list_device_configs(device_id, file_type=file_type)
 

--- a/src/nv_config_manager/mcp/tools.py
+++ b/src/nv_config_manager/mcp/tools.py
@@ -222,7 +222,7 @@ def register_tools(server: FastMCP, settings: MCPSettings) -> None:
         device_id: str,
         file_type: str | None = "intended",
     ) -> dict[str, Any]:
-        """List configuration files for a device from Config Store."""
+        """Return a bounded response whose data is a list of Config Store files."""
         return await fetch_device_configs(settings, device_id, file_type=file_type)
 
     @server.tool()

--- a/src/nv_config_manager/temporal/ngc/activities/__init__.py
+++ b/src/nv_config_manager/temporal/ngc/activities/__init__.py
@@ -120,6 +120,7 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     get_switch_port_by_remote_mac_address,
     get_vrfs_by_overlay_id,
     provision_vrf,
+    reconcile_spx_overlay_assignments,
 )
 from nv_config_manager.temporal.ngc.activities.nvlinkswitch_firmware import (
     compare_running_desired,
@@ -203,6 +204,7 @@ REGISTERED_ACTIVITIES = [
     assign_vrf_to_device,
     get_device_interfaces,
     assign_vrf_to_interface,
+    reconcile_spx_overlay_assignments,
     get_ib_ports,
     send_slack_message,
     get_current_os,

--- a/src/nv_config_manager/temporal/ngc/activities/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/activities/deploy.py
@@ -50,6 +50,7 @@ class LoadPartialConfigurationActivityInput(BaseModel):
 
     device_data: NetworkDeviceData
     config_file: str
+    commit_id: str | None = None
 
 
 @activity.defn
@@ -59,16 +60,27 @@ async def load_partial_configuration(
     """Load the latest partial config for a device from Gitlab."""
     client = config_store_client(ConfigStoreType.INTENDED)
     async with client:
-        file = await client.load_file(
-            device_uuid=activity_input.device_data.id,
-            filename=activity_input.config_file,
-        )
+        if activity_input.commit_id is None:
+            file = await client.load_file(
+                device_uuid=activity_input.device_data.id,
+                filename=activity_input.config_file,
+            )
+            content = file.content
+            commit_id = file.commit
+        else:
+            file_data = await client.get_config_file(
+                device_uuid=activity_input.device_data.id,
+                filename=activity_input.config_file,
+                version=int(activity_input.commit_id),
+            )
+            content = str(file_data["content"])
+            commit_id = str(file_data["version"])
         url = client.file_url(
             device_uuid=activity_input.device_data.id,
             filename=activity_input.config_file,
-            version=file.commit,
+            version=commit_id,
         )
-    return file.content, file.commit, url
+    return content, commit_id, url
 
 
 class DiffActivityInput(BaseModel):

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -26,7 +26,11 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from nv_config_manager.common.log import LogCategory, get_logger
-from nv_config_manager.temporal.client.nautobot import DeviceVrfInfo, NautobotClient
+from nv_config_manager.temporal.client.nautobot import (
+    OVERLAYS_PLUGIN_BASE,
+    DeviceVrfInfo,
+    NautobotClient,
+)
 from nv_config_manager.temporal.common.mixins.device import (
     HostDeviceData,
     InterfaceData,
@@ -770,3 +774,107 @@ async def assign_vrf_to_interface(
         await client.update_interface(
             activity_input.interface_id, data={"vrf": activity_input.vrf_id}
         )
+
+
+class ReconcileSpXOverlayAssignmentsInput(BaseModel):
+    """Spectrum-X overlay assignments to reconcile in Nautobot."""
+
+    overlay_id: str
+    site: str
+    device_id: str
+    interface_ids: list[str]
+
+
+class ReconcileSpXOverlayAssignmentsOutput(BaseModel):
+    """Result of reconciling Spectrum-X overlay assignments."""
+
+    created: int
+    removed: int
+
+
+def _related_object_id(value: Any) -> str | None:
+    """Extract a related object's ID from a Nautobot REST value."""
+    if isinstance(value, dict):
+        object_id = value.get("id")
+        return str(object_id) if object_id else None
+    return str(value) if value else None
+
+
+@activity.defn
+async def reconcile_spx_overlay_assignments(
+    activity_input: ReconcileSpXOverlayAssignmentsInput,
+) -> ReconcileSpXOverlayAssignmentsOutput:
+    """Make overlay-plugin assignments match Spectrum-X device and port intent.
+
+    Device assignments are additive because a switch can host several VRFs. An
+    interface can belong to only one Spectrum-X VRF, so stale Spectrum-X
+    assignments are removed when a port moves between overlays.
+    """
+    client = NautobotClient()
+    created = 0
+    removed = 0
+    status_id: str | None = None
+
+    async with client:
+        overlay = await client.find_overlay(activity_input.overlay_id, activity_input.site)
+        if not overlay:
+            raise ApplicationError(
+                f"Overlay {activity_input.overlay_id} not found in site {activity_input.site}"
+            )
+        target_overlay_id = str(overlay["id"])
+
+        assigned_objects = [("dcim.device", activity_input.device_id, False)]
+        assigned_objects.extend(
+            ("dcim.interface", interface_id, True) for interface_id in activity_input.interface_ids
+        )
+        for object_type, object_id, remove_stale in assigned_objects:
+            response = await client.get(
+                f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/",
+                params={"assigned_object_id": object_id, "depth": 1},
+            )
+            target_exists = False
+            for assignment in response.get("results", []):
+                assignment_overlay = assignment.get("overlay")
+                assignment_overlay_id = _related_object_id(assignment_overlay)
+                if assignment_overlay_id == target_overlay_id:
+                    target_exists = True
+                    continue
+                if not remove_stale or not assignment_overlay_id:
+                    continue
+
+                if isinstance(assignment_overlay, dict) and assignment_overlay.get(
+                    "isolation_type"
+                ):
+                    isolation_type = assignment_overlay["isolation_type"]
+                else:
+                    overlay_details = await client.get_overlay(assignment_overlay_id)
+                    isolation_type = overlay_details.get("isolation_type")
+
+                if isolation_type == SPECTRUMX_ISOLATION_TYPE:
+                    await client.delete(
+                        f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/{assignment['id']}/"
+                    )
+                    removed += 1
+
+            if target_exists:
+                continue
+
+            if status_id is None:
+                status_id = await client.lookup_id_by_name("extras/statuses/", DEFAULT_STATUS_NAME)
+                if status_id is None:
+                    raise ApplicationError(
+                        f"Status {DEFAULT_STATUS_NAME} not found for overlay assignment"
+                    )
+
+            await client.post(
+                f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/",
+                data={
+                    "overlay": target_overlay_id,
+                    "assigned_object_type": object_type,
+                    "assigned_object_id": object_id,
+                    "status": status_id,
+                },
+            )
+            created += 1
+
+    return ReconcileSpXOverlayAssignmentsOutput(created=created, removed=removed)

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -941,6 +941,11 @@ async def reconcile_spx_overlay_assignments(
             raise ApplicationError(
                 f"Overlay {activity_input.overlay_id} not found in site {activity_input.site}"
             )
+        if overlay.get("isolation_type") != SPECTRUMX_ISOLATION_TYPE:
+            raise ApplicationError(
+                f"Overlay {activity_input.overlay_id} in site {activity_input.site} "
+                f"is not a {SPECTRUMX_ISOLATION_TYPE} overlay"
+            )
         target_overlay_id = str(overlay["id"])
 
         device_assignments = await _get_overlay_assignments(client, activity_input.device_id)

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any, ClassVar, cast
-from urllib.parse import parse_qsl, urlparse
 
 import netaddr
 from pydantic import BaseModel, computed_field
@@ -825,32 +824,14 @@ def _related_object_id(value: Any) -> str | None:
     return str(value) if value else None
 
 
-async def _get_all_results(
-    client: NautobotClient,
-    path: str,
-    params: dict[str, Any],
-) -> list[dict[str, Any]]:
-    """Fetch every page from a paginated Nautobot REST endpoint."""
-    results: list[dict[str, Any]] = []
-    next_params = params
-    while True:
-        response = await client.get(path, params=next_params)
-        results.extend(response.get("results", []))
-        next_url = response.get("next")
-        if not next_url:
-            return results
-        next_params = dict(parse_qsl(urlparse(next_url).query))
-
-
 async def _get_overlay_assignments(
     client: NautobotClient,
     assigned_object_id: str,
 ) -> list[dict[str, Any]]:
     """Fetch all overlay-plugin assignments for a Nautobot object."""
-    return await _get_all_results(
-        client,
+    return await client.get_all(
         OVERLAY_ASSIGNMENTS_PATH,
-        {"assigned_object_id": assigned_object_id, "depth": 1},
+        params={"assigned_object_id": assigned_object_id, "depth": 1},
     )
 
 

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any, ClassVar
+from urllib.parse import parse_qsl, urlparse
 
 import netaddr
 from pydantic import BaseModel, computed_field
@@ -800,6 +801,23 @@ def _related_object_id(value: Any) -> str | None:
     return str(value) if value else None
 
 
+async def _get_all_results(
+    client: NautobotClient,
+    path: str,
+    params: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Fetch every page from a paginated Nautobot REST endpoint."""
+    results: list[dict[str, Any]] = []
+    next_params = params
+    while True:
+        response = await client.get(path, params=next_params)
+        results.extend(response.get("results", []))
+        next_url = response.get("next")
+        if not next_url:
+            return results
+        next_params = dict(parse_qsl(urlparse(next_url).query))
+
+
 @activity.defn
 async def reconcile_spx_overlay_assignments(
     activity_input: ReconcileSpXOverlayAssignmentsInput,
@@ -828,12 +846,14 @@ async def reconcile_spx_overlay_assignments(
             ("dcim.interface", interface_id, True) for interface_id in activity_input.interface_ids
         )
         for object_type, object_id, remove_stale in assigned_objects:
-            response = await client.get(
+            assignments = await _get_all_results(
+                client,
                 f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/",
-                params={"assigned_object_id": object_id, "depth": 1},
+                {"assigned_object_id": object_id, "depth": 1},
             )
             target_exists = False
-            for assignment in response.get("results", []):
+            stale_assignment_ids: list[str] = []
+            for assignment in assignments:
                 assignment_overlay = assignment.get("overlay")
                 assignment_overlay_id = _related_object_id(assignment_overlay)
                 if assignment_overlay_id == target_overlay_id:
@@ -851,30 +871,31 @@ async def reconcile_spx_overlay_assignments(
                     isolation_type = overlay_details.get("isolation_type")
 
                 if isolation_type == SPECTRUMX_ISOLATION_TYPE:
-                    await client.delete(
-                        f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/{assignment['id']}/"
-                    )
-                    removed += 1
+                    stale_assignment_ids.append(str(assignment["id"]))
 
-            if target_exists:
-                continue
-
-            if status_id is None:
-                status_id = await client.lookup_id_by_name("extras/statuses/", DEFAULT_STATUS_NAME)
+            if not target_exists:
                 if status_id is None:
-                    raise ApplicationError(
-                        f"Status {DEFAULT_STATUS_NAME} not found for overlay assignment"
+                    status_id = await client.lookup_id_by_name(
+                        "extras/statuses/", DEFAULT_STATUS_NAME
                     )
+                    if status_id is None:
+                        raise ApplicationError(
+                            f"Status {DEFAULT_STATUS_NAME} not found for overlay assignment"
+                        )
 
-            await client.post(
-                f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/",
-                data={
-                    "overlay": target_overlay_id,
-                    "assigned_object_type": object_type,
-                    "assigned_object_id": object_id,
-                    "status": status_id,
-                },
-            )
-            created += 1
+                await client.post(
+                    f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/",
+                    data={
+                        "overlay": target_overlay_id,
+                        "assigned_object_type": object_type,
+                        "assigned_object_id": object_id,
+                        "status": status_id,
+                    },
+                )
+                created += 1
+
+            for assignment_id in stale_assignment_ids:
+                await client.delete(f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/{assignment_id}/")
+                removed += 1
 
     return ReconcileSpXOverlayAssignmentsOutput(created=created, removed=removed)

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -594,7 +594,7 @@ class DeleteOverlayOutput(BaseModel):
 
 @activity.defn
 async def delete_overlay(activity_input: DeleteOverlayInput) -> DeleteOverlayOutput:
-    """Delete the SpectrumX overlay if no VXLANs or assignments remain."""
+    """Delete the SpectrumX overlay and its assignments if no VXLANs remain."""
     overlay_name = activity_input.overlay_id
     client = NautobotClient()
     async with client:
@@ -602,12 +602,13 @@ async def delete_overlay(activity_input: DeleteOverlayInput) -> DeleteOverlayOut
         if not overlay:
             return DeleteOverlayOutput(deleted=False, overlay_name=overlay_name)
 
-        details = await client.get_overlay(overlay["id"])
         remaining_vxlans = await client.get_vxlans_by_overlay(overlay["id"])
-        if remaining_vxlans or details.get("member_count"):
-            logger.info("Overlay %s still has members, leaving in place", overlay_name)
+        if remaining_vxlans:
+            logger.info("Overlay %s still has VXLANs, leaving in place", overlay_name)
             return DeleteOverlayOutput(deleted=False, overlay_name=overlay_name)
 
+        # OverlayAssignment.overlay uses on_delete=CASCADE, so deleting the
+        # overlay also removes its device, interface, and VRF assignments.
         await client.delete_overlay(overlay["id"])
         return DeleteOverlayOutput(deleted=True, overlay_name=overlay_name)
 

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -45,6 +45,7 @@ logger.setLevel(logging.INFO)
 SPECTRUMX_ISOLATION_TYPE = "spectrum_x_vrf"
 VXLAN_L3_VNI_TYPE = "l3"
 DEFAULT_STATUS_NAME = "Active"
+OVERLAY_ASSIGNMENTS_PATH = f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/"
 
 
 def _vni_from_rd(route_distinguisher: str) -> int:
@@ -818,6 +819,100 @@ async def _get_all_results(
         next_params = dict(parse_qsl(urlparse(next_url).query))
 
 
+async def _get_overlay_assignments(
+    client: NautobotClient,
+    assigned_object_id: str,
+) -> list[dict[str, Any]]:
+    """Fetch all overlay-plugin assignments for a Nautobot object."""
+    return await _get_all_results(
+        client,
+        OVERLAY_ASSIGNMENTS_PATH,
+        {"assigned_object_id": assigned_object_id, "depth": 1},
+    )
+
+
+def _has_overlay_assignment(assignments: list[dict[str, Any]], overlay_id: str) -> bool:
+    """Return whether the object is already assigned to the target overlay."""
+    return any(
+        _related_object_id(assignment.get("overlay")) == overlay_id for assignment in assignments
+    )
+
+
+async def _get_assignment_overlay_isolation_type(
+    client: NautobotClient,
+    assignment: dict[str, Any],
+) -> str | None:
+    """Return the overlay isolation type for an overlay assignment."""
+    assignment_overlay = assignment.get("overlay")
+    if isinstance(assignment_overlay, dict) and assignment_overlay.get("isolation_type"):
+        return str(assignment_overlay["isolation_type"])
+
+    assignment_overlay_id = _related_object_id(assignment_overlay)
+    if not assignment_overlay_id:
+        return None
+
+    overlay_details = await client.get_overlay(assignment_overlay_id)
+    isolation_type = overlay_details.get("isolation_type")
+    return str(isolation_type) if isolation_type else None
+
+
+async def _stale_spectrumx_assignment_ids(
+    client: NautobotClient,
+    assignments: list[dict[str, Any]],
+    target_overlay_id: str,
+) -> list[str]:
+    """Return stale Spectrum-X assignment IDs, preserving other overlay types."""
+    stale_assignment_ids: list[str] = []
+    for assignment in assignments:
+        assignment_overlay_id = _related_object_id(assignment.get("overlay"))
+        if assignment_overlay_id == target_overlay_id:
+            continue
+
+        isolation_type = await _get_assignment_overlay_isolation_type(client, assignment)
+        if isolation_type == SPECTRUMX_ISOLATION_TYPE:
+            stale_assignment_ids.append(str(assignment["id"]))
+
+    return stale_assignment_ids
+
+
+async def _lookup_overlay_assignment_status_id(client: NautobotClient) -> str:
+    """Return the default status ID used for new overlay assignments."""
+    status_id = await client.lookup_id_by_name("extras/statuses/", DEFAULT_STATUS_NAME)
+    if status_id is None:
+        raise ApplicationError(f"Status {DEFAULT_STATUS_NAME} not found for overlay assignment")
+    return status_id
+
+
+async def _create_overlay_assignment(
+    client: NautobotClient,
+    *,
+    target_overlay_id: str,
+    assigned_object_type: str,
+    assigned_object_id: str,
+    status_id: str,
+) -> None:
+    """Create an overlay assignment for a Nautobot object."""
+    await client.post(
+        OVERLAY_ASSIGNMENTS_PATH,
+        data={
+            "overlay": target_overlay_id,
+            "assigned_object_type": assigned_object_type,
+            "assigned_object_id": assigned_object_id,
+            "status": status_id,
+        },
+    )
+
+
+async def _delete_overlay_assignments(
+    client: NautobotClient,
+    assignment_ids: list[str],
+) -> int:
+    """Delete the given overlay assignments and return the count removed."""
+    for assignment_id in assignment_ids:
+        await client.delete(f"{OVERLAY_ASSIGNMENTS_PATH}{assignment_id}/")
+    return len(assignment_ids)
+
+
 @activity.defn
 async def reconcile_spx_overlay_assignments(
     activity_input: ReconcileSpXOverlayAssignmentsInput,
@@ -841,61 +936,41 @@ async def reconcile_spx_overlay_assignments(
             )
         target_overlay_id = str(overlay["id"])
 
-        assigned_objects = [("dcim.device", activity_input.device_id, False)]
-        assigned_objects.extend(
-            ("dcim.interface", interface_id, True) for interface_id in activity_input.interface_ids
-        )
-        for object_type, object_id, remove_stale in assigned_objects:
-            assignments = await _get_all_results(
+        device_assignments = await _get_overlay_assignments(client, activity_input.device_id)
+        if not _has_overlay_assignment(device_assignments, target_overlay_id):
+            status_id = await _lookup_overlay_assignment_status_id(client)
+            await _create_overlay_assignment(
                 client,
-                f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/",
-                {"assigned_object_id": object_id, "depth": 1},
+                target_overlay_id=target_overlay_id,
+                assigned_object_type="dcim.device",
+                assigned_object_id=activity_input.device_id,
+                status_id=status_id,
             )
-            target_exists = False
-            stale_assignment_ids: list[str] = []
-            for assignment in assignments:
-                assignment_overlay = assignment.get("overlay")
-                assignment_overlay_id = _related_object_id(assignment_overlay)
-                if assignment_overlay_id == target_overlay_id:
-                    target_exists = True
-                    continue
-                if not remove_stale or not assignment_overlay_id:
-                    continue
+            created += 1
 
-                if isinstance(assignment_overlay, dict) and assignment_overlay.get(
-                    "isolation_type"
-                ):
-                    isolation_type = assignment_overlay["isolation_type"]
-                else:
-                    overlay_details = await client.get_overlay(assignment_overlay_id)
-                    isolation_type = overlay_details.get("isolation_type")
+        for interface_id in activity_input.interface_ids:
+            interface_assignments = await _get_overlay_assignments(client, interface_id)
+            stale_assignment_ids = await _stale_spectrumx_assignment_ids(
+                client,
+                interface_assignments,
+                target_overlay_id,
+            )
 
-                if isolation_type == SPECTRUMX_ISOLATION_TYPE:
-                    stale_assignment_ids.append(str(assignment["id"]))
-
-            if not target_exists:
+            if not _has_overlay_assignment(interface_assignments, target_overlay_id):
                 if status_id is None:
-                    status_id = await client.lookup_id_by_name(
-                        "extras/statuses/", DEFAULT_STATUS_NAME
-                    )
-                    if status_id is None:
-                        raise ApplicationError(
-                            f"Status {DEFAULT_STATUS_NAME} not found for overlay assignment"
-                        )
-
-                await client.post(
-                    f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/",
-                    data={
-                        "overlay": target_overlay_id,
-                        "assigned_object_type": object_type,
-                        "assigned_object_id": object_id,
-                        "status": status_id,
-                    },
+                    status_id = await _lookup_overlay_assignment_status_id(client)
+                await _create_overlay_assignment(
+                    client,
+                    target_overlay_id=target_overlay_id,
+                    assigned_object_type="dcim.interface",
+                    assigned_object_id=interface_id,
+                    status_id=status_id,
                 )
                 created += 1
 
-            for assignment_id in stale_assignment_ids:
-                await client.delete(f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/{assignment_id}/")
-                removed += 1
+            removed += await _delete_overlay_assignments(
+                client,
+                stale_assignment_ids,
+            )
 
     return ReconcileSpXOverlayAssignmentsOutput(created=created, removed=removed)

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -422,9 +422,9 @@ async def provision_vrf(
     """Provision the SpectrumX overlay, VRFs, and L3 VXLANs for a VPC.
 
     Finds or creates the (location-scoped) SpectrumX overlay, then creates one VRF
-    and one L3 VXLAN per namespace, binding each VXLAN to both its VRF and the
-    overlay. VRFs and VXLANs created in this call are rolled back on failure; the
-    overlay is left in place since it is found-or-created and may be shared.
+    and one L3 VXLAN per namespace, binding each VRF and VXLAN to the overlay.
+    Resources created in this call are rolled back on failure; the overlay is left
+    in place since it is found-or-created and may be shared.
     """
     client = NautobotClient()
     vni = _vni_from_rd(activity_input.route_distinguisher)
@@ -432,6 +432,7 @@ async def provision_vrf(
     overlay_name = activity_input.overlay_id
     vrfs_created: list[Any] = []
     vxlans_created: list[Any] = []
+    assignments_created: list[Any] = []
     async with client:
         status_id = await client.lookup_id_by_name("extras/statuses/", DEFAULT_STATUS_NAME)
         if not status_id:
@@ -475,6 +476,14 @@ async def provision_vrf(
                     }
                 )
                 vrfs_created.append(vrf)
+                assignment = await _create_overlay_assignment(
+                    client,
+                    target_overlay_id=str(overlay_id),
+                    assigned_object_type="ipam.vrf",
+                    assigned_object_id=str(vrf["id"]),
+                    status_id=status_id,
+                )
+                assignments_created.append(assignment)
                 vxlan = await client.create_vxlan(
                     data={
                         "vnid": vni,
@@ -494,6 +503,14 @@ async def provision_vrf(
                     await client.delete_vxlan(vxlan["id"])
                 except Exception:
                     logger.exception("Failed to delete vxlan %s during rollback", vxlan["id"])
+            for assignment in assignments_created:
+                try:
+                    await client.delete(f"{OVERLAY_ASSIGNMENTS_PATH}{assignment['id']}/")
+                except Exception:
+                    logger.exception(
+                        "Failed to delete overlay assignment %s during rollback",
+                        assignment["id"],
+                    )
             for vrf in vrfs_created:
                 try:
                     await client.delete_vrf(vrf["id"])
@@ -541,7 +558,7 @@ class VrfDeletionActivityInput(BaseModel):
 
 @activity.defn
 async def delete_vrf(activity_input: VrfDeletionActivityInput) -> None:
-    """Delete a VRF and the L3 VXLAN bound to it.
+    """Delete a VRF, its overlay assignments, and the L3 VXLAN bound to it.
 
     VXLANs are fetched by VNI then filtered to those whose vrf.id matches
     vrf_id (the VRF FK is SET_NULL on VRF deletion, so they are removed
@@ -553,6 +570,11 @@ async def delete_vrf(activity_input: VrfDeletionActivityInput) -> None:
         for vxlan in vxlans:
             if (vxlan.get("vrf") or {}).get("id") == activity_input.vrf_id:
                 await client.delete_vxlan(vxlan["id"])
+        assignments = await _get_overlay_assignments(client, activity_input.vrf_id)
+        await _delete_overlay_assignments(
+            client,
+            [str(assignment["id"]) for assignment in assignments],
+        )
         await client.delete_vrf(activity_input.vrf_id)
 
 
@@ -890,9 +912,9 @@ async def _create_overlay_assignment(
     assigned_object_type: str,
     assigned_object_id: str,
     status_id: str,
-) -> None:
+) -> dict[str, Any]:
     """Create an overlay assignment for a Nautobot object."""
-    await client.post(
+    return await client.post(
         OVERLAY_ASSIGNMENTS_PATH,
         data={
             "overlay": target_overlay_id,

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from urllib.parse import parse_qsl, urlparse
 
 import netaddr
@@ -915,14 +915,17 @@ async def _create_overlay_assignment(
     status_id: str,
 ) -> dict[str, Any]:
     """Create an overlay assignment for a Nautobot object."""
-    return await client.post(
-        OVERLAY_ASSIGNMENTS_PATH,
-        data={
-            "overlay": target_overlay_id,
-            "assigned_object_type": assigned_object_type,
-            "assigned_object_id": assigned_object_id,
-            "status": status_id,
-        },
+    return cast(
+        dict[str, Any],
+        await client.post(
+            OVERLAY_ASSIGNMENTS_PATH,
+            data={
+                "overlay": target_overlay_id,
+                "assigned_object_type": assigned_object_type,
+                "assigned_object_id": assigned_object_id,
+                "status": status_id,
+            },
+        ),
     )
 
 

--- a/src/nv_config_manager/temporal/ngc/activities/render.py
+++ b/src/nv_config_manager/temporal/ngc/activities/render.py
@@ -17,7 +17,7 @@
 import asyncio
 from datetime import datetime, timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
@@ -36,11 +36,12 @@ class ExecuteRenderInput(BaseModel):
 class ExecuteRenderOutput(BaseModel):
     """Output for render operation."""
 
-    updated_files: list[FileCommit] = []
+    updated_files: list[FileCommit] = Field(default_factory=list)
+    snapshot_files: list[FileCommit] = Field(default_factory=list)
 
     def get_commit(self, filename: str) -> str | None:
-        """Look up the commit ID for a given filename."""
-        return next((fc.commit for fc in self.updated_files if fc.filename == filename), None)
+        """Look up a commit ID in the post-render Config Store snapshot."""
+        return next((fc.commit for fc in self.snapshot_files if fc.filename == filename), None)
 
 
 @activity.defn
@@ -53,13 +54,27 @@ async def execute_render(
         activity_input: Input containing the device ID
 
     Returns:
-        ExecuteRenderOutput containing updated_files list
+        ExecuteRenderOutput containing changed files and the post-render snapshot
     """
     client = render_client()
     updated_files = await client.execute_render(
         activity_input.device_id, activity_input.workflow_id
     )
-    return ExecuteRenderOutput(updated_files=updated_files)
+
+    # Config Store returns every latest file version in one response, keeping
+    # commit IDs used together for deployment pinned to the same snapshot.
+    config_client = config_store_client(ConfigStoreType.INTENDED)
+    async with config_client:
+        configs = await config_client.list_device_configs(activity_input.device_id)
+    snapshot_files = [
+        FileCommit(filename=str(config["filename"]), commit=str(config["version"]))
+        for config in configs
+    ]
+
+    return ExecuteRenderOutput(
+        updated_files=updated_files,
+        snapshot_files=snapshot_files,
+    )
 
 
 class ValidateRenderedImageChangeInput(BaseModel):

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -84,7 +84,6 @@ INTENDED_CONFIG_COMMIT_ID_DESCRIPTION = (
     "snapshot as tenant_config_commit_id. Must be supplied with tenant_config_commit_id; omit both "
     "to deploy the latest tenant and intended configurations."
 )
-TENANT_DEPLOY_RENDER_SNAPSHOT_PATCH = "tenant-deploy-render-snapshot-v1"
 
 
 class DeployInput(BaseModel):
@@ -543,16 +542,14 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
             start_to_close_timeout=timedelta(minutes=1),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
-        intended_config_commit_id: str | None = commit_id
-        if workflow.patched(TENANT_DEPLOY_RENDER_SNAPSHOT_PATCH):
-            intended_config_commit_id = stage_input.intended_config_commit_id
-            if intended_config_commit_id is None:
-                _, intended_config_commit_id, _ = await workflow.execute_activity(
-                    load_intended_configuration,
-                    device,
-                    start_to_close_timeout=timedelta(minutes=1),
-                    retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-                )
+        intended_config_commit_id = stage_input.intended_config_commit_id
+        if intended_config_commit_id is None:
+            _, intended_config_commit_id, _ = await workflow.execute_activity(
+                load_intended_configuration,
+                device,
+                start_to_close_timeout=timedelta(minutes=1),
+                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            )
         if intended_config_commit_id is None:
             raise ApplicationError(
                 "Unable to resolve intended configuration commit ID for tenant deployment"

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -418,6 +418,7 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
         device: NetworkDeviceData
         tenant_config: str
         commit_id: str
+        intended_config_commit_id: str
 
     @stage_executor("load_tenant_configuration")
     async def load_tenant_configuration(
@@ -446,10 +447,20 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
             start_to_close_timeout=timedelta(minutes=1),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
+        _, intended_config_commit_id, _ = await workflow.execute_activity(
+            load_intended_configuration,
+            device,
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+        )
         config_path = device.tenant_config_path
         markdown = f"Loaded tenant configuration from [{config_path}]({url})."
         return TenantDeployWorkflow.LoadConfigStageOutput(
-            device=device, tenant_config=content, commit_id=commit_id, display=markdown
+            device=device,
+            tenant_config=content,
+            commit_id=commit_id,
+            intended_config_commit_id=intended_config_commit_id,
+            display=markdown,
         )
 
     class PerformDiffStageInput(StageInput):
@@ -661,7 +672,7 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
         await self.perform_backup(
             TenantDeployWorkflow.BackupStageInput(
                 device_id=load_config_output.device.id,
-                commit_id=load_config_output.commit_id,
+                commit_id=load_config_output.intended_config_commit_id,
             )
         )
         await self.archive_results()

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError
@@ -356,6 +356,17 @@ class TenantDeployInput(BaseModel):
     """Tenant Config Deployment Workflow Input Definiton."""
 
     device: str | NetworkDeviceData
+    tenant_config_commit_id: str | None = None
+    intended_config_commit_id: str | None = None
+
+    @model_validator(mode="after")
+    def validate_render_snapshot(self) -> "TenantDeployInput":
+        """Require tenant and intended commit IDs to be supplied as one snapshot pair."""
+        if (self.tenant_config_commit_id is None) != (self.intended_config_commit_id is None):
+            raise ValueError(
+                "tenant_config_commit_id and intended_config_commit_id must be supplied together"
+            )
+        return self
 
 
 @workflow.defn
@@ -411,6 +422,8 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
         """Load Tenant Config Stage Input."""
 
         device: str | NetworkDeviceData
+        tenant_config_commit_id: str | None = None
+        intended_config_commit_id: str | None = None
 
     class LoadConfigStageOutput(StageOutput):
         """Load Tenant Config Stage Output."""
@@ -443,16 +456,20 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
             LoadPartialConfigurationActivityInput(
                 device_data=device,
                 config_file=device.tenant_config_file,
+                commit_id=stage_input.tenant_config_commit_id,
             ),
             start_to_close_timeout=timedelta(minutes=1),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
-        _, intended_config_commit_id, _ = await workflow.execute_activity(
-            load_intended_configuration,
-            device,
-            start_to_close_timeout=timedelta(minutes=1),
-            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-        )
+        intended_config_commit_id = stage_input.intended_config_commit_id
+        if intended_config_commit_id is None:
+            _, intended_config_commit_id, _ = await workflow.execute_activity(
+                load_intended_configuration,
+                device,
+                start_to_close_timeout=timedelta(minutes=1),
+                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            )
+        assert intended_config_commit_id is not None
         config_path = device.tenant_config_path
         markdown = f"Loaded tenant configuration from [{config_path}]({url})."
         return TenantDeployWorkflow.LoadConfigStageOutput(
@@ -638,7 +655,11 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
         """Execute tenant deployment workflow."""
         self.set_input(workflow_input)
         load_config_output = await self.load_tenant_configuration(
-            TenantDeployWorkflow.LoadConfigStageInput(device=workflow_input.device)
+            TenantDeployWorkflow.LoadConfigStageInput(
+                device=workflow_input.device,
+                tenant_config_commit_id=workflow_input.tenant_config_commit_id,
+                intended_config_commit_id=workflow_input.intended_config_commit_id,
+            )
         )
 
         diff_output = await self.perform_configuration_diff(

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -84,6 +84,7 @@ INTENDED_CONFIG_COMMIT_ID_DESCRIPTION = (
     "snapshot as tenant_config_commit_id. Must be supplied with tenant_config_commit_id; omit both "
     "to deploy the latest tenant and intended configurations."
 )
+TENANT_DEPLOY_RENDER_SNAPSHOT_PATCH = "tenant-deploy-render-snapshot-v1"
 
 
 class DeployInput(BaseModel):
@@ -542,14 +543,16 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
             start_to_close_timeout=timedelta(minutes=1),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
-        intended_config_commit_id = stage_input.intended_config_commit_id
-        if intended_config_commit_id is None:
-            _, intended_config_commit_id, _ = await workflow.execute_activity(
-                load_intended_configuration,
-                device,
-                start_to_close_timeout=timedelta(minutes=1),
-                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-            )
+        intended_config_commit_id: str | None = commit_id
+        if workflow.patched(TENANT_DEPLOY_RENDER_SNAPSHOT_PATCH):
+            intended_config_commit_id = stage_input.intended_config_commit_id
+            if intended_config_commit_id is None:
+                _, intended_config_commit_id, _ = await workflow.execute_activity(
+                    load_intended_configuration,
+                    device,
+                    start_to_close_timeout=timedelta(minutes=1),
+                    retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+                )
         if intended_config_commit_id is None:
             raise ApplicationError(
                 "Unable to resolve intended configuration commit ID for tenant deployment"

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError
@@ -355,9 +355,30 @@ class DeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, ArchiveMixi
 class TenantDeployInput(BaseModel):
     """Tenant Config Deployment Workflow Input Definiton."""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "oneOf": [
+                {
+                    "required": [
+                        "tenant_config_commit_id",
+                        "intended_config_commit_id",
+                    ]
+                },
+                {
+                    "not": {
+                        "anyOf": [
+                            {"required": ["tenant_config_commit_id"]},
+                            {"required": ["intended_config_commit_id"]},
+                        ]
+                    }
+                },
+            ]
+        }
+    )
+
     device: str | NetworkDeviceData
-    tenant_config_commit_id: str | None = None
-    intended_config_commit_id: str | None = None
+    tenant_config_commit_id: str | None = Field(default=None, pattern=r"^\d+$")
+    intended_config_commit_id: str | None = Field(default=None, pattern=r"^\d+$")
 
     @model_validator(mode="after")
     def validate_render_snapshot(self) -> "TenantDeployInput":

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -528,7 +528,10 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
                 start_to_close_timeout=timedelta(minutes=1),
                 retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
             )
-        assert intended_config_commit_id is not None
+        if intended_config_commit_id is None:
+            raise ApplicationError(
+                "Unable to resolve intended configuration commit ID for tenant deployment"
+            )
         config_path = device.tenant_config_path
         markdown = f"Loaded tenant configuration from [{config_path}]({url})."
         return TenantDeployWorkflow.LoadConfigStageOutput(

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -16,7 +16,14 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    model_serializer,
+    model_validator,
+)
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError
@@ -426,6 +433,20 @@ class TenantDeployInput(BaseModel):
                 "tenant_config_commit_id and intended_config_commit_id must both be non-null or both be omitted"
             )
         return self
+
+    @model_serializer(mode="wrap")
+    def serialize_render_snapshot(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> dict[str, object]:
+        """Keep omitted snapshot IDs absent during Temporal serialization."""
+        data = handler(self)
+        if not self.model_fields_set & {
+            "tenant_config_commit_id",
+            "intended_config_commit_id",
+        }:
+            data.pop("tenant_config_commit_id", None)
+            data.pop("intended_config_commit_id", None)
+        return data
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -67,6 +67,15 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
         "DiffChangedException",
     ],
 )
+TENANT_CONFIG_COMMIT_ID_DESCRIPTION = (
+    "Optional config-store commit ID for the tenant configuration. Must be supplied with "
+    "intended_config_commit_id; omit both to deploy the latest tenant and intended configurations."
+)
+INTENDED_CONFIG_COMMIT_ID_DESCRIPTION = (
+    "Optional config-store commit ID for the intended startup configuration from the same render "
+    "snapshot as tenant_config_commit_id. Must be supplied with tenant_config_commit_id; omit both "
+    "to deploy the latest tenant and intended configurations."
+)
 
 
 class DeployInput(BaseModel):
@@ -367,10 +376,12 @@ class TenantDeployInput(BaseModel):
                         "tenant_config_commit_id": {
                             "type": "string",
                             "pattern": r"^\d+$",
+                            "description": TENANT_CONFIG_COMMIT_ID_DESCRIPTION,
                         },
                         "intended_config_commit_id": {
                             "type": "string",
                             "pattern": r"^\d+$",
+                            "description": INTENDED_CONFIG_COMMIT_ID_DESCRIPTION,
                         },
                     },
                 },
@@ -387,8 +398,16 @@ class TenantDeployInput(BaseModel):
     )
 
     device: str | NetworkDeviceData
-    tenant_config_commit_id: str | None = Field(default=None, pattern=r"^\d+$")
-    intended_config_commit_id: str | None = Field(default=None, pattern=r"^\d+$")
+    tenant_config_commit_id: str | None = Field(
+        default=None,
+        pattern=r"^\d+$",
+        description=TENANT_CONFIG_COMMIT_ID_DESCRIPTION,
+    )
+    intended_config_commit_id: str | None = Field(
+        default=None,
+        pattern=r"^\d+$",
+        description=INTENDED_CONFIG_COMMIT_ID_DESCRIPTION,
+    )
 
     @model_validator(mode="after")
     def validate_render_snapshot(self) -> "TenantDeployInput":

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -15,6 +15,7 @@
 """Network Device Backup Workflow Definition."""
 
 from datetime import timedelta
+from typing import cast
 
 from pydantic import (
     BaseModel,
@@ -439,7 +440,7 @@ class TenantDeployInput(BaseModel):
         self, handler: SerializerFunctionWrapHandler
     ) -> dict[str, object]:
         """Keep omitted snapshot IDs absent during Temporal serialization."""
-        data = handler(self)
+        data = cast(dict[str, object], handler(self))
         if not self.model_fields_set & {
             "tenant_config_commit_id",
             "intended_config_commit_id",

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -362,7 +362,17 @@ class TenantDeployInput(BaseModel):
                     "required": [
                         "tenant_config_commit_id",
                         "intended_config_commit_id",
-                    ]
+                    ],
+                    "properties": {
+                        "tenant_config_commit_id": {
+                            "type": "string",
+                            "pattern": r"^\d+$",
+                        },
+                        "intended_config_commit_id": {
+                            "type": "string",
+                            "pattern": r"^\d+$",
+                        },
+                    },
                 },
                 {
                     "not": {
@@ -382,10 +392,19 @@ class TenantDeployInput(BaseModel):
 
     @model_validator(mode="after")
     def validate_render_snapshot(self) -> "TenantDeployInput":
-        """Require tenant and intended commit IDs to be supplied as one snapshot pair."""
-        if (self.tenant_config_commit_id is None) != (self.intended_config_commit_id is None):
+        """Require non-null commit IDs to be supplied together or both omitted."""
+        snapshot_fields = {
+            "tenant_config_commit_id",
+            "intended_config_commit_id",
+        }
+        supplied_fields = self.model_fields_set & snapshot_fields
+        if supplied_fields and (
+            supplied_fields != snapshot_fields
+            or self.tenant_config_commit_id is None
+            or self.intended_config_commit_id is None
+        ):
             raise ValueError(
-                "tenant_config_commit_id and intended_config_commit_id must be supplied together"
+                "tenant_config_commit_id and intended_config_commit_id must both be non-null or both be omitted"
             )
         return self
 

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -50,6 +50,7 @@ with workflow.unsafe.imports_passed_through():
         GetNetworkDeviceInput,
         ProvisionVrfInput,
         QueryVRFByVPCInput,
+        ReconcileSpXOverlayAssignmentsInput,
         Vrf,
         VrfDeletionActivityInput,
         _vni_from_rd,
@@ -63,6 +64,7 @@ with workflow.unsafe.imports_passed_through():
         get_network_device,
         get_vrfs_by_overlay_id,
         provision_vrf,
+        reconcile_spx_overlay_assignments,
     )
     from nv_config_manager.temporal.ngc.activities.render import (
         ExecuteRenderInput,
@@ -555,6 +557,8 @@ class SpXOverlayAssignmentWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixi
         """Assign VRF to Ports Stage Input."""
 
         device_id: str
+        overlay_id: str
+        site: str
         vrf_id: str
         vrf_name: str
         port_names: list[str]
@@ -601,13 +605,27 @@ class SpXOverlayAssignmentWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixi
 
         await asyncio.gather(*tasks)
 
+        overlay_assignments = await workflow.execute_activity(
+            reconcile_spx_overlay_assignments,
+            ReconcileSpXOverlayAssignmentsInput(
+                overlay_id=stage_input.overlay_id,
+                site=stage_input.site,
+                device_id=stage_input.device_id,
+                interface_ids=[interface.id for interface in interfaces_output.interfaces],
+            ),
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+        )
+
         return self.AssignVrfToPortsStageOutput(
             assigned_ports=assigned_ports,
             already_assigned_ports=already_assigned_ports,
             display=(
                 f"VRF {stage_input.vrf_name} assigned "
                 f"to ports: {', '.join(assigned_ports)}\n"
-                f"Ports already assigned: {', '.join(already_assigned_ports)}"
+                f"Ports already assigned: {', '.join(already_assigned_ports)}\n"
+                f"Overlay assignments created: {overlay_assignments.created}; "
+                f"stale assignments removed: {overlay_assignments.removed}"
             ),
         )
 
@@ -639,6 +657,8 @@ class SpXOverlayAssignmentWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixi
         ports_output = await self.assign_vrf_to_ports_stage(
             self.AssignVrfToPortsStageInput(
                 device_id=device_vrf_output.device.id,
+                overlay_id=workflow_input.overlay_id,
+                site=workflow_input.site,
                 vrf_id=device_vrf_output.vrf.id,
                 vrf_name=device_vrf_output.vrf.name,
                 port_names=workflow_input.port_names,

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -37,7 +37,9 @@ with workflow.unsafe.imports_passed_through():
     from nv_config_manager.temporal.common.mixins.archive import ArchiveMixin
     from nv_config_manager.temporal.common.mixins.device import DeviceMixin, NetworkDeviceData
     from nv_config_manager.temporal.ngc.activities.deploy import (
+        LoadPartialConfigurationActivityInput,
         WaitForTenantRenderInput,
+        load_partial_configuration,
         wait_for_tenant_render,
     )
     from nv_config_manager.temporal.ngc.activities.nautobot import (
@@ -911,14 +913,29 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         tenant_config_file = stage_input.device.tenant_config_file
         tenant_config_commit_id = result.get_commit(tenant_config_file)
         intended_config_commit_id = result.get_commit(stage_input.device.intended_config_file)
-        if tenant_config_commit_id is None or intended_config_commit_id is None:
-            missing_files = []
-            if tenant_config_commit_id is None:
-                missing_files.append(tenant_config_file)
-            if intended_config_commit_id is None:
-                missing_files.append(stage_input.device.intended_config_file)
-            raise ApplicationError(
-                f"Render did not return commit IDs for: {', '.join(missing_files)}"
+
+        # A Nautobot-triggered render can commit the same content just before this
+        # forced render. In that case updated_files omits the unchanged file, so use
+        # the version that the successful forced render just confirmed as current.
+        if tenant_config_commit_id is None:
+            _, tenant_config_commit_id, _ = await workflow.execute_activity(
+                load_partial_configuration,
+                LoadPartialConfigurationActivityInput(
+                    device_data=stage_input.device,
+                    config_file=tenant_config_file,
+                ),
+                start_to_close_timeout=timedelta(minutes=1),
+                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            )
+        if intended_config_commit_id is None:
+            _, intended_config_commit_id, _ = await workflow.execute_activity(
+                load_partial_configuration,
+                LoadPartialConfigurationActivityInput(
+                    device_data=stage_input.device,
+                    config_file=stage_input.device.intended_config_file,
+                ),
+                start_to_close_timeout=timedelta(minutes=1),
+                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
             )
 
         display_message = f"Rendered tenant configuration (config ID: {tenant_config_commit_id})"

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -92,8 +92,6 @@ NAMESPACE_TAG = "spectrumx"
 DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
     maximum_attempts=3,
 )
-SPX_OVERLAY_ASSIGNMENTS_PATCH = "spx-overlay-assignments-v1"
-SPX_TENANT_CHANGE_DEPLOYMENT_PATCH = "spx-tenant-change-deployment-v1"
 
 
 class SpXOverlayCreationInput(BaseModel):
@@ -625,35 +623,28 @@ class SpXOverlayAssignmentWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixi
 
         await asyncio.gather(*tasks)
 
-        overlay_assignments = None
-        if workflow.patched(SPX_OVERLAY_ASSIGNMENTS_PATCH):
-            overlay_assignments = await workflow.execute_activity(
-                reconcile_spx_overlay_assignments,
-                ReconcileSpXOverlayAssignmentsInput(
-                    overlay_id=stage_input.overlay_id,
-                    site=stage_input.site,
-                    device_id=stage_input.device_id,
-                    interface_ids=[interface.id for interface in interfaces_output.interfaces],
-                ),
-                start_to_close_timeout=timedelta(minutes=1),
-                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-            )
-
-        display = (
-            f"VRF {stage_input.vrf_name} assigned "
-            f"to ports: {', '.join(assigned_ports)}\n"
-            f"Ports already assigned: {', '.join(already_assigned_ports)}"
+        overlay_assignments = await workflow.execute_activity(
+            reconcile_spx_overlay_assignments,
+            ReconcileSpXOverlayAssignmentsInput(
+                overlay_id=stage_input.overlay_id,
+                site=stage_input.site,
+                device_id=stage_input.device_id,
+                interface_ids=[interface.id for interface in interfaces_output.interfaces],
+            ),
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
-        if overlay_assignments is not None:
-            display += (
-                f"\nOverlay assignments created: {overlay_assignments.created}; "
-                f"stale assignments removed: {overlay_assignments.removed}"
-            )
 
         return self.AssignVrfToPortsStageOutput(
             assigned_ports=assigned_ports,
             already_assigned_ports=already_assigned_ports,
-            display=display,
+            display=(
+                f"VRF {stage_input.vrf_name} assigned "
+                f"to ports: {', '.join(assigned_ports)}\n"
+                f"Ports already assigned: {', '.join(already_assigned_ports)}\n"
+                f"Overlay assignments created: {overlay_assignments.created}; "
+                f"stale assignments removed: {overlay_assignments.removed}"
+            ),
         )
 
     @run_nv_config_manager_workflow
@@ -738,7 +729,6 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
     def __init__(self) -> None:
         """Initialize workflow."""
         StageMixin.__init__(self)
-        self.use_new_deployment_flow = workflow.patched(SPX_TENANT_CHANGE_DEPLOYMENT_PATCH)
         self.define_stage(
             name="get_device",
             description="Get device information from Nautobot",
@@ -753,23 +743,18 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             depends_on=["get_device"],
         )
 
-        if self.use_new_deployment_flow:
-            self.define_stage(
-                name="determine_deployment_action",
-                description="Determine whether the tenant change needs deployment",
-                requires_approval=False,
-                depends_on=["assign_spx_overlay"],
-            )
+        self.define_stage(
+            name="determine_deployment_action",
+            description="Determine whether the tenant change needs deployment",
+            requires_approval=False,
+            depends_on=["assign_spx_overlay"],
+        )
 
         self.define_stage(
             name="render_tenant_config",
             description="Render tenant configuration",
             requires_approval=False,
-            depends_on=(
-                ["determine_deployment_action"]
-                if self.use_new_deployment_flow
-                else ["assign_spx_overlay"]
-            ),
+            depends_on=["determine_deployment_action"],
         )
 
         self.define_stage(
@@ -925,34 +910,6 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         tenant_config_commit_id: str
         intended_config_commit_id: str
 
-    class LegacyRenderStageOutput(StageOutput):
-        """Render output used when replaying workflows started before snapshot deployment."""
-
-        config_id: str | None = None
-
-    @stage_executor("render_tenant_config")
-    async def legacy_render_stage(self, stage_input: RenderStageInput) -> LegacyRenderStageOutput:
-        """Preserve the original render command sequence for existing histories."""
-        result = await workflow.execute_activity(
-            execute_render,
-            ExecuteRenderInput(
-                device_id=stage_input.device.id,
-                workflow_id=workflow.info().workflow_id,
-            ),
-            start_to_close_timeout=timedelta(minutes=5),
-            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-        )
-
-        config_id = result.get_commit(stage_input.device.tenant_config_file)
-        display_message = "Rendered tenant configuration"
-        if config_id:
-            display_message += f" (config ID: {config_id})"
-
-        return self.LegacyRenderStageOutput(
-            config_id=config_id,
-            display=display_message,
-        )
-
     @stage_executor("render_tenant_config")
     async def render_stage(self, stage_input: RenderStageInput) -> RenderStageOutput:
         """Render tenant configuration."""
@@ -1009,7 +966,7 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         """Wait For Render Stage Input."""
 
         device: NetworkDeviceData
-        config_id: str | None
+        config_id: str
 
     class WaitForRenderStageOutput(StageOutput):
         """Wait For Render Stage Output."""
@@ -1101,19 +1058,12 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             )
         )
 
-        assignment_changed = bool(assign_output.assigned_ports or assign_output.vrf_assigned)
-        if self.use_new_deployment_flow:
-            deployment_action_output = await self.determine_deployment_action_stage(
-                self.DetermineDeploymentActionStageInput(
-                    device_id=device_output.device.id,
-                    assignment_changed=assignment_changed,
-                )
+        deployment_action_output = await self.determine_deployment_action_stage(
+            self.DetermineDeploymentActionStageInput(
+                device_id=device_output.device.id,
+                assignment_changed=bool(assign_output.assigned_ports or assign_output.vrf_assigned),
             )
-        else:
-            deployment_action_output = self.DetermineDeploymentActionStageOutput(
-                deploy_required=assignment_changed,
-                display="Using the deployment behavior recorded by the existing workflow.",
-            )
+        )
 
         if not deployment_action_output.deploy_required:
             self.set_stage_state("render_tenant_config", StateEnum.UNREACHABLE)
@@ -1141,40 +1091,26 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             vrf_assigned = assign_output.vrf_assigned
             vrf = assign_output.vrf
         else:
-            tenant_config_commit_id: str | None
-            intended_config_commit_id: str | None
-            if self.use_new_deployment_flow:
-                render_output = await self.render_stage(
-                    self.RenderStageInput(device=device_output.device)
+            render_output = await self.render_stage(
+                self.RenderStageInput(
+                    device=device_output.device,
                 )
-                tenant_config_commit_id = render_output.tenant_config_commit_id
-                intended_config_commit_id = render_output.intended_config_commit_id
-            else:
-                legacy_render_output = await self.legacy_render_stage(
-                    self.RenderStageInput(device=device_output.device)
-                )
-                tenant_config_commit_id = legacy_render_output.config_id
-                intended_config_commit_id = None
+            )
 
             await self.wait_for_render_stage(
                 self.WaitForRenderStageInput(
                     device=device_output.device,
-                    config_id=tenant_config_commit_id,
+                    config_id=render_output.tenant_config_commit_id,
                 )
             )
 
-            if self.use_new_deployment_flow:
-                deploy_output = await self.deploy_stage(
-                    self.DeployStageInput(
-                        device=device_output.device,
-                        tenant_config_commit_id=tenant_config_commit_id,
-                        intended_config_commit_id=intended_config_commit_id,
-                    )
+            deploy_output = await self.deploy_stage(
+                self.DeployStageInput(
+                    device=device_output.device,
+                    tenant_config_commit_id=render_output.tenant_config_commit_id,
+                    intended_config_commit_id=render_output.intended_config_commit_id,
                 )
-            else:
-                deploy_output = await self.deploy_stage(
-                    self.DeployStageInput(device=device_output.device)
-                )
+            )
             device_deployed = deploy_output.device_id
             assigned_ports = assign_output.assigned_ports
             vrf_assigned = assign_output.vrf_assigned

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -43,6 +43,7 @@ with workflow.unsafe.imports_passed_through():
     from nv_config_manager.temporal.ngc.activities.nautobot import (
         AssignVrfToDeviceInput,
         AssignVrfToInterfaceInput,
+        CheckRecordedConfigDriftInput,
         DeleteOverlayInput,
         GetAvailableRouteDistinguishersInput,
         GetDeviceInterfacesInput,
@@ -56,6 +57,7 @@ with workflow.unsafe.imports_passed_through():
         _vni_from_rd,
         assign_vrf_to_device,
         assign_vrf_to_interface,
+        check_recorded_config_drift,
         delete_overlay,
         delete_vrf,
         get_available_route_distinguishers,
@@ -726,10 +728,17 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         )
 
         self.define_stage(
+            name="determine_deployment_action",
+            description="Determine whether the tenant change needs deployment",
+            requires_approval=False,
+            depends_on=["assign_spx_overlay"],
+        )
+
+        self.define_stage(
             name="render_tenant_config",
             description="Render tenant configuration",
             requires_approval=False,
-            depends_on=["assign_spx_overlay"],
+            depends_on=["determine_deployment_action"],
         )
 
         self.define_stage(
@@ -830,6 +839,50 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             display=display,
         )
 
+    class DetermineDeploymentActionStageInput(StageInput):
+        """Determine Deployment Action Stage Input."""
+
+        device_id: str
+        assignment_changed: bool
+
+    class DetermineDeploymentActionStageOutput(StageOutput):
+        """Determine Deployment Action Stage Output."""
+
+        deploy_required: bool
+        use_latest_render: bool = False
+
+    @stage_executor("determine_deployment_action")
+    async def determine_deployment_action_stage(
+        self, stage_input: DetermineDeploymentActionStageInput
+    ) -> DetermineDeploymentActionStageOutput:
+        """Determine whether a tenant deployment is required."""
+        if stage_input.assignment_changed:
+            return self.DetermineDeploymentActionStageOutput(
+                deploy_required=True,
+                display="Nautobot assignment changed; tenant render and deploy are required.",
+            )
+
+        has_pending_deployment = await workflow.execute_activity(
+            check_recorded_config_drift,
+            CheckRecordedConfigDriftInput(device_id=stage_input.device_id),
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+        )
+        if has_pending_deployment:
+            return self.DetermineDeploymentActionStageOutput(
+                deploy_required=True,
+                use_latest_render=True,
+                display=(
+                    "Nautobot assignment was already complete, but the device has a pending "
+                    "deployment; deploying the latest rendered tenant configuration."
+                ),
+            )
+
+        return self.DetermineDeploymentActionStageOutput(
+            deploy_required=False,
+            display="Nautobot assignment is already complete and no deployment is pending.",
+        )
+
     class RenderStageInput(StageInput):
         """Render Stage Input."""
 
@@ -915,8 +968,8 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         """Deploy Stage Input."""
 
         device: NetworkDeviceData
-        tenant_config_commit_id: str
-        intended_config_commit_id: str
+        tenant_config_commit_id: str | None = None
+        intended_config_commit_id: str | None = None
 
     class DeployStageOutput(StageOutput):
         """Deploy Stage Output."""
@@ -926,13 +979,21 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
     @stage_executor("deploy")
     async def deploy_stage(self, stage_input: DeployStageInput) -> DeployStageOutput:
         """Deploy tenant configuration to device."""
-        await workflow.execute_child_workflow(
-            TenantDeployWorkflow.run,
-            TenantDeployInput(
+        if (
+            stage_input.tenant_config_commit_id is None
+            and stage_input.intended_config_commit_id is None
+        ):
+            tenant_deploy_input = TenantDeployInput(device=stage_input.device)
+        else:
+            tenant_deploy_input = TenantDeployInput(
                 device=stage_input.device,
                 tenant_config_commit_id=stage_input.tenant_config_commit_id,
                 intended_config_commit_id=stage_input.intended_config_commit_id,
-            ),
+            )
+
+        await workflow.execute_child_workflow(
+            TenantDeployWorkflow.run,
+            tenant_deploy_input,
             run_timeout=timedelta(minutes=10),
         )
 
@@ -964,7 +1025,14 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             )
         )
 
-        if not assign_output.assigned_ports and not assign_output.vrf_assigned:
+        deployment_action_output = await self.determine_deployment_action_stage(
+            self.DetermineDeploymentActionStageInput(
+                device_id=device_output.device.id,
+                assignment_changed=bool(assign_output.assigned_ports or assign_output.vrf_assigned),
+            )
+        )
+
+        if not deployment_action_output.deploy_required:
             self.set_stage_state("render_tenant_config", StateEnum.UNREACHABLE)
             self.set_stage_state("wait_for_render", StateEnum.UNREACHABLE)
             self.set_stage_state("deploy", StateEnum.UNREACHABLE)
@@ -972,6 +1040,23 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             vrf_assigned = False
             vrf = None
             device_deployed = None
+        elif deployment_action_output.use_latest_render:
+            self.set_stage_state(
+                "render_tenant_config", StateEnum.UNREACHABLE, cascade_unreachable=False
+            )
+            self.set_stage_state(
+                "wait_for_render", StateEnum.UNREACHABLE, cascade_unreachable=False
+            )
+
+            deploy_output = await self.deploy_stage(
+                self.DeployStageInput(
+                    device=device_output.device,
+                )
+            )
+            device_deployed = deploy_output.device_id
+            assigned_ports = assign_output.assigned_ports
+            vrf_assigned = assign_output.vrf_assigned
+            vrf = assign_output.vrf
         else:
             render_output = await self.render_stage(
                 self.RenderStageInput(

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -818,7 +818,8 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
     class RenderStageOutput(StageOutput):
         """Render Stage Output."""
 
-        config_id: str | None = None
+        tenant_config_commit_id: str | None = None
+        intended_config_commit_id: str | None = None
 
     @stage_executor("render_tenant_config")
     async def render_stage(self, stage_input: RenderStageInput) -> RenderStageOutput:
@@ -835,14 +836,16 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
 
         # Get commit_id for tenant.yaml from the updated_files list
         tenant_config_file = stage_input.device.tenant_config_file
-        config_id = result.get_commit(tenant_config_file)
+        tenant_config_commit_id = result.get_commit(tenant_config_file)
+        intended_config_commit_id = result.get_commit(stage_input.device.intended_config_file)
 
         display_message = "Rendered tenant configuration"
-        if config_id:
-            display_message += f" (config ID: {config_id})"
+        if tenant_config_commit_id:
+            display_message += f" (config ID: {tenant_config_commit_id})"
 
         return self.RenderStageOutput(
-            config_id=config_id,
+            tenant_config_commit_id=tenant_config_commit_id,
+            intended_config_commit_id=intended_config_commit_id,
             display=display_message,
         )
 
@@ -885,6 +888,8 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         """Deploy Stage Input."""
 
         device: NetworkDeviceData
+        tenant_config_commit_id: str | None = None
+        intended_config_commit_id: str | None = None
 
     class DeployStageOutput(StageOutput):
         """Deploy Stage Output."""
@@ -896,7 +901,11 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         """Deploy tenant configuration to device."""
         await workflow.execute_child_workflow(
             TenantDeployWorkflow.run,
-            TenantDeployInput(device=stage_input.device),
+            TenantDeployInput(
+                device=stage_input.device,
+                tenant_config_commit_id=stage_input.tenant_config_commit_id,
+                intended_config_commit_id=stage_input.intended_config_commit_id,
+            ),
             run_timeout=timedelta(minutes=10),
         )
 
@@ -946,12 +955,16 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             await self.wait_for_render_stage(
                 self.WaitForRenderStageInput(
                     device=device_output.device,
-                    config_id=render_output.config_id,
+                    config_id=render_output.tenant_config_commit_id,
                 )
             )
 
             deploy_output = await self.deploy_stage(
-                self.DeployStageInput(device=device_output.device)
+                self.DeployStageInput(
+                    device=device_output.device,
+                    tenant_config_commit_id=render_output.tenant_config_commit_id,
+                    intended_config_commit_id=render_output.intended_config_commit_id,
+                )
             )
             device_deployed = deploy_output.device_id
             assigned_ports = assign_output.assigned_ports

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -951,6 +951,8 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
                 start_to_close_timeout=timedelta(minutes=1),
                 retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
             )
+        if tenant_config_commit_id is None or intended_config_commit_id is None:
+            raise ApplicationError("Failed to resolve rendered configuration commit IDs")
 
         display_message = f"Rendered tenant configuration (config ID: {tenant_config_commit_id})"
 

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -629,7 +629,7 @@ class SpXOverlayAssignmentWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixi
                 device_id=stage_input.device_id,
                 interface_ids=[interface.id for interface in interfaces_output.interfaces],
             ),
-            start_to_close_timeout=timedelta(minutes=1),
+            start_to_close_timeout=timedelta(minutes=5),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
 
@@ -987,6 +987,14 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
     @stage_executor("deploy")
     async def deploy_stage(self, stage_input: DeployStageInput) -> DeployStageOutput:
         """Deploy tenant configuration to device."""
+        if (stage_input.tenant_config_commit_id is None) != (
+            stage_input.intended_config_commit_id is None
+        ):
+            raise ApplicationError(
+                "tenant_config_commit_id and intended_config_commit_id must both be supplied "
+                "or both be omitted"
+            )
+
         if (
             stage_input.tenant_config_commit_id is None
             and stage_input.intended_config_commit_id is None

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -929,7 +929,7 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         )
 
         if not assign_output.assigned_ports and not assign_output.vrf_assigned:
-            self.set_stage_state("render", StateEnum.UNREACHABLE)
+            self.set_stage_state("render_tenant_config", StateEnum.UNREACHABLE)
             self.set_stage_state("wait_for_render", StateEnum.UNREACHABLE)
             self.set_stage_state("deploy", StateEnum.UNREACHABLE)
             assigned_ports = []

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -37,9 +37,7 @@ with workflow.unsafe.imports_passed_through():
     from nv_config_manager.temporal.common.mixins.archive import ArchiveMixin
     from nv_config_manager.temporal.common.mixins.device import DeviceMixin, NetworkDeviceData
     from nv_config_manager.temporal.ngc.activities.deploy import (
-        LoadPartialConfigurationActivityInput,
         WaitForTenantRenderInput,
-        load_partial_configuration,
         wait_for_tenant_render,
     )
     from nv_config_manager.temporal.ngc.activities.nautobot import (
@@ -923,34 +921,11 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
 
-        # Get commit_id for tenant.yaml from the updated_files list
+        # Resolve both commit IDs from the same post-render Config Store snapshot.
         tenant_config_file = stage_input.device.tenant_config_file
         tenant_config_commit_id = result.get_commit(tenant_config_file)
         intended_config_commit_id = result.get_commit(stage_input.device.intended_config_file)
 
-        # A Nautobot-triggered render can commit the same content just before this
-        # forced render. In that case updated_files omits the unchanged file, so use
-        # the version that the successful forced render just confirmed as current.
-        if tenant_config_commit_id is None:
-            _, tenant_config_commit_id, _ = await workflow.execute_activity(
-                load_partial_configuration,
-                LoadPartialConfigurationActivityInput(
-                    device_data=stage_input.device,
-                    config_file=tenant_config_file,
-                ),
-                start_to_close_timeout=timedelta(minutes=1),
-                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-            )
-        if intended_config_commit_id is None:
-            _, intended_config_commit_id, _ = await workflow.execute_activity(
-                load_partial_configuration,
-                LoadPartialConfigurationActivityInput(
-                    device_data=stage_input.device,
-                    config_file=stage_input.device.intended_config_file,
-                ),
-                start_to_close_timeout=timedelta(minutes=1),
-                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-            )
         if tenant_config_commit_id is None or intended_config_commit_id is None:
             raise ApplicationError("Failed to resolve rendered configuration commit IDs")
 

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -323,10 +323,24 @@ class SpXOverlayDeletionWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
         if not existing_vrfs:
+            overlay_result = await workflow.execute_activity(
+                delete_overlay,
+                DeleteOverlayInput(
+                    overlay_id=stage_input.overlay_id,
+                    site=stage_input.site,
+                ),
+                start_to_close_timeout=timedelta(minutes=1),
+                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            )
+            display = (
+                f"Deleted overlay {overlay_result.overlay_name}"
+                if overlay_result.deleted
+                else f"No VRFs or overlay exist for Overlay ID {stage_input.overlay_id}"
+            )
             return self.DeleteSpXOverlayStageOutput(
                 deleted_vrfs=[],
                 in_use_vrfs=[],
-                display=f"No VRFs exist for Overlay ID {stage_input.overlay_id}",
+                display=display,
             )
 
         in_use_vrfs = [vrf for vrf in existing_vrfs if vrf.interface_count > 0]

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -838,8 +838,8 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
     class RenderStageOutput(StageOutput):
         """Render Stage Output."""
 
-        tenant_config_commit_id: str | None = None
-        intended_config_commit_id: str | None = None
+        tenant_config_commit_id: str
+        intended_config_commit_id: str
 
     @stage_executor("render_tenant_config")
     async def render_stage(self, stage_input: RenderStageInput) -> RenderStageOutput:
@@ -858,10 +858,17 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         tenant_config_file = stage_input.device.tenant_config_file
         tenant_config_commit_id = result.get_commit(tenant_config_file)
         intended_config_commit_id = result.get_commit(stage_input.device.intended_config_file)
+        if tenant_config_commit_id is None or intended_config_commit_id is None:
+            missing_files = []
+            if tenant_config_commit_id is None:
+                missing_files.append(tenant_config_file)
+            if intended_config_commit_id is None:
+                missing_files.append(stage_input.device.intended_config_file)
+            raise ApplicationError(
+                f"Render did not return commit IDs for: {', '.join(missing_files)}"
+            )
 
-        display_message = "Rendered tenant configuration"
-        if tenant_config_commit_id:
-            display_message += f" (config ID: {tenant_config_commit_id})"
+        display_message = f"Rendered tenant configuration (config ID: {tenant_config_commit_id})"
 
         return self.RenderStageOutput(
             tenant_config_commit_id=tenant_config_commit_id,
@@ -873,7 +880,7 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         """Wait For Render Stage Input."""
 
         device: NetworkDeviceData
-        config_id: str | None
+        config_id: str
 
     class WaitForRenderStageOutput(StageOutput):
         """Wait For Render Stage Output."""
@@ -908,8 +915,8 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         """Deploy Stage Input."""
 
         device: NetworkDeviceData
-        tenant_config_commit_id: str | None = None
-        intended_config_commit_id: str | None = None
+        tenant_config_commit_id: str
+        intended_config_commit_id: str
 
     class DeployStageOutput(StageOutput):
         """Deploy Stage Output."""

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -92,6 +92,8 @@ NAMESPACE_TAG = "spectrumx"
 DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
     maximum_attempts=3,
 )
+SPX_OVERLAY_ASSIGNMENTS_PATCH = "spx-overlay-assignments-v1"
+SPX_TENANT_CHANGE_DEPLOYMENT_PATCH = "spx-tenant-change-deployment-v1"
 
 
 class SpXOverlayCreationInput(BaseModel):
@@ -623,28 +625,35 @@ class SpXOverlayAssignmentWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixi
 
         await asyncio.gather(*tasks)
 
-        overlay_assignments = await workflow.execute_activity(
-            reconcile_spx_overlay_assignments,
-            ReconcileSpXOverlayAssignmentsInput(
-                overlay_id=stage_input.overlay_id,
-                site=stage_input.site,
-                device_id=stage_input.device_id,
-                interface_ids=[interface.id for interface in interfaces_output.interfaces],
-            ),
-            start_to_close_timeout=timedelta(minutes=1),
-            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+        overlay_assignments = None
+        if workflow.patched(SPX_OVERLAY_ASSIGNMENTS_PATCH):
+            overlay_assignments = await workflow.execute_activity(
+                reconcile_spx_overlay_assignments,
+                ReconcileSpXOverlayAssignmentsInput(
+                    overlay_id=stage_input.overlay_id,
+                    site=stage_input.site,
+                    device_id=stage_input.device_id,
+                    interface_ids=[interface.id for interface in interfaces_output.interfaces],
+                ),
+                start_to_close_timeout=timedelta(minutes=1),
+                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            )
+
+        display = (
+            f"VRF {stage_input.vrf_name} assigned "
+            f"to ports: {', '.join(assigned_ports)}\n"
+            f"Ports already assigned: {', '.join(already_assigned_ports)}"
         )
+        if overlay_assignments is not None:
+            display += (
+                f"\nOverlay assignments created: {overlay_assignments.created}; "
+                f"stale assignments removed: {overlay_assignments.removed}"
+            )
 
         return self.AssignVrfToPortsStageOutput(
             assigned_ports=assigned_ports,
             already_assigned_ports=already_assigned_ports,
-            display=(
-                f"VRF {stage_input.vrf_name} assigned "
-                f"to ports: {', '.join(assigned_ports)}\n"
-                f"Ports already assigned: {', '.join(already_assigned_ports)}\n"
-                f"Overlay assignments created: {overlay_assignments.created}; "
-                f"stale assignments removed: {overlay_assignments.removed}"
-            ),
+            display=display,
         )
 
     @run_nv_config_manager_workflow
@@ -729,6 +738,7 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
     def __init__(self) -> None:
         """Initialize workflow."""
         StageMixin.__init__(self)
+        self.use_new_deployment_flow = workflow.patched(SPX_TENANT_CHANGE_DEPLOYMENT_PATCH)
         self.define_stage(
             name="get_device",
             description="Get device information from Nautobot",
@@ -743,18 +753,23 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             depends_on=["get_device"],
         )
 
-        self.define_stage(
-            name="determine_deployment_action",
-            description="Determine whether the tenant change needs deployment",
-            requires_approval=False,
-            depends_on=["assign_spx_overlay"],
-        )
+        if self.use_new_deployment_flow:
+            self.define_stage(
+                name="determine_deployment_action",
+                description="Determine whether the tenant change needs deployment",
+                requires_approval=False,
+                depends_on=["assign_spx_overlay"],
+            )
 
         self.define_stage(
             name="render_tenant_config",
             description="Render tenant configuration",
             requires_approval=False,
-            depends_on=["determine_deployment_action"],
+            depends_on=(
+                ["determine_deployment_action"]
+                if self.use_new_deployment_flow
+                else ["assign_spx_overlay"]
+            ),
         )
 
         self.define_stage(
@@ -910,6 +925,34 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         tenant_config_commit_id: str
         intended_config_commit_id: str
 
+    class LegacyRenderStageOutput(StageOutput):
+        """Render output used when replaying workflows started before snapshot deployment."""
+
+        config_id: str | None = None
+
+    @stage_executor("render_tenant_config")
+    async def legacy_render_stage(self, stage_input: RenderStageInput) -> LegacyRenderStageOutput:
+        """Preserve the original render command sequence for existing histories."""
+        result = await workflow.execute_activity(
+            execute_render,
+            ExecuteRenderInput(
+                device_id=stage_input.device.id,
+                workflow_id=workflow.info().workflow_id,
+            ),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+        )
+
+        config_id = result.get_commit(stage_input.device.tenant_config_file)
+        display_message = "Rendered tenant configuration"
+        if config_id:
+            display_message += f" (config ID: {config_id})"
+
+        return self.LegacyRenderStageOutput(
+            config_id=config_id,
+            display=display_message,
+        )
+
     @stage_executor("render_tenant_config")
     async def render_stage(self, stage_input: RenderStageInput) -> RenderStageOutput:
         """Render tenant configuration."""
@@ -966,7 +1009,7 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
         """Wait For Render Stage Input."""
 
         device: NetworkDeviceData
-        config_id: str
+        config_id: str | None
 
     class WaitForRenderStageOutput(StageOutput):
         """Wait For Render Stage Output."""
@@ -1058,12 +1101,19 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             )
         )
 
-        deployment_action_output = await self.determine_deployment_action_stage(
-            self.DetermineDeploymentActionStageInput(
-                device_id=device_output.device.id,
-                assignment_changed=bool(assign_output.assigned_ports or assign_output.vrf_assigned),
+        assignment_changed = bool(assign_output.assigned_ports or assign_output.vrf_assigned)
+        if self.use_new_deployment_flow:
+            deployment_action_output = await self.determine_deployment_action_stage(
+                self.DetermineDeploymentActionStageInput(
+                    device_id=device_output.device.id,
+                    assignment_changed=assignment_changed,
+                )
             )
-        )
+        else:
+            deployment_action_output = self.DetermineDeploymentActionStageOutput(
+                deploy_required=assignment_changed,
+                display="Using the deployment behavior recorded by the existing workflow.",
+            )
 
         if not deployment_action_output.deploy_required:
             self.set_stage_state("render_tenant_config", StateEnum.UNREACHABLE)
@@ -1091,26 +1141,40 @@ class SpXOverlayTenantChangeWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMi
             vrf_assigned = assign_output.vrf_assigned
             vrf = assign_output.vrf
         else:
-            render_output = await self.render_stage(
-                self.RenderStageInput(
-                    device=device_output.device,
+            tenant_config_commit_id: str | None
+            intended_config_commit_id: str | None
+            if self.use_new_deployment_flow:
+                render_output = await self.render_stage(
+                    self.RenderStageInput(device=device_output.device)
                 )
-            )
+                tenant_config_commit_id = render_output.tenant_config_commit_id
+                intended_config_commit_id = render_output.intended_config_commit_id
+            else:
+                legacy_render_output = await self.legacy_render_stage(
+                    self.RenderStageInput(device=device_output.device)
+                )
+                tenant_config_commit_id = legacy_render_output.config_id
+                intended_config_commit_id = None
 
             await self.wait_for_render_stage(
                 self.WaitForRenderStageInput(
                     device=device_output.device,
-                    config_id=render_output.tenant_config_commit_id,
+                    config_id=tenant_config_commit_id,
                 )
             )
 
-            deploy_output = await self.deploy_stage(
-                self.DeployStageInput(
-                    device=device_output.device,
-                    tenant_config_commit_id=render_output.tenant_config_commit_id,
-                    intended_config_commit_id=render_output.intended_config_commit_id,
+            if self.use_new_deployment_flow:
+                deploy_output = await self.deploy_stage(
+                    self.DeployStageInput(
+                        device=device_output.device,
+                        tenant_config_commit_id=tenant_config_commit_id,
+                        intended_config_commit_id=intended_config_commit_id,
+                    )
                 )
-            )
+            else:
+                deploy_output = await self.deploy_stage(
+                    self.DeployStageInput(device=device_output.device)
+                )
             device_deployed = deploy_output.device_id
             assigned_ports = assign_output.assigned_ports
             vrf_assigned = assign_output.vrf_assigned

--- a/src/tests/mcp/test_clients.py
+++ b/src/tests/mcp/test_clients.py
@@ -106,3 +106,34 @@ async def test_workflow_list_adds_config_manager_ui_href(settings: MCPSettings) 
     assert workflow["temporal_href"] == (
         "http://localhost:8080/namespaces/default/workflows/workflow-123"
     )
+
+
+async def test_fetch_device_configs_preserves_list_response_shape(
+    settings: MCPSettings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_files = [{"filename": "startup.yaml", "version": 5}]
+
+    class FakeConfigStoreClient:
+        async def __aenter__(self) -> FakeConfigStoreClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def list_device_configs(
+            self,
+            device_id: str,
+            file_type: str | None = "intended",
+        ) -> list[dict[str, object]]:
+            return config_files
+
+    monkeypatch.setattr(
+        clients,
+        "config_store_client",
+        lambda settings, file_type: FakeConfigStoreClient(),
+    )
+
+    result = await clients.fetch_device_configs(settings, "device-1")
+
+    assert result == {"truncated": False, "data": config_files}

--- a/src/tests/temporal/ngc/activities/test_deploy.py
+++ b/src/tests/temporal/ngc/activities/test_deploy.py
@@ -28,8 +28,10 @@ from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData, P
 from nv_config_manager.temporal.ngc.activities.deploy import (
     ConfigApplyActivityInput,
     DiffActivityInput,
+    LoadPartialConfigurationActivityInput,
     WaitForTenantRenderInput,
     apply_approved_configuration,
+    load_partial_configuration,
     perform_candidate_diff,
     wait_for_tenant_render,
 )
@@ -294,6 +296,54 @@ def test_apply_approved_configuration_ignore_fail_without_transition(
     assert exc_info.value.non_retryable is True
     assert "Config apply failed with ignore_fail state" in str(exc_info.value)
     assert "MANUAL INTERVENTION REQUIRED" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_load_partial_configuration_at_pinned_commit():
+    """Load the exact tenant config version supplied by the render snapshot."""
+    mock_config_client = AsyncMock()
+    mock_config_client.__aenter__ = AsyncMock(return_value=mock_config_client)
+    mock_config_client.__aexit__ = AsyncMock(return_value=None)
+    mock_config_client.get_config_file = AsyncMock(
+        return_value={"content": "nv set interface swp1 ip vrf tenant", "version": 7}
+    )
+    mock_config_client.load_file = AsyncMock()
+    mock_config_client.file_url = MagicMock(return_value="https://config-store/tenant.yaml?v=7")
+
+    device_data = NetworkDeviceData(
+        id="test-device-id",
+        name="test-device",
+        platform="cumulus-linux",
+        role="test_role",
+        site="test_site",
+        device_type="test_device_type",
+        primary_ip4="192.0.2.1",
+        primary_ip6=None,
+    )
+
+    with patch(
+        "nv_config_manager.temporal.ngc.activities.deploy.config_store_client",
+        return_value=mock_config_client,
+    ):
+        result = await load_partial_configuration(
+            LoadPartialConfigurationActivityInput(
+                device_data=device_data,
+                config_file="tenant.yaml",
+                commit_id="7",
+            )
+        )
+
+    assert result == (
+        "nv set interface swp1 ip vrf tenant",
+        "7",
+        "https://config-store/tenant.yaml?v=7",
+    )
+    mock_config_client.get_config_file.assert_awaited_once_with(
+        device_uuid="test-device-id",
+        filename="tenant.yaml",
+        version=7,
+    )
+    mock_config_client.load_file.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/activities/test_render.py
+++ b/src/tests/temporal/ngc/activities/test_render.py
@@ -14,12 +14,16 @@
 # limitations under the License.
 """Test Render Activities."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from aioresponses import aioresponses
 
-from nv_config_manager.common.client.render import FileCommit, RenderClient
+from nv_config_manager.common.client.render import (
+    FileCommit,
+    RenderClient,
+    RenderClientException,
+)
 from nv_config_manager.temporal.ngc.activities.render import (
     ExecuteRenderInput,
     ExecuteRenderOutput,
@@ -32,10 +36,22 @@ async def test_execute_render_success() -> None:
     """Test execute_render activity when render succeeds."""
     base_url = "https://render.test.config-manager.example.com"
     mock_client = RenderClient(base_url=base_url)
+    mock_config_client = AsyncMock()
+    mock_config_client.__aenter__.return_value = mock_config_client
+    mock_config_client.list_device_configs.return_value = [
+        {"filename": "tenant.yaml", "version": 5},
+        {"filename": "startup.yaml", "version": 6},
+    ]
 
-    with patch(
-        "nv_config_manager.temporal.ngc.activities.render.render_client",
-        return_value=mock_client,
+    with (
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.render_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.config_store_client",
+            return_value=mock_config_client,
+        ),
     ):
         with aioresponses() as m:
             m.post(
@@ -61,6 +77,10 @@ async def test_execute_render_success() -> None:
         FileCommit(filename="tenant.yaml", commit="5"),
         FileCommit(filename="startup.yaml", commit="6"),
     ]
+    assert result.snapshot_files == [
+        FileCommit(filename="tenant.yaml", commit="5"),
+        FileCommit(filename="startup.yaml", commit="6"),
+    ]
     assert result.get_commit("tenant.yaml") == "5"
     assert result.get_commit("startup.yaml") == "6"
     assert result.get_commit("nonexistent.yaml") is None
@@ -71,10 +91,22 @@ async def test_execute_render_empty_result() -> None:
     """Test execute_render activity when no files are changed."""
     base_url = "https://render.test.config-manager.example.com"
     mock_client = RenderClient(base_url=base_url)
+    mock_config_client = AsyncMock()
+    mock_config_client.__aenter__.return_value = mock_config_client
+    mock_config_client.list_device_configs.return_value = [
+        {"filename": "tenant.yaml", "version": 7},
+        {"filename": "startup.yaml", "version": 11},
+    ]
 
-    with patch(
-        "nv_config_manager.temporal.ngc.activities.render.render_client",
-        return_value=mock_client,
+    with (
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.render_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.config_store_client",
+            return_value=mock_config_client,
+        ),
     ):
         with aioresponses() as m:
             m.post(
@@ -92,13 +124,17 @@ async def test_execute_render_empty_result() -> None:
 
     assert isinstance(result, ExecuteRenderOutput)
     assert result.updated_files == []
+    assert result.snapshot_files == [
+        FileCommit(filename="tenant.yaml", commit="7"),
+        FileCommit(filename="startup.yaml", commit="11"),
+    ]
+    assert result.get_commit("tenant.yaml") == "7"
+    assert result.get_commit("startup.yaml") == "11"
 
 
 @pytest.mark.asyncio
 async def test_execute_render_http_error() -> None:
     """Test execute_render activity when HTTP request fails."""
-    from nv_config_manager.common.client.render import RenderClientException
-
     base_url = "https://render.test.config-manager.example.com"
     mock_client = RenderClient(base_url=base_url)
 

--- a/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
+++ b/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
@@ -549,10 +549,6 @@ async def test_delete_overlay_deletes_when_no_members():
             _r(f"{OVERLAYS_BASE}/overlays/"),
             payload={"results": [{"id": OVERLAY_ID, "name": "test-overlay-001"}]},
         )
-        m.get(
-            _r(f"{OVERLAYS_BASE}/overlays/{OVERLAY_ID}/"),
-            payload={"id": OVERLAY_ID, "member_count": 0},
-        )
         m.get(_r(f"{OVERLAYS_BASE}/vxlans/"), payload={"results": []})
         m.delete(f"{OVERLAYS_BASE}/overlays/{OVERLAY_ID}/", status=204)
 
@@ -571,10 +567,6 @@ async def test_delete_overlay_skips_when_vxlans_remain():
             _r(f"{OVERLAYS_BASE}/overlays/"),
             payload={"results": [{"id": OVERLAY_ID, "name": "test-overlay-001"}]},
         )
-        m.get(
-            _r(f"{OVERLAYS_BASE}/overlays/{OVERLAY_ID}/"),
-            payload={"id": OVERLAY_ID, "member_count": 0},
-        )
         m.get(_r(f"{OVERLAYS_BASE}/vxlans/"), payload={"results": [{"id": VXLAN_ID}]})
 
         result = await delete_overlay(
@@ -585,23 +577,20 @@ async def test_delete_overlay_skips_when_vxlans_remain():
 
 
 @pytest.mark.asyncio
-async def test_delete_overlay_skips_when_assignments_remain():
+async def test_delete_overlay_cascades_assignments_when_no_vxlans_remain():
     with aioresponses() as m:
         m.get(
             _r(f"{OVERLAYS_BASE}/overlays/"),
             payload={"results": [{"id": OVERLAY_ID, "name": "test-overlay-001"}]},
         )
-        m.get(
-            _r(f"{OVERLAYS_BASE}/overlays/{OVERLAY_ID}/"),
-            payload={"id": OVERLAY_ID, "member_count": 2},
-        )
         m.get(_r(f"{OVERLAYS_BASE}/vxlans/"), payload={"results": []})
+        m.delete(f"{OVERLAYS_BASE}/overlays/{OVERLAY_ID}/", status=204)
 
         result = await delete_overlay(
             DeleteOverlayInput(overlay_id="test-overlay-001", site=LOCATION_ID)
         )
 
-    assert result.deleted is False
+    assert result.deleted is True
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
+++ b/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
@@ -26,12 +26,14 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     DeleteOverlayInput,
     GetAvailableRouteDistinguishersInput,
     ProvisionVrfInput,
+    ReconcileSpXOverlayAssignmentsInput,
     VrfDeletionActivityInput,
     _vni_from_rd,
     delete_overlay,
     delete_vrf,
     get_available_route_distinguishers,
     provision_vrf,
+    reconcile_spx_overlay_assignments,
 )
 
 NAUTOBOT = "https://nautobot.example.com"
@@ -74,6 +76,106 @@ def _namespace_graphql_response(*rds, namespace_id=NS_ID, namespace_name="spectr
                 }
             ]
         }
+    }
+
+
+# ---------------------------------------------------------------------------
+# reconcile_spx_overlay_assignments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_spx_overlay_assignments_moves_port_between_overlays():
+    device_id = "22220000-0000-0000-0000-000000000001"
+    interface_id = "33330000-0000-0000-0000-000000000001"
+    existing_interface_id = "33330000-0000-0000-0000-000000000002"
+    old_overlay_id = "44440000-0000-0000-0000-000000000001"
+    ib_overlay_id = "55550000-0000-0000-0000-000000000001"
+    old_assignment_id = "66660000-0000-0000-0000-000000000001"
+
+    with aioresponses() as m:
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlays/"),
+            payload={"results": [{"id": OVERLAY_ID, "name": "Panda"}]},
+        )
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
+            payload={
+                "results": [
+                    {
+                        "id": "device-assignment",
+                        "overlay": {
+                            "id": OVERLAY_ID,
+                            "isolation_type": "spectrum_x_vrf",
+                        },
+                    }
+                ]
+            },
+        )
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
+            payload={
+                "results": [
+                    {
+                        "id": old_assignment_id,
+                        "overlay": {
+                            "id": old_overlay_id,
+                            "isolation_type": "spectrum_x_vrf",
+                        },
+                    },
+                    {
+                        "id": "ib-assignment",
+                        "overlay": {
+                            "id": ib_overlay_id,
+                            "isolation_type": "ib_pkey",
+                        },
+                    },
+                ]
+            },
+        )
+        m.delete(
+            f"{OVERLAYS_BASE}/overlay-assignments/{old_assignment_id}/",
+            status=204,
+        )
+        m.get(
+            _r(f"{NAUTOBOT}/api/extras/statuses/"),
+            payload={"results": [{"id": STATUS_ID}]},
+        )
+        m.post(
+            f"{OVERLAYS_BASE}/overlay-assignments/",
+            payload={"id": "new-interface-assignment"},
+        )
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
+            payload={
+                "results": [
+                    {
+                        "id": "existing-interface-assignment",
+                        "overlay": {
+                            "id": OVERLAY_ID,
+                            "isolation_type": "spectrum_x_vrf",
+                        },
+                    }
+                ]
+            },
+        )
+
+        result = await reconcile_spx_overlay_assignments(
+            ReconcileSpXOverlayAssignmentsInput(
+                overlay_id="Panda",
+                site=LOCATION_ID,
+                device_id=device_id,
+                interface_ids=[interface_id, existing_interface_id],
+            )
+        )
+
+    assert result.created == 1
+    assert result.removed == 1
+    assert _request_json(m, "post", f"{OVERLAYS_BASE}/overlay-assignments/") == {
+        "overlay": OVERLAY_ID,
+        "assigned_object_type": "dcim.interface",
+        "assigned_object_id": interface_id,
+        "status": STATUS_ID,
     }
 
 

--- a/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
+++ b/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
@@ -117,20 +117,32 @@ async def test_reconcile_spx_overlay_assignments_moves_port_between_overlays():
             payload={
                 "results": [
                     {
-                        "id": old_assignment_id,
-                        "overlay": {
-                            "id": old_overlay_id,
-                            "isolation_type": "spectrum_x_vrf",
-                        },
-                    },
-                    {
                         "id": "ib-assignment",
                         "overlay": {
                             "id": ib_overlay_id,
                             "isolation_type": "ib_pkey",
                         },
                     },
-                ]
+                ],
+                "next": (
+                    f"{OVERLAYS_BASE}/overlay-assignments/"
+                    f"?assigned_object_id={interface_id}&depth=1&limit=50&offset=50"
+                ),
+            },
+        )
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
+            payload={
+                "results": [
+                    {
+                        "id": old_assignment_id,
+                        "overlay": {
+                            "id": old_overlay_id,
+                            "isolation_type": "spectrum_x_vrf",
+                        },
+                    }
+                ],
+                "next": None,
             },
         )
         m.delete(
@@ -177,6 +189,79 @@ async def test_reconcile_spx_overlay_assignments_moves_port_between_overlays():
         "assigned_object_id": interface_id,
         "status": STATUS_ID,
     }
+    assignment_mutations = [
+        request_method.lower()
+        for (request_method, request_url) in m.requests
+        if str(request_url).startswith(f"{OVERLAYS_BASE}/overlay-assignments/")
+        and request_method.lower() in {"post", "delete"}
+    ]
+    assert assignment_mutations == ["post", "delete"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_spx_overlay_assignments_keeps_old_assignment_if_create_fails():
+    device_id = "22220000-0000-0000-0000-000000000001"
+    interface_id = "33330000-0000-0000-0000-000000000001"
+    old_assignment_id = "66660000-0000-0000-0000-000000000001"
+
+    with aioresponses() as m:
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlays/"),
+            payload={"results": [{"id": OVERLAY_ID, "name": "Panda"}]},
+        )
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
+            payload={
+                "results": [
+                    {
+                        "id": "device-assignment",
+                        "overlay": {
+                            "id": OVERLAY_ID,
+                            "isolation_type": "spectrum_x_vrf",
+                        },
+                    }
+                ]
+            },
+        )
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
+            payload={
+                "results": [
+                    {
+                        "id": old_assignment_id,
+                        "overlay": {
+                            "id": "44440000-0000-0000-0000-000000000001",
+                            "isolation_type": "spectrum_x_vrf",
+                        },
+                    }
+                ]
+            },
+        )
+        m.get(
+            _r(f"{NAUTOBOT}/api/extras/statuses/"),
+            payload={"results": [{"id": STATUS_ID}]},
+        )
+        m.post(
+            f"{OVERLAYS_BASE}/overlay-assignments/",
+            status=400,
+            payload={"detail": "replacement rejected"},
+        )
+        m.delete(
+            f"{OVERLAYS_BASE}/overlay-assignments/{old_assignment_id}/",
+            status=204,
+        )
+
+        with pytest.raises(NautobotException, match="replacement rejected"):
+            await reconcile_spx_overlay_assignments(
+                ReconcileSpXOverlayAssignmentsInput(
+                    overlay_id="Panda",
+                    site=LOCATION_ID,
+                    device_id=device_id,
+                    interface_ids=[interface_id],
+                )
+            )
+
+    assert all(request_method.lower() != "delete" for request_method, _ in m.requests)
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
+++ b/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
@@ -46,6 +46,7 @@ TENANT_ID = "cccc0000-0000-0000-0000-000000000001"
 OVERLAY_ID = "dddd0000-0000-0000-0000-000000000001"
 VRF_ID = "eeee0000-0000-0000-0000-000000000001"
 VXLAN_ID = "ffff0000-0000-0000-0000-000000000001"
+ASSIGNMENT_ID = "99990000-0000-0000-0000-000000000001"
 NS_ID = "11110000-0000-0000-0000-000000000001"
 
 
@@ -360,13 +361,17 @@ async def test_get_available_route_distinguishers_raises_when_range_full():
 
 
 @pytest.mark.asyncio
-async def test_provision_vrf_creates_overlay_vrf_vxlan():
+async def test_provision_vrf_creates_overlay_vrf_assignment_and_vxlan():
     with aioresponses() as m:
         m.get(_r(f"{NAUTOBOT}/api/extras/statuses/"), payload=_lookup(STATUS_ID))
         m.get(_r(f"{NAUTOBOT}/api/tenancy/tenants/"), payload=_lookup(TENANT_ID))
         m.get(_r(f"{OVERLAYS_BASE}/overlays/"), payload={"results": []})
         m.post(f"{OVERLAYS_BASE}/overlays/", payload={"id": OVERLAY_ID})
         m.post(f"{NAUTOBOT}/api/ipam/vrfs/", payload={"id": VRF_ID})
+        m.post(
+            f"{OVERLAYS_BASE}/overlay-assignments/",
+            payload={"id": ASSIGNMENT_ID},
+        )
         m.post(f"{OVERLAYS_BASE}/vxlans/", payload={"id": VXLAN_ID})
 
         await provision_vrf(
@@ -385,6 +390,12 @@ async def test_provision_vrf_creates_overlay_vrf_vxlan():
             "namespace": NS_ID,
             "tenant": TENANT_ID,
         }
+        assert _request_json(m, "post", f"{OVERLAYS_BASE}/overlay-assignments/") == {
+            "overlay": OVERLAY_ID,
+            "assigned_object_type": "ipam.vrf",
+            "assigned_object_id": VRF_ID,
+            "status": STATUS_ID,
+        }
 
 
 @pytest.mark.asyncio
@@ -398,6 +409,10 @@ async def test_provision_vrf_reuses_existing_overlay():
         )
         # No create_overlay call — overlay already exists
         m.post(f"{NAUTOBOT}/api/ipam/vrfs/", payload={"id": VRF_ID})
+        m.post(
+            f"{OVERLAYS_BASE}/overlay-assignments/",
+            payload={"id": ASSIGNMENT_ID},
+        )
         m.post(f"{OVERLAYS_BASE}/vxlans/", payload={"id": VXLAN_ID})
 
         await provision_vrf(
@@ -419,9 +434,17 @@ async def test_provision_vrf_rolls_back_on_vxlan_failure():
         m.get(_r(f"{OVERLAYS_BASE}/overlays/"), payload={"results": []})
         m.post(f"{OVERLAYS_BASE}/overlays/", payload={"id": OVERLAY_ID})
         m.post(f"{NAUTOBOT}/api/ipam/vrfs/", payload={"id": VRF_ID})
+        m.post(
+            f"{OVERLAYS_BASE}/overlay-assignments/",
+            payload={"id": ASSIGNMENT_ID},
+        )
         # vxlan creation fails
         m.post(f"{OVERLAYS_BASE}/vxlans/", status=400, payload={"detail": "bad"})
-        # rollback: delete vrf (no vxlans were created)
+        # rollback: delete assignment and VRF (no VXLANs were created)
+        m.delete(
+            f"{OVERLAYS_BASE}/overlay-assignments/{ASSIGNMENT_ID}/",
+            status=204,
+        )
         m.delete(f"{NAUTOBOT}/api/ipam/vrfs/{VRF_ID}/", status=204)
 
         with pytest.raises(ApplicationError, match="Failed to provision VPC"):
@@ -477,13 +500,21 @@ async def test_provision_vrf_missing_tenant_raises():
 
 
 @pytest.mark.asyncio
-async def test_delete_vrf_deletes_vxlan_then_vrf():
+async def test_delete_vrf_deletes_vxlan_assignment_then_vrf():
     with aioresponses() as m:
         m.get(
             _r(f"{OVERLAYS_BASE}/vxlans/"),
             payload={"results": [{"id": VXLAN_ID, "vrf": {"id": VRF_ID}}]},
         )
         m.delete(f"{OVERLAYS_BASE}/vxlans/{VXLAN_ID}/", status=204)
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
+            payload={"results": [{"id": ASSIGNMENT_ID}]},
+        )
+        m.delete(
+            f"{OVERLAYS_BASE}/overlay-assignments/{ASSIGNMENT_ID}/",
+            status=204,
+        )
         m.delete(f"{NAUTOBOT}/api/ipam/vrfs/{VRF_ID}/", status=204)
 
         await delete_vrf(VrfDeletionActivityInput(vrf_id=VRF_ID, vnid=60004))
@@ -497,6 +528,10 @@ async def test_delete_vrf_skips_vxlan_bound_to_different_vrf():
             payload={"results": [{"id": VXLAN_ID, "vrf": {"id": "other-vrf-id"}}]},
         )
         # No VXLAN delete — vrf_id doesn't match
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
+            payload={"results": []},
+        )
         m.delete(f"{NAUTOBOT}/api/ipam/vrfs/{VRF_ID}/", status=204)
 
         await delete_vrf(VrfDeletionActivityInput(vrf_id=VRF_ID, vnid=60004))

--- a/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
+++ b/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
@@ -97,7 +97,15 @@ async def test_reconcile_spx_overlay_assignments_moves_port_between_overlays():
     with aioresponses() as m:
         m.get(
             _r(f"{OVERLAYS_BASE}/overlays/"),
-            payload={"results": [{"id": OVERLAY_ID, "name": "Panda"}]},
+            payload={
+                "results": [
+                    {
+                        "id": OVERLAY_ID,
+                        "name": "Panda",
+                        "isolation_type": "spectrum_x_vrf",
+                    }
+                ]
+            },
         )
         m.get(
             _r(f"{OVERLAYS_BASE}/overlay-assignments/"),
@@ -200,6 +208,35 @@ async def test_reconcile_spx_overlay_assignments_moves_port_between_overlays():
 
 
 @pytest.mark.asyncio
+async def test_reconcile_spx_overlay_assignments_rejects_non_spx_overlay():
+    with aioresponses() as m:
+        m.get(
+            _r(f"{OVERLAYS_BASE}/overlays/"),
+            payload={
+                "results": [
+                    {
+                        "id": OVERLAY_ID,
+                        "name": "Panda",
+                        "isolation_type": "ib_pkey",
+                    }
+                ]
+            },
+        )
+
+        with pytest.raises(ApplicationError, match="is not a spectrum_x_vrf overlay"):
+            await reconcile_spx_overlay_assignments(
+                ReconcileSpXOverlayAssignmentsInput(
+                    overlay_id="Panda",
+                    site=LOCATION_ID,
+                    device_id="22220000-0000-0000-0000-000000000001",
+                    interface_ids=["33330000-0000-0000-0000-000000000001"],
+                )
+            )
+
+    assert all("overlay-assignments" not in str(request_url) for _, request_url in m.requests)
+
+
+@pytest.mark.asyncio
 async def test_reconcile_spx_overlay_assignments_keeps_old_assignment_if_create_fails():
     device_id = "22220000-0000-0000-0000-000000000001"
     interface_id = "33330000-0000-0000-0000-000000000001"
@@ -208,7 +245,15 @@ async def test_reconcile_spx_overlay_assignments_keeps_old_assignment_if_create_
     with aioresponses() as m:
         m.get(
             _r(f"{OVERLAYS_BASE}/overlays/"),
-            payload={"results": [{"id": OVERLAY_ID, "name": "Panda"}]},
+            payload={
+                "results": [
+                    {
+                        "id": OVERLAY_ID,
+                        "name": "Panda",
+                        "isolation_type": "spectrum_x_vrf",
+                    }
+                ]
+            },
         )
         m.get(
             _r(f"{OVERLAYS_BASE}/overlay-assignments/"),

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -36,7 +36,6 @@ from nv_config_manager.temporal.ngc.activities.deploy import (
     perform_candidate_diff,
     validate_config_diff,
 )
-from nv_config_manager.temporal.ngc.activities.nats import publish_nats
 from nv_config_manager.temporal.ngc.activities.nautobot import (
     GetNetworkDeviceInput,
     GetNetworkDeviceOutput,
@@ -45,17 +44,11 @@ from nv_config_manager.temporal.ngc.workflows.backup import BackupWorkflow
 from nv_config_manager.temporal.ngc.workflows.deploy import (
     INTENDED_CONFIG_COMMIT_ID_DESCRIPTION,
     TENANT_CONFIG_COMMIT_ID_DESCRIPTION,
-    TENANT_DEPLOY_RENDER_SNAPSHOT_PATCH,
     DeployInput,
     DeployWorkflow,
     TenantDeployInput,
     TenantDeployWorkflow,
 )
-
-
-def _legacy_tenant_deploy_patch(patch_id: str) -> bool:
-    """Select the legacy tenant deploy path while leaving unrelated patches enabled."""
-    return patch_id != TENANT_DEPLOY_RENDER_SNAPSHOT_PATCH
 
 
 @activity.defn(name="get_network_device")
@@ -242,69 +235,6 @@ async def mock_get_ui_base_url() -> str:
 
 
 @pytest.mark.asyncio
-@patch(
-    "nv_config_manager.temporal.ngc.workflows.deploy.workflow.patched",
-    side_effect=_legacy_tenant_deploy_patch,
-)
-@patch("nv_config_manager.temporal.client.device.CumulusConnection")
-@patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
-@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
-async def test_tenant_deploy_preserves_legacy_command_path(
-    _mock_time,
-    mock_nats_client,
-    mock_cumulus_connection,
-    _mock_patched,
-    env,
-):
-    """Histories without the snapshot marker do not load a second configuration."""
-    _newer_commit_mock_state["use_newer_commit"] = False
-    task_queue_name = str(uuid.uuid4())
-    client: Client = env.client
-
-    async with Worker(
-        client,
-        task_queue=task_queue_name,
-        workflows=[TenantDeployWorkflow, BackupWorkflow],
-        activities=[
-            mock_get_network_device,
-            mock_load_partial_configuration,
-            perform_candidate_diff,
-            load_running_configuration,
-            mock_persist_config_backup,
-            mock_record_backup_config_manager_plugin,
-            mock_get_ui_base_url,
-            publish_nats,
-        ],
-        activity_executor=ThreadPoolExecutor(5),
-    ):
-        mock_cumulus_connection.return_value.get_running_configuration.return_value = (
-            "mock running config"
-        )
-        mock_cumulus_connection.return_value.perform_candidate_diff.return_value = ""
-
-        handle: WorkflowHandle = await client.start_workflow(
-            TenantDeployWorkflow.run,
-            TenantDeployInput(device="mock_device_uuid"),
-            id=str(uuid.uuid4()),
-            task_queue=task_queue_name,
-            run_timeout=timedelta(minutes=10),
-        )
-
-        assert await handle.result() is False
-
-        stages = {stage["name"]: stage for stage in await handle.query("stages")}
-        assert stages["load_tenant_configuration"]["output"]["commit_id"] == (
-            "mock_tenant_commit_id"
-        )
-        assert (
-            stages["load_tenant_configuration"]["output"]["intended_config_commit_id"]
-            == "mock_tenant_commit_id"
-        )
-        assert stages["perform_backup"]["input"]["commit_id"] == "mock_tenant_commit_id"
-        assert mock_nats_client.return_value.publish.called
-
-
-@pytest.mark.asyncio
 @patch("nv_config_manager.temporal.client.device.CumulusConnection")
 @patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
 @patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
@@ -314,6 +244,8 @@ async def test_execute_workflow(
     mock_cumulus_connection: Any,
     env: Any,
 ) -> None:
+    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
+
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -763,6 +695,8 @@ async def test_execute_workflow_no_diff(
     mock_cumulus_connection: Any,
     env: Any,
 ) -> None:
+    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
+
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -930,6 +864,8 @@ async def test_execute_workflow_rejected_diff(
     env: Any,
 ) -> None:
     """Test that when a diff is rejected, apply and backup stages are UNREACHABLE."""
+    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
+
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -1006,6 +942,8 @@ async def test_execute_tenant_deploy_workflow(
     mock_cumulus_connection,
     env,
 ):
+    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
+
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -1408,6 +1346,7 @@ async def test_apply_config_with_ignore_fail_and_retry(
 ) -> None:
     """Test that ConfigApplyFailureException displays error message and fails workflow."""
     from nv_config_manager.temporal.client.device import ConfigApplyFailureException
+    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
 
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
@@ -1505,6 +1444,8 @@ async def test_execute_tenant_deploy_workflow_invalid_config(
     mock_cumulus_connection,
     env,
 ):
+    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
+
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -1575,6 +1516,8 @@ async def test_execute_tenant_deploy_workflow_newer_commit_allowed(
     env,
 ):
     """Test tenant deploy when commit is newer but all lines are allowed."""
+    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
+
     _newer_commit_mock_state["use_newer_commit"] = True
     _newer_commit_mock_state["newer_commit_allowed"] = True
 
@@ -1659,6 +1602,8 @@ async def test_execute_tenant_deploy_workflow_newer_commit_disallowed(
     env,
 ):
     """Test tenant deploy when commit is newer but has disallowed lines."""
+    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
+
     _newer_commit_mock_state["use_newer_commit"] = True
     _newer_commit_mock_state["newer_commit_allowed"] = False
 

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -36,6 +36,7 @@ from nv_config_manager.temporal.ngc.activities.deploy import (
     perform_candidate_diff,
     validate_config_diff,
 )
+from nv_config_manager.temporal.ngc.activities.nats import publish_nats
 from nv_config_manager.temporal.ngc.activities.nautobot import (
     GetNetworkDeviceInput,
     GetNetworkDeviceOutput,
@@ -44,11 +45,17 @@ from nv_config_manager.temporal.ngc.workflows.backup import BackupWorkflow
 from nv_config_manager.temporal.ngc.workflows.deploy import (
     INTENDED_CONFIG_COMMIT_ID_DESCRIPTION,
     TENANT_CONFIG_COMMIT_ID_DESCRIPTION,
+    TENANT_DEPLOY_RENDER_SNAPSHOT_PATCH,
     DeployInput,
     DeployWorkflow,
     TenantDeployInput,
     TenantDeployWorkflow,
 )
+
+
+def _legacy_tenant_deploy_patch(patch_id: str) -> bool:
+    """Select the legacy tenant deploy path while leaving unrelated patches enabled."""
+    return patch_id != TENANT_DEPLOY_RENDER_SNAPSHOT_PATCH
 
 
 @activity.defn(name="get_network_device")
@@ -235,6 +242,69 @@ async def mock_get_ui_base_url() -> str:
 
 
 @pytest.mark.asyncio
+@patch(
+    "nv_config_manager.temporal.ngc.workflows.deploy.workflow.patched",
+    side_effect=_legacy_tenant_deploy_patch,
+)
+@patch("nv_config_manager.temporal.client.device.CumulusConnection")
+@patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+async def test_tenant_deploy_preserves_legacy_command_path(
+    _mock_time,
+    mock_nats_client,
+    mock_cumulus_connection,
+    _mock_patched,
+    env,
+):
+    """Histories without the snapshot marker do not load a second configuration."""
+    _newer_commit_mock_state["use_newer_commit"] = False
+    task_queue_name = str(uuid.uuid4())
+    client: Client = env.client
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[TenantDeployWorkflow, BackupWorkflow],
+        activities=[
+            mock_get_network_device,
+            mock_load_partial_configuration,
+            perform_candidate_diff,
+            load_running_configuration,
+            mock_persist_config_backup,
+            mock_record_backup_config_manager_plugin,
+            mock_get_ui_base_url,
+            publish_nats,
+        ],
+        activity_executor=ThreadPoolExecutor(5),
+    ):
+        mock_cumulus_connection.return_value.get_running_configuration.return_value = (
+            "mock running config"
+        )
+        mock_cumulus_connection.return_value.perform_candidate_diff.return_value = ""
+
+        handle: WorkflowHandle = await client.start_workflow(
+            TenantDeployWorkflow.run,
+            TenantDeployInput(device="mock_device_uuid"),
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+            run_timeout=timedelta(minutes=10),
+        )
+
+        assert await handle.result() is False
+
+        stages = {stage["name"]: stage for stage in await handle.query("stages")}
+        assert stages["load_tenant_configuration"]["output"]["commit_id"] == (
+            "mock_tenant_commit_id"
+        )
+        assert (
+            stages["load_tenant_configuration"]["output"]["intended_config_commit_id"]
+            == "mock_tenant_commit_id"
+        )
+        assert stages["perform_backup"]["input"]["commit_id"] == "mock_tenant_commit_id"
+        assert mock_nats_client.return_value.publish.called
+
+
+@pytest.mark.asyncio
 @patch("nv_config_manager.temporal.client.device.CumulusConnection")
 @patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
 @patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
@@ -244,8 +314,6 @@ async def test_execute_workflow(
     mock_cumulus_connection: Any,
     env: Any,
 ) -> None:
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -695,8 +763,6 @@ async def test_execute_workflow_no_diff(
     mock_cumulus_connection: Any,
     env: Any,
 ) -> None:
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -864,8 +930,6 @@ async def test_execute_workflow_rejected_diff(
     env: Any,
 ) -> None:
     """Test that when a diff is rejected, apply and backup stages are UNREACHABLE."""
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -942,8 +1006,6 @@ async def test_execute_tenant_deploy_workflow(
     mock_cumulus_connection,
     env,
 ):
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -1346,7 +1408,6 @@ async def test_apply_config_with_ignore_fail_and_retry(
 ) -> None:
     """Test that ConfigApplyFailureException displays error message and fails workflow."""
     from nv_config_manager.temporal.client.device import ConfigApplyFailureException
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
 
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
@@ -1444,8 +1505,6 @@ async def test_execute_tenant_deploy_workflow_invalid_config(
     mock_cumulus_connection,
     env,
 ):
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -1516,8 +1575,6 @@ async def test_execute_tenant_deploy_workflow_newer_commit_allowed(
     env,
 ):
     """Test tenant deploy when commit is newer but all lines are allowed."""
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     _newer_commit_mock_state["use_newer_commit"] = True
     _newer_commit_mock_state["newer_commit_allowed"] = True
 
@@ -1602,8 +1659,6 @@ async def test_execute_tenant_deploy_workflow_newer_commit_disallowed(
     env,
 ):
     """Test tenant deploy when commit is newer but has disallowed lines."""
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     _newer_commit_mock_state["use_newer_commit"] = True
     _newer_commit_mock_state["newer_commit_allowed"] = False
 

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -861,6 +861,7 @@ async def test_execute_tenant_deploy_workflow(
         activities=[
             mock_get_network_device,
             mock_load_partial_configuration,
+            mock_load_intended_configuration,
             perform_candidate_diff,
             validate_config_diff,
             apply_approved_configuration,
@@ -932,6 +933,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                     "device": ANY,
                     "display": "Loaded tenant configuration from "
                     "[mock_device_uuid/tenant.yaml](https://gitlab.example.com/example-user/intended-network-configs/-/blob/mock_tenant_commit_id/SITEA/MOCK_DEVICE/tenant.yaml).",
+                    "intended_config_commit_id": "mock_commit_id",
                     "tenant_config": "mock tenant config",
                 },
                 "rejecters": [],
@@ -1033,7 +1035,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                 "description": "Run the backup workflow for the device..",
                 "execution_time": 0.0,
                 "input": {
-                    "commit_id": "mock_tenant_commit_id",
+                    "commit_id": "mock_commit_id",
                     "device_id": "mock_device_uuid",
                 },
                 "name": "perform_backup",
@@ -1116,11 +1118,11 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                 "execution_time": 0.0,
                 "input": {
                     "device_id": "mock_device_uuid",
-                    "intended_config_commit_id": "mock_tenant_commit_id",
+                    "intended_config_commit_id": "mock_commit_id",
                 },
                 "name": "check_drift",
                 "output": {
-                    "commit_id": "mock_tenant_commit_id",
+                    "commit_id": "mock_commit_id",
                     "diff": "",
                     "display": "No drift detected between running and intended configuration.",
                     "has_drift": False,
@@ -1169,7 +1171,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                         "ztp_enabled": False,
                         "config_context": None,
                     },
-                    "intended_config_commit_id": "mock_tenant_commit_id",
+                    "intended_config_commit_id": "mock_commit_id",
                     "running_config": "mock running config",
                     "trigger": "WORKFLOW",
                     "user": "nv-config-manager-temporal",
@@ -1203,7 +1205,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
 
         expected_backup_input = {
             "device_id": "mock_device_uuid",
-            "intended_config_commit_id": "mock_tenant_commit_id",
+            "intended_config_commit_id": "mock_commit_id",
             "trigger": "WORKFLOW",
             "user": "nv-config-manager-temporal",
             "user_domain": None,
@@ -1353,6 +1355,7 @@ async def test_execute_tenant_deploy_workflow_invalid_config(
         activities=[
             mock_get_network_device,
             mock_load_partial_configuration,
+            mock_load_intended_configuration,
             perform_candidate_diff,
             validate_config_diff,
             apply_approved_configuration,
@@ -1423,6 +1426,7 @@ async def test_execute_tenant_deploy_workflow_newer_commit_allowed(
         activities=[
             mock_get_network_device,
             mock_load_partial_configuration,
+            mock_load_intended_configuration,
             perform_candidate_diff,
             validate_config_diff,
             apply_approved_configuration,
@@ -1497,6 +1501,7 @@ async def test_execute_tenant_deploy_workflow_newer_commit_disallowed(
         activities=[
             mock_get_network_device,
             mock_load_partial_configuration,
+            mock_load_intended_configuration,
             perform_candidate_diff,
             validate_config_diff,
             apply_approved_configuration,

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -92,16 +92,18 @@ _newer_commit_mock_state = {
 async def mock_load_partial_configuration(
     activity_input: LoadPartialConfigurationActivityInput,
 ) -> tuple[str, str, str]:
+    commit_id = activity_input.commit_id or "mock_tenant_commit_id"
     # Check if we should return a newer commit for testing
     if _newer_commit_mock_state.get("use_newer_commit", False):
+        commit_id = activity_input.commit_id or "7"
         if _newer_commit_mock_state.get("newer_commit_allowed", True):
             return (
                 "nv set vrf test-vrf router bgp router-id 172.28.0.2\n"
                 "nv set vrf test-vrf router bgp autonomous-system 4266990009\n"
                 "nv set interface swp1 ip vrf test-vrf\n"
                 "nv set interface swp2 ip vrf test-vrf\n",
-                "7",  # Newer commit ID
-                "https://config-manager.example.com/device/mock_device/tenant.yaml?commit=7",
+                commit_id,
+                f"https://config-manager.example.com/device/mock_device/tenant.yaml?commit={commit_id}",
             )
         else:
             return (
@@ -110,14 +112,14 @@ async def mock_load_partial_configuration(
                 "nv set interface swp1 ip vrf test-vrf\n"
                 "nv set interface swp2 ip vrf test-vrf\n"
                 "nv set system hostname disallowed-change\n",  # Disallowed line
-                "7",  # Newer commit ID
-                "https://config-manager.example.com/device/mock_device/tenant.yaml?commit=7",
+                commit_id,
+                f"https://config-manager.example.com/device/mock_device/tenant.yaml?commit={commit_id}",
             )
     # Default behavior for other tests
     return (
         "mock tenant config",
-        "mock_tenant_commit_id",
-        "https://gitlab.example.com/example-user/intended-network-configs/-/blob/mock_tenant_commit_id/SITEA/MOCK_DEVICE/tenant.yaml",
+        commit_id,
+        f"https://config-manager.example.com/device/mock_device_uuid/tenant.yaml?commit={commit_id}",
     )
 
 
@@ -903,7 +905,11 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
 """
         mock_cumulus_connection.return_value.perform_candidate_diff.return_value = mock_tenant_diff
 
-        input = TenantDeployInput(device="mock_device_uuid")
+        input = TenantDeployInput(
+            device="mock_device_uuid",
+            tenant_config_commit_id="7",
+            intended_config_commit_id="11",
+        )
 
         workflow_id = str(uuid.uuid4())
         handle: WorkflowHandle = await env.client.start_workflow(
@@ -926,14 +932,18 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                 "depends_on": [],
                 "description": "Load the latest tenant configuration from config store.",
                 "execution_time": 0.0,
-                "input": {"device": "mock_device_uuid"},
+                "input": {
+                    "device": "mock_device_uuid",
+                    "intended_config_commit_id": "11",
+                    "tenant_config_commit_id": "7",
+                },
                 "name": "load_tenant_configuration",
                 "output": {
-                    "commit_id": "mock_tenant_commit_id",
+                    "commit_id": "7",
                     "device": ANY,
                     "display": "Loaded tenant configuration from "
-                    "[mock_device_uuid/tenant.yaml](https://gitlab.example.com/example-user/intended-network-configs/-/blob/mock_tenant_commit_id/SITEA/MOCK_DEVICE/tenant.yaml).",
-                    "intended_config_commit_id": "mock_commit_id",
+                    "[mock_device_uuid/tenant.yaml](https://config-manager.example.com/device/mock_device_uuid/tenant.yaml?commit=7).",
+                    "intended_config_commit_id": "11",
                     "tenant_config": "mock tenant config",
                 },
                 "rejecters": [],
@@ -1035,7 +1045,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                 "description": "Run the backup workflow for the device..",
                 "execution_time": 0.0,
                 "input": {
-                    "commit_id": "mock_commit_id",
+                    "commit_id": "11",
                     "device_id": "mock_device_uuid",
                 },
                 "name": "perform_backup",
@@ -1118,11 +1128,11 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                 "execution_time": 0.0,
                 "input": {
                     "device_id": "mock_device_uuid",
-                    "intended_config_commit_id": "mock_commit_id",
+                    "intended_config_commit_id": "11",
                 },
                 "name": "check_drift",
                 "output": {
-                    "commit_id": "mock_commit_id",
+                    "commit_id": "11",
                     "diff": "",
                     "display": "No drift detected between running and intended configuration.",
                     "has_drift": False,
@@ -1171,7 +1181,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                         "ztp_enabled": False,
                         "config_context": None,
                     },
-                    "intended_config_commit_id": "mock_commit_id",
+                    "intended_config_commit_id": "11",
                     "running_config": "mock running config",
                     "trigger": "WORKFLOW",
                     "user": "nv-config-manager-temporal",
@@ -1205,7 +1215,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
 
         expected_backup_input = {
             "device_id": "mock_device_uuid",
-            "intended_config_commit_id": "mock_commit_id",
+            "intended_config_commit_id": "11",
             "trigger": "WORKFLOW",
             "user": "nv-config-manager-temporal",
             "user_domain": None,
@@ -1375,7 +1385,11 @@ nv set interface swp1 ip address 10.0.0.1/24
 """
         mock_cumulus_connection.return_value.perform_candidate_diff.return_value = mock_invalid_diff
 
-        input = TenantDeployInput(device="mock_device_uuid")
+        input = TenantDeployInput(
+            device="mock_device_uuid",
+            tenant_config_commit_id="7",
+            intended_config_commit_id="11",
+        )
 
         workflow_id = str(uuid.uuid4())
 
@@ -1450,7 +1464,11 @@ nv set interface swp2 ip vrf test-vrf
 """
         mock_cumulus_connection.return_value.perform_candidate_diff.return_value = mock_tenant_diff
 
-        input = TenantDeployInput(device="mock_device_uuid")
+        input = TenantDeployInput(
+            device="mock_device_uuid",
+            tenant_config_commit_id="7",
+            intended_config_commit_id="11",
+        )
 
         workflow_id = str(uuid.uuid4())
         handle: WorkflowHandle = await env.client.start_workflow(
@@ -1470,6 +1488,13 @@ nv set interface swp2 ip vrf test-vrf
         load_stage = next((s for s in stages if s["name"] == "load_tenant_configuration"), None)
         assert load_stage is not None
         assert load_stage["output"]["commit_id"] == "7"
+        assert load_stage["output"]["intended_config_commit_id"] == "11"
+        assert stages[-1]["input"]["commit_id"] == "11"
+
+        backup_workflow_id = stages[-1]["child_workflows"][0]
+        backup_handle = client.get_workflow_handle(backup_workflow_id)
+        backup_input = await backup_handle.query("input")
+        assert backup_input["intended_config_commit_id"] == "11"
 
     # Reset state for other tests
     _newer_commit_mock_state["use_newer_commit"] = False
@@ -1526,7 +1551,11 @@ nv set system hostname disallowed-change
 """
         mock_cumulus_connection.return_value.perform_candidate_diff.return_value = mock_tenant_diff
 
-        input = TenantDeployInput(device="mock_device_uuid")
+        input = TenantDeployInput(
+            device="mock_device_uuid",
+            tenant_config_commit_id="7",
+            intended_config_commit_id="11",
+        )
 
         workflow_id = str(uuid.uuid4())
 
@@ -1541,6 +1570,10 @@ nv set system hostname disallowed-change
         # Wait a bit for workflow to progress, then check stages
         await asyncio.sleep(2)
         stages = await handle.query("stages")
+        load_stage = next((s for s in stages if s["name"] == "load_tenant_configuration"), None)
+        assert load_stage is not None
+        assert load_stage["output"]["commit_id"] == "7"
+        assert load_stage["output"]["intended_config_commit_id"] == "11"
         validate_stage = next(
             (s for s in stages if s["name"] == "validate_configuration_diff"), None
         )

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -41,6 +41,8 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
 )
 from nv_config_manager.temporal.ngc.workflows.backup import BackupWorkflow
 from nv_config_manager.temporal.ngc.workflows.deploy import (
+    INTENDED_CONFIG_COMMIT_ID_DESCRIPTION,
+    TENANT_CONFIG_COMMIT_ID_DESCRIPTION,
     DeployInput,
     DeployWorkflow,
     TenantDeployInput,
@@ -112,10 +114,12 @@ def test_tenant_deploy_input_schema_requires_both_snapshot_commit_ids_or_neither
             ],
             "properties": {
                 "tenant_config_commit_id": {
+                    "description": TENANT_CONFIG_COMMIT_ID_DESCRIPTION,
                     "type": "string",
                     "pattern": r"^\d+$",
                 },
                 "intended_config_commit_id": {
+                    "description": INTENDED_CONFIG_COMMIT_ID_DESCRIPTION,
                     "type": "string",
                     "pattern": r"^\d+$",
                 },

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -109,7 +109,17 @@ def test_tenant_deploy_input_schema_requires_both_snapshot_commit_ids_or_neither
             "required": [
                 "tenant_config_commit_id",
                 "intended_config_commit_id",
-            ]
+            ],
+            "properties": {
+                "tenant_config_commit_id": {
+                    "type": "string",
+                    "pattern": r"^\d+$",
+                },
+                "intended_config_commit_id": {
+                    "type": "string",
+                    "pattern": r"^\d+$",
+                },
+            },
         },
         {
             "not": {
@@ -120,6 +130,35 @@ def test_tenant_deploy_input_schema_requires_both_snapshot_commit_ids_or_neither
             }
         },
     ]
+
+
+@pytest.mark.parametrize(
+    "snapshot_fields",
+    [
+        {"tenant_config_commit_id": None},
+        {"intended_config_commit_id": None},
+        {
+            "tenant_config_commit_id": None,
+            "intended_config_commit_id": None,
+        },
+        {
+            "tenant_config_commit_id": None,
+            "intended_config_commit_id": "11",
+        },
+    ],
+)
+def test_tenant_deploy_input_rejects_explicit_null_snapshot_commit_ids(snapshot_fields):
+    """Treat explicit null snapshot fields as invalid rather than omitted."""
+    with pytest.raises(ValidationError, match="must both be non-null or both be omitted"):
+        TenantDeployInput(device="mock_device_uuid", **snapshot_fields)
+
+
+def test_tenant_deploy_input_allows_snapshot_commit_ids_to_be_omitted():
+    """Keep the direct tenant-deploy latest-config path backwards compatible."""
+    deploy_input = TenantDeployInput(device="mock_device_uuid")
+
+    assert deploy_input.tenant_config_commit_id is None
+    assert deploy_input.intended_config_commit_id is None
 
 
 @activity.defn(name="load_partial_configuration")

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -25,6 +25,7 @@ from temporalio import activity
 from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.worker import Worker
 
+from nv_config_manager.temporal.client.device import ConfigApplyFailureException
 from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData, Platform
 from nv_config_manager.temporal.converter import get_data_converter
 from nv_config_manager.temporal.ngc.activities.backup import (
@@ -36,6 +37,7 @@ from nv_config_manager.temporal.ngc.activities.deploy import (
     perform_candidate_diff,
     validate_config_diff,
 )
+from nv_config_manager.temporal.ngc.activities.nats import publish_nats
 from nv_config_manager.temporal.ngc.activities.nautobot import (
     GetNetworkDeviceInput,
     GetNetworkDeviceOutput,
@@ -244,8 +246,6 @@ async def test_execute_workflow(
     mock_cumulus_connection: Any,
     env: Any,
 ) -> None:
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -695,8 +695,6 @@ async def test_execute_workflow_no_diff(
     mock_cumulus_connection: Any,
     env: Any,
 ) -> None:
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -864,8 +862,6 @@ async def test_execute_workflow_rejected_diff(
     env: Any,
 ) -> None:
     """Test that when a diff is rejected, apply and backup stages are UNREACHABLE."""
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -942,8 +938,6 @@ async def test_execute_tenant_deploy_workflow(
     mock_cumulus_connection,
     env,
 ):
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -1345,9 +1339,6 @@ async def test_apply_config_with_ignore_fail_and_retry(
     env: Any,
 ) -> None:
     """Test that ConfigApplyFailureException displays error message and fails workflow."""
-    from nv_config_manager.temporal.client.device import ConfigApplyFailureException
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
 
@@ -1444,8 +1435,6 @@ async def test_execute_tenant_deploy_workflow_invalid_config(
     mock_cumulus_connection,
     env,
 ):
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client
     async with Worker(
@@ -1516,8 +1505,6 @@ async def test_execute_tenant_deploy_workflow_newer_commit_allowed(
     env,
 ):
     """Test tenant deploy when commit is newer but all lines are allowed."""
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     _newer_commit_mock_state["use_newer_commit"] = True
     _newer_commit_mock_state["newer_commit_allowed"] = True
 
@@ -1602,8 +1589,6 @@ async def test_execute_tenant_deploy_workflow_newer_commit_disallowed(
     env,
 ):
     """Test tenant deploy when commit is newer but has disallowed lines."""
-    from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-
     _newer_commit_mock_state["use_newer_commit"] = True
     _newer_commit_mock_state["newer_commit_allowed"] = False
 

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -26,6 +26,7 @@ from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.worker import Worker
 
 from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData, Platform
+from nv_config_manager.temporal.converter import get_data_converter
 from nv_config_manager.temporal.ngc.activities.backup import (
     load_running_configuration,
 )
@@ -163,6 +164,18 @@ def test_tenant_deploy_input_allows_snapshot_commit_ids_to_be_omitted():
 
     assert deploy_input.tenant_config_commit_id is None
     assert deploy_input.intended_config_commit_id is None
+
+
+@pytest.mark.asyncio
+async def test_tenant_deploy_input_preserves_omitted_snapshot_ids_during_temporal_round_trip():
+    """Temporal serialization must not turn omitted snapshot IDs into explicit nulls."""
+    converter = get_data_converter()
+    deploy_input = TenantDeployInput(device="mock_device_uuid")
+
+    payloads = await converter.encode([deploy_input])
+    [decoded_input] = await converter.decode(payloads, [TenantDeployInput])
+
+    assert decoded_input == deploy_input
 
 
 @activity.defn(name="load_partial_configuration")

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -20,6 +20,7 @@ from typing import Any
 from unittest.mock import ANY, patch
 
 import pytest
+from pydantic import ValidationError
 from temporalio import activity
 from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.worker import Worker
@@ -86,6 +87,39 @@ _newer_commit_mock_state = {
     "newer_commit_allowed": True,
     "use_newer_commit": False,
 }
+
+
+@pytest.mark.parametrize("invalid_commit_id", ["abc", "12.5", "-1", ""])
+def test_tenant_deploy_input_rejects_non_numeric_commit_ids(invalid_commit_id):
+    """Reject invalid snapshot versions before starting the workflow."""
+    with pytest.raises(ValidationError, match="string_pattern_mismatch"):
+        TenantDeployInput(
+            device="mock_device_uuid",
+            tenant_config_commit_id=invalid_commit_id,
+            intended_config_commit_id="11",
+        )
+
+
+def test_tenant_deploy_input_schema_requires_both_snapshot_commit_ids_or_neither():
+    """Publish the runtime snapshot-pair constraint in the API schema."""
+    schema = TenantDeployInput.model_json_schema()
+
+    assert schema["oneOf"] == [
+        {
+            "required": [
+                "tenant_config_commit_id",
+                "intended_config_commit_id",
+            ]
+        },
+        {
+            "not": {
+                "anyOf": [
+                    {"required": ["tenant_config_commit_id"]},
+                    {"required": ["intended_config_commit_id"]},
+                ]
+            }
+        },
+    ]
 
 
 @activity.defn(name="load_partial_configuration")

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -28,6 +28,11 @@ from temporalio.exceptions import ApplicationError
 from temporalio.worker import Worker
 
 from nv_config_manager.temporal.common.mixins.device import InterfaceData, NetworkDeviceData
+from nv_config_manager.temporal.ngc.activities.deploy import (
+    LoadPartialConfigurationActivityInput,
+    WaitForTenantRenderInput,
+    WaitForTenantRenderOutput,
+)
 from nv_config_manager.temporal.ngc.activities.nats import publish_nats
 from nv_config_manager.temporal.ngc.activities.nautobot import (
     AssignVrfToDeviceInput,
@@ -44,6 +49,10 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     ReconcileSpXOverlayAssignmentsInput,
     ReconcileSpXOverlayAssignmentsOutput,
     Vrf,
+)
+from nv_config_manager.temporal.ngc.activities.render import (
+    ExecuteRenderInput,
+    ExecuteRenderOutput,
 )
 from nv_config_manager.temporal.ngc.workflows.deploy import TenantDeployInput
 from nv_config_manager.temporal.ngc.workflows.spx_overlay import (
@@ -149,6 +158,13 @@ async def mock_get_device_interfaces(
             mac_address="00:00:00:00:00:02",
             vrf_id="mock_namespace1" if "swp2" in interfaces_with_vrf else None,
         ),
+        InterfaceData(
+            id="interface3_id",
+            name="swp3",
+            host="mock_device",
+            mac_address="00:00:00:00:00:03",
+            vrf_id="mock_namespace1" if "swp3" in interfaces_with_vrf else None,
+        ),
     ]
 
     if activity_input.interface_names:
@@ -192,6 +208,29 @@ async def mock_check_recorded_config_drift(
 ) -> bool:
     """Mock pending deployment check."""
     return bool(_mock_state["recorded_config_drift"])
+
+
+@activity.defn(name="execute_render")
+async def mock_execute_render(_activity_input: ExecuteRenderInput) -> ExecuteRenderOutput:
+    """Model the forced render losing a race with the Nautobot render consumer."""
+    return ExecuteRenderOutput(updated_files=[])
+
+
+@activity.defn(name="load_partial_configuration")
+async def mock_load_partial_configuration(
+    activity_input: LoadPartialConfigurationActivityInput,
+) -> tuple[str, str, str]:
+    """Return the versions already committed by the Nautobot-triggered render."""
+    commit_id = "7" if activity_input.config_file == "tenant.yaml" else "11"
+    return "mock config", commit_id, "https://config-store.example.com"
+
+
+@activity.defn(name="wait_for_tenant_render")
+async def mock_wait_for_tenant_render(
+    activity_input: WaitForTenantRenderInput,
+) -> WaitForTenantRenderOutput:
+    """Return the tenant version immediately."""
+    return WaitForTenantRenderOutput(config_id=activity_input.config_id)
 
 
 @workflow.defn(name="TenantDeployWorkflow", sandboxed=False)
@@ -369,6 +408,67 @@ async def test_spx_overlay_tenant_change_is_noop_when_already_assigned(
         assert stages["render_tenant_config"]["state"] == "UNREACHABLE"
         assert stages["wait_for_render"]["state"] == "UNREACHABLE"
         assert stages["deploy"]["state"] == "UNREACHABLE"
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+async def test_spx_overlay_tenant_change_uses_current_versions_after_render_race(
+    _mock_time, _mock_nats_client, env
+):
+    """Use versions committed by the Nautobot consumer before the forced render."""
+
+    _mock_state["vrf_exists"] = True
+    _mock_state["interfaces_with_vrf"] = ["swp1", "swp2"]
+    _mock_state["reconcile_calls"] = 0
+
+    task_queue_name = str(uuid.uuid4())
+    async with Worker(
+        env.client,
+        task_queue=task_queue_name,
+        workflows=[
+            SpXOverlayAssignmentWorkflow,
+            SpXOverlayTenantChangeWorkflow,
+            MockTenantDeployWorkflow,
+        ],
+        activities=[
+            mock_get_network_device,
+            mock_get_vrfs_by_overlay_id,
+            mock_get_device_vrfs,
+            mock_assign_vrf_to_device,
+            mock_get_device_interfaces,
+            mock_assign_vrf_to_interface,
+            mock_reconcile_spx_overlay_assignments,
+            mock_execute_render,
+            mock_load_partial_configuration,
+            mock_wait_for_tenant_render,
+            publish_nats,
+        ],
+        activity_executor=ThreadPoolExecutor(1),
+    ):
+        handle = await env.client.start_workflow(
+            SpXOverlayTenantChangeWorkflow.run,
+            SpXOverlayTenantChangeInput(
+                overlay_id="mock_overlay_id",
+                device_id="mock_device_id_with_vrf",
+                port_names=["swp1", "swp2", "swp3"],
+                site="mock_site",
+            ),
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+            run_timeout=timedelta(seconds=30),
+        )
+
+        result = await handle.result()
+
+        assert result.assigned_ports == ["swp3"]
+        assert result.device_deployed == "mock_device_id_with_vrf"
+
+        stages = {stage["name"]: stage for stage in await handle.query("stages")}
+        assert stages["render_tenant_config"]["state"] == "COMPLETE"
+        assert stages["render_tenant_config"]["output"]["tenant_config_commit_id"] == "7"
+        assert stages["render_tenant_config"]["output"]["intended_config_commit_id"] == "11"
+        assert stages["deploy"]["state"] == "COMPLETE"
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -229,6 +229,33 @@ async def mock_wait_for_tenant_render(
     return WaitForTenantRenderOutput(config_id=activity_input.config_id)
 
 
+@pytest.mark.parametrize(
+    "commit_ids",
+    [
+        {"tenant_config_commit_id": "7"},
+        {"intended_config_commit_id": "11"},
+    ],
+)
+@pytest.mark.asyncio
+async def test_spx_deploy_stage_rejects_partial_render_commit_pair(commit_ids):
+    device_output = await mock_get_network_device(GetNetworkDeviceInput(device_id="device-1"))
+    with patch(
+        "nv_config_manager.temporal.common.mixins.stage.workflow.time",
+        return_value=float(0),
+    ):
+        workflow_instance = SpXOverlayTenantChangeWorkflow()
+    stage_input = workflow_instance.DeployStageInput(
+        device=device_output.device,
+        **commit_ids,
+    )
+
+    with pytest.raises(ApplicationError, match="must both be supplied or both be omitted"):
+        await SpXOverlayTenantChangeWorkflow.deploy_stage.__wrapped__(
+            workflow_instance,
+            stage_input,
+        )
+
+
 @workflow.defn(name="TenantDeployWorkflow", sandboxed=False)
 class MockTenantDeployWorkflow:
     """Mock tenant deploy child workflow."""

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -18,11 +18,12 @@ import asyncio
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 from temporalio.worker import Worker
 
 from nv_config_manager.temporal.common.mixins.device import InterfaceData, NetworkDeviceData
@@ -38,6 +39,8 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     GetNetworkDeviceInput,
     GetNetworkDeviceOutput,
     QueryVRFByVPCInput,
+    ReconcileSpXOverlayAssignmentsInput,
+    ReconcileSpXOverlayAssignmentsOutput,
     Vrf,
 )
 from nv_config_manager.temporal.ngc.workflows.spx_overlay import (
@@ -87,6 +90,7 @@ _mock_state = {
     "vrf_exists": True,
     "interfaces_with_vrf": [],
     "newer_commit_allowed": True,
+    "reconcile_calls": 0,
 }
 
 
@@ -124,10 +128,6 @@ async def mock_get_device_interfaces(
     activity_input: GetDeviceInterfacesInput,
 ) -> GetDeviceInterfacesOutput:
     """Mock activity for getting device interfaces."""
-    from typing import cast
-
-    from temporalio.exceptions import ApplicationError
-
     interfaces_with_vrf = cast(list[str], _mock_state.get("interfaces_with_vrf", []))
 
     all_interfaces = [
@@ -170,6 +170,18 @@ async def mock_assign_vrf_to_interface(
     """Mock activity for assigning VRF to interface."""
 
 
+@activity.defn(name="reconcile_spx_overlay_assignments")
+async def mock_reconcile_spx_overlay_assignments(
+    activity_input: ReconcileSpXOverlayAssignmentsInput,
+) -> ReconcileSpXOverlayAssignmentsOutput:
+    """Mock reconciliation of overlay-plugin assignments."""
+    _mock_state["reconcile_calls"] = int(_mock_state["reconcile_calls"]) + 1
+    return ReconcileSpXOverlayAssignmentsOutput(
+        created=1 + len(activity_input.interface_ids),
+        removed=0,
+    )
+
+
 @pytest.mark.asyncio
 @patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
 @patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
@@ -191,6 +203,7 @@ async def test_spx_overlay_assignment_workflow_vrf_not_assigned(_mock_time, _moc
             mock_assign_vrf_to_device,
             mock_get_device_interfaces,
             mock_assign_vrf_to_interface,
+            mock_reconcile_spx_overlay_assignments,
             publish_nats,
         ],
         activity_executor=ThreadPoolExecutor(1),
@@ -241,6 +254,7 @@ async def test_spx_overlay_assignment_workflow_vrf_already_assigned(
             mock_assign_vrf_to_device,
             mock_get_device_interfaces,
             mock_assign_vrf_to_interface,
+            mock_reconcile_spx_overlay_assignments,
             publish_nats,
         ],
         activity_executor=ThreadPoolExecutor(1),
@@ -278,6 +292,7 @@ async def test_spx_overlay_tenant_change_is_noop_when_already_assigned(
 
     _mock_state["vrf_exists"] = True
     _mock_state["interfaces_with_vrf"] = ["swp1", "swp2"]
+    _mock_state["reconcile_calls"] = 0
 
     task_queue_name = str(uuid.uuid4())
     async with Worker(
@@ -291,6 +306,7 @@ async def test_spx_overlay_tenant_change_is_noop_when_already_assigned(
             mock_assign_vrf_to_device,
             mock_get_device_interfaces,
             mock_assign_vrf_to_interface,
+            mock_reconcile_spx_overlay_assignments,
             publish_nats,
         ],
         activity_executor=ThreadPoolExecutor(1),
@@ -314,6 +330,7 @@ async def test_spx_overlay_tenant_change_is_noop_when_already_assigned(
         assert result.vrf_assigned is False
         assert result.vrf is None
         assert result.device_deployed is None
+        assert _mock_state["reconcile_calls"] == 1
 
         stages = {stage["name"]: stage for stage in await handle.query("stages")}
         assert stages["render_tenant_config"]["state"] == "UNREACHABLE"
@@ -342,6 +359,7 @@ async def test_spx_overlay_assignment_workflow_vrf_not_found(_mock_time, _mock_n
             mock_assign_vrf_to_device,
             mock_get_device_interfaces,
             mock_assign_vrf_to_interface,
+            mock_reconcile_spx_overlay_assignments,
             publish_nats,
         ],
         activity_executor=ThreadPoolExecutor(1),
@@ -401,6 +419,7 @@ async def test_spx_overlay_assignment_workflow_interface_not_found(
             mock_assign_vrf_to_device,
             mock_get_device_interfaces,
             mock_assign_vrf_to_interface,
+            mock_reconcile_spx_overlay_assignments,
             publish_nats,
         ],
         activity_executor=ThreadPoolExecutor(1),

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -22,6 +22,7 @@ from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 from temporalio.worker import Worker
@@ -180,6 +181,15 @@ async def mock_reconcile_spx_overlay_assignments(
         created=1 + len(activity_input.interface_ids),
         removed=0,
     )
+
+
+def test_spx_render_stage_output_requires_snapshot_commit_ids():
+    """Do not allow the SpX workflow to fall back to an unpinned deploy."""
+    with pytest.raises(ValidationError):
+        SpXOverlayTenantChangeWorkflow.RenderStageOutput(
+            tenant_config_commit_id=None,
+            intended_config_commit_id="11",
+        )
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -56,11 +56,21 @@ from nv_config_manager.temporal.ngc.activities.render import (
 )
 from nv_config_manager.temporal.ngc.workflows.deploy import TenantDeployInput
 from nv_config_manager.temporal.ngc.workflows.spx_overlay import (
+    SPX_OVERLAY_ASSIGNMENTS_PATCH,
+    SPX_TENANT_CHANGE_DEPLOYMENT_PATCH,
     SpXOverlayAssignmentInput,
     SpXOverlayAssignmentWorkflow,
     SpXOverlayTenantChangeInput,
     SpXOverlayTenantChangeWorkflow,
 )
+
+
+def _legacy_spx_patch(patch_id: str) -> bool:
+    """Select legacy SpX paths while leaving unrelated patches enabled."""
+    return patch_id not in {
+        SPX_OVERLAY_ASSIGNMENTS_PATCH,
+        SPX_TENANT_CHANGE_DEPLOYMENT_PATCH,
+    }
 
 
 def make_test_vrf(namespace: str) -> dict[str, Any]:
@@ -468,6 +478,71 @@ async def test_spx_overlay_tenant_change_uses_current_versions_after_render_race
         assert stages["render_tenant_config"]["state"] == "COMPLETE"
         assert stages["render_tenant_config"]["output"]["tenant_config_commit_id"] == "7"
         assert stages["render_tenant_config"]["output"]["intended_config_commit_id"] == "11"
+        assert stages["deploy"]["state"] == "COMPLETE"
+
+
+@pytest.mark.asyncio
+@patch(
+    "nv_config_manager.temporal.ngc.workflows.spx_overlay.workflow.patched",
+    side_effect=_legacy_spx_patch,
+)
+@patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+async def test_spx_overlay_tenant_change_preserves_legacy_command_path(
+    _mock_time, _mock_nats_client, _mock_patched, env
+):
+    """Histories without patch markers retain the original activity sequence."""
+    _mock_state["vrf_exists"] = True
+    _mock_state["interfaces_with_vrf"] = ["swp1"]
+    _mock_state["reconcile_calls"] = 0
+
+    task_queue_name = str(uuid.uuid4())
+    async with Worker(
+        env.client,
+        task_queue=task_queue_name,
+        workflows=[
+            SpXOverlayAssignmentWorkflow,
+            SpXOverlayTenantChangeWorkflow,
+            MockTenantDeployWorkflow,
+        ],
+        activities=[
+            mock_get_network_device,
+            mock_get_vrfs_by_overlay_id,
+            mock_get_device_vrfs,
+            mock_assign_vrf_to_device,
+            mock_get_device_interfaces,
+            mock_assign_vrf_to_interface,
+            mock_execute_render,
+            mock_wait_for_tenant_render,
+            publish_nats,
+        ],
+        activity_executor=ThreadPoolExecutor(1),
+    ):
+        handle = await env.client.start_workflow(
+            SpXOverlayTenantChangeWorkflow.run,
+            SpXOverlayTenantChangeInput(
+                overlay_id="mock_overlay_id",
+                device_id="mock_device_id_with_vrf",
+                port_names=["swp1", "swp2"],
+                site="mock_site",
+            ),
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+            run_timeout=timedelta(seconds=30),
+        )
+
+        result = await handle.result()
+
+        assert result.assigned_ports == ["swp2"]
+        assert result.device_deployed == "mock_device_id_with_vrf"
+        assert _mock_state["reconcile_calls"] == 0
+
+        stages = {stage["name"]: stage for stage in await handle.query("stages")}
+        assert "determine_deployment_action" not in stages
+        assert stages["render_tenant_config"]["output"] == {
+            "config_id": None,
+            "display": "Rendered tenant configuration",
+        }
         assert stages["deploy"]["state"] == "COMPLETE"
 
 

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -29,7 +29,6 @@ from temporalio.worker import Worker
 
 from nv_config_manager.temporal.common.mixins.device import InterfaceData, NetworkDeviceData
 from nv_config_manager.temporal.ngc.activities.deploy import (
-    LoadPartialConfigurationActivityInput,
     WaitForTenantRenderInput,
     WaitForTenantRenderOutput,
 )
@@ -213,16 +212,13 @@ async def mock_check_recorded_config_drift(
 @activity.defn(name="execute_render")
 async def mock_execute_render(_activity_input: ExecuteRenderInput) -> ExecuteRenderOutput:
     """Model the forced render losing a race with the Nautobot render consumer."""
-    return ExecuteRenderOutput(updated_files=[])
-
-
-@activity.defn(name="load_partial_configuration")
-async def mock_load_partial_configuration(
-    activity_input: LoadPartialConfigurationActivityInput,
-) -> tuple[str, str, str]:
-    """Return the versions already committed by the Nautobot-triggered render."""
-    commit_id = "7" if activity_input.config_file == "tenant.yaml" else "11"
-    return "mock config", commit_id, "https://config-store.example.com"
+    return ExecuteRenderOutput(
+        updated_files=[],
+        snapshot_files=[
+            {"filename": "tenant.yaml", "commit": "7"},
+            {"filename": "startup.yaml", "commit": "11"},
+        ],
+    )
 
 
 @activity.defn(name="wait_for_tenant_render")
@@ -440,7 +436,6 @@ async def test_spx_overlay_tenant_change_uses_current_versions_after_render_race
             mock_assign_vrf_to_interface,
             mock_reconcile_spx_overlay_assignments,
             mock_execute_render,
-            mock_load_partial_configuration,
             mock_wait_for_tenant_render,
             publish_nats,
         ],
@@ -468,6 +463,10 @@ async def test_spx_overlay_tenant_change_uses_current_versions_after_render_race
         assert stages["render_tenant_config"]["state"] == "COMPLETE"
         assert stages["render_tenant_config"]["output"]["tenant_config_commit_id"] == "7"
         assert stages["render_tenant_config"]["output"]["intended_config_commit_id"] == "11"
+        assert (
+            stages["wait_for_render"]["input"]["config_id"]
+            == stages["render_tenant_config"]["output"]["tenant_config_commit_id"]
+        )
         assert stages["deploy"]["state"] == "COMPLETE"
         assert stages["deploy"]["input"]["tenant_config_commit_id"] == "7"
         assert stages["deploy"]["input"]["intended_config_commit_id"] == "11"

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -45,6 +45,7 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     ReconcileSpXOverlayAssignmentsOutput,
     Vrf,
 )
+from nv_config_manager.temporal.ngc.workflows.deploy import TenantDeployInput
 from nv_config_manager.temporal.ngc.workflows.spx_overlay import (
     SpXOverlayAssignmentInput,
     SpXOverlayAssignmentWorkflow,
@@ -198,7 +199,7 @@ class MockTenantDeployWorkflow:
     """Mock tenant deploy child workflow."""
 
     @workflow.run
-    async def run(self, _workflow_input: Any) -> bool:
+    async def run(self, _workflow_input: TenantDeployInput) -> bool:
         """Mock tenant deploy run."""
         return True
 

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -56,21 +56,11 @@ from nv_config_manager.temporal.ngc.activities.render import (
 )
 from nv_config_manager.temporal.ngc.workflows.deploy import TenantDeployInput
 from nv_config_manager.temporal.ngc.workflows.spx_overlay import (
-    SPX_OVERLAY_ASSIGNMENTS_PATCH,
-    SPX_TENANT_CHANGE_DEPLOYMENT_PATCH,
     SpXOverlayAssignmentInput,
     SpXOverlayAssignmentWorkflow,
     SpXOverlayTenantChangeInput,
     SpXOverlayTenantChangeWorkflow,
 )
-
-
-def _legacy_spx_patch(patch_id: str) -> bool:
-    """Select legacy SpX paths while leaving unrelated patches enabled."""
-    return patch_id not in {
-        SPX_OVERLAY_ASSIGNMENTS_PATCH,
-        SPX_TENANT_CHANGE_DEPLOYMENT_PATCH,
-    }
 
 
 def make_test_vrf(namespace: str) -> dict[str, Any]:
@@ -478,71 +468,6 @@ async def test_spx_overlay_tenant_change_uses_current_versions_after_render_race
         assert stages["render_tenant_config"]["state"] == "COMPLETE"
         assert stages["render_tenant_config"]["output"]["tenant_config_commit_id"] == "7"
         assert stages["render_tenant_config"]["output"]["intended_config_commit_id"] == "11"
-        assert stages["deploy"]["state"] == "COMPLETE"
-
-
-@pytest.mark.asyncio
-@patch(
-    "nv_config_manager.temporal.ngc.workflows.spx_overlay.workflow.patched",
-    side_effect=_legacy_spx_patch,
-)
-@patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
-@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
-async def test_spx_overlay_tenant_change_preserves_legacy_command_path(
-    _mock_time, _mock_nats_client, _mock_patched, env
-):
-    """Histories without patch markers retain the original activity sequence."""
-    _mock_state["vrf_exists"] = True
-    _mock_state["interfaces_with_vrf"] = ["swp1"]
-    _mock_state["reconcile_calls"] = 0
-
-    task_queue_name = str(uuid.uuid4())
-    async with Worker(
-        env.client,
-        task_queue=task_queue_name,
-        workflows=[
-            SpXOverlayAssignmentWorkflow,
-            SpXOverlayTenantChangeWorkflow,
-            MockTenantDeployWorkflow,
-        ],
-        activities=[
-            mock_get_network_device,
-            mock_get_vrfs_by_overlay_id,
-            mock_get_device_vrfs,
-            mock_assign_vrf_to_device,
-            mock_get_device_interfaces,
-            mock_assign_vrf_to_interface,
-            mock_execute_render,
-            mock_wait_for_tenant_render,
-            publish_nats,
-        ],
-        activity_executor=ThreadPoolExecutor(1),
-    ):
-        handle = await env.client.start_workflow(
-            SpXOverlayTenantChangeWorkflow.run,
-            SpXOverlayTenantChangeInput(
-                overlay_id="mock_overlay_id",
-                device_id="mock_device_id_with_vrf",
-                port_names=["swp1", "swp2"],
-                site="mock_site",
-            ),
-            id=str(uuid.uuid4()),
-            task_queue=task_queue_name,
-            run_timeout=timedelta(seconds=30),
-        )
-
-        result = await handle.result()
-
-        assert result.assigned_ports == ["swp2"]
-        assert result.device_deployed == "mock_device_id_with_vrf"
-        assert _mock_state["reconcile_calls"] == 0
-
-        stages = {stage["name"]: stage for stage in await handle.query("stages")}
-        assert "determine_deployment_action" not in stages
-        assert stages["render_tenant_config"]["output"] == {
-            "config_id": None,
-            "display": "Rendered tenant configuration",
-        }
         assert stages["deploy"]["state"] == "COMPLETE"
 
 

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -43,6 +43,8 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
 from nv_config_manager.temporal.ngc.workflows.spx_overlay import (
     SpXOverlayAssignmentInput,
     SpXOverlayAssignmentWorkflow,
+    SpXOverlayTenantChangeInput,
+    SpXOverlayTenantChangeWorkflow,
 )
 
 
@@ -264,6 +266,59 @@ async def test_spx_overlay_assignment_workflow_vrf_already_assigned(
         assert result.vrf.vrf_id == "mock_namespace1"
         assert result.vrf.vrf_name == "SpXTenant60004"
         assert set(result.assigned_ports) == {"swp2"}
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+async def test_spx_overlay_tenant_change_is_noop_when_already_assigned(
+    _mock_time, _mock_nats_client, env
+):
+    """A repeated tenant change completes without rendering or deploying again."""
+
+    _mock_state["vrf_exists"] = True
+    _mock_state["interfaces_with_vrf"] = ["swp1", "swp2"]
+
+    task_queue_name = str(uuid.uuid4())
+    async with Worker(
+        env.client,
+        task_queue=task_queue_name,
+        workflows=[SpXOverlayAssignmentWorkflow, SpXOverlayTenantChangeWorkflow],
+        activities=[
+            mock_get_network_device,
+            mock_get_vrfs_by_overlay_id,
+            mock_get_device_vrfs,
+            mock_assign_vrf_to_device,
+            mock_get_device_interfaces,
+            mock_assign_vrf_to_interface,
+            publish_nats,
+        ],
+        activity_executor=ThreadPoolExecutor(1),
+    ):
+        handle = await env.client.start_workflow(
+            SpXOverlayTenantChangeWorkflow.run,
+            SpXOverlayTenantChangeInput(
+                overlay_id="mock_overlay_id",
+                device_id="mock_device_id_with_vrf",
+                port_names=["swp1", "swp2"],
+                site="mock_site",
+            ),
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+            run_timeout=timedelta(seconds=30),
+        )
+
+        result = await handle.result()
+
+        assert result.assigned_ports == []
+        assert result.vrf_assigned is False
+        assert result.vrf is None
+        assert result.device_deployed is None
+
+        stages = {stage["name"]: stage for stage in await handle.query("stages")}
+        assert stages["render_tenant_config"]["state"] == "UNREACHABLE"
+        assert stages["wait_for_render"]["state"] == "UNREACHABLE"
+        assert stages["deploy"]["state"] == "UNREACHABLE"
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
-from temporalio import activity
+from temporalio import activity, workflow
 from temporalio.exceptions import ApplicationError
 from temporalio.worker import Worker
 
@@ -32,6 +32,7 @@ from nv_config_manager.temporal.ngc.activities.nats import publish_nats
 from nv_config_manager.temporal.ngc.activities.nautobot import (
     AssignVrfToDeviceInput,
     AssignVrfToInterfaceInput,
+    CheckRecordedConfigDriftInput,
     DeviceVrfInfo,
     GetDeviceInterfacesInput,
     GetDeviceInterfacesOutput,
@@ -92,6 +93,7 @@ _mock_state = {
     "interfaces_with_vrf": [],
     "newer_commit_allowed": True,
     "reconcile_calls": 0,
+    "recorded_config_drift": False,
 }
 
 
@@ -181,6 +183,24 @@ async def mock_reconcile_spx_overlay_assignments(
         created=1 + len(activity_input.interface_ids),
         removed=0,
     )
+
+
+@activity.defn(name="check_recorded_config_drift")
+async def mock_check_recorded_config_drift(
+    _activity_input: CheckRecordedConfigDriftInput,
+) -> bool:
+    """Mock pending deployment check."""
+    return bool(_mock_state["recorded_config_drift"])
+
+
+@workflow.defn(name="TenantDeployWorkflow", sandboxed=False)
+class MockTenantDeployWorkflow:
+    """Mock tenant deploy child workflow."""
+
+    @workflow.run
+    async def run(self, _workflow_input: Any) -> bool:
+        """Mock tenant deploy run."""
+        return True
 
 
 def test_spx_render_stage_output_requires_snapshot_commit_ids():
@@ -303,6 +323,7 @@ async def test_spx_overlay_tenant_change_is_noop_when_already_assigned(
     _mock_state["vrf_exists"] = True
     _mock_state["interfaces_with_vrf"] = ["swp1", "swp2"]
     _mock_state["reconcile_calls"] = 0
+    _mock_state["recorded_config_drift"] = False
 
     task_queue_name = str(uuid.uuid4())
     async with Worker(
@@ -317,6 +338,7 @@ async def test_spx_overlay_tenant_change_is_noop_when_already_assigned(
             mock_get_device_interfaces,
             mock_assign_vrf_to_interface,
             mock_reconcile_spx_overlay_assignments,
+            mock_check_recorded_config_drift,
             publish_nats,
         ],
         activity_executor=ThreadPoolExecutor(1),
@@ -346,6 +368,69 @@ async def test_spx_overlay_tenant_change_is_noop_when_already_assigned(
         assert stages["render_tenant_config"]["state"] == "UNREACHABLE"
         assert stages["wait_for_render"]["state"] == "UNREACHABLE"
         assert stages["deploy"]["state"] == "UNREACHABLE"
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.ngc.activities.nats.NatsProducer", autospec=True)
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+async def test_spx_overlay_tenant_change_retries_deploy_when_already_assigned_but_pending(
+    _mock_time, _mock_nats_client, env
+):
+    """A rerun deploys if Nautobot assignment is complete but deployment is still pending."""
+
+    _mock_state["vrf_exists"] = True
+    _mock_state["interfaces_with_vrf"] = ["swp1", "swp2"]
+    _mock_state["reconcile_calls"] = 0
+    _mock_state["recorded_config_drift"] = True
+
+    task_queue_name = str(uuid.uuid4())
+    async with Worker(
+        env.client,
+        task_queue=task_queue_name,
+        workflows=[
+            SpXOverlayAssignmentWorkflow,
+            SpXOverlayTenantChangeWorkflow,
+            MockTenantDeployWorkflow,
+        ],
+        activities=[
+            mock_get_network_device,
+            mock_get_vrfs_by_overlay_id,
+            mock_get_device_vrfs,
+            mock_assign_vrf_to_device,
+            mock_get_device_interfaces,
+            mock_assign_vrf_to_interface,
+            mock_reconcile_spx_overlay_assignments,
+            mock_check_recorded_config_drift,
+            publish_nats,
+        ],
+        activity_executor=ThreadPoolExecutor(1),
+    ):
+        handle = await env.client.start_workflow(
+            SpXOverlayTenantChangeWorkflow.run,
+            SpXOverlayTenantChangeInput(
+                overlay_id="mock_overlay_id",
+                device_id="mock_device_id_with_vrf",
+                port_names=["swp1", "swp2"],
+                site="mock_site",
+            ),
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+            run_timeout=timedelta(seconds=30),
+        )
+
+        result = await handle.result()
+
+        assert result.assigned_ports == []
+        assert result.vrf_assigned is False
+        assert result.device_deployed == "mock_device_id_with_vrf"
+
+        stages = {stage["name"]: stage for stage in await handle.query("stages")}
+        assert stages["determine_deployment_action"]["state"] == "COMPLETE"
+        assert stages["render_tenant_config"]["state"] == "UNREACHABLE"
+        assert stages["wait_for_render"]["state"] == "UNREACHABLE"
+        assert stages["deploy"]["state"] == "COMPLETE"
+        assert stages["deploy"]["input"]["tenant_config_commit_id"] is None
+        assert stages["deploy"]["input"]["intended_config_commit_id"] is None
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_assignment_workflow.py
@@ -469,6 +469,8 @@ async def test_spx_overlay_tenant_change_uses_current_versions_after_render_race
         assert stages["render_tenant_config"]["output"]["tenant_config_commit_id"] == "7"
         assert stages["render_tenant_config"]["output"]["intended_config_commit_id"] == "11"
         assert stages["deploy"]["state"] == "COMPLETE"
+        assert stages["deploy"]["input"]["tenant_config_commit_id"] == "7"
+        assert stages["deploy"]["input"]["intended_config_commit_id"] == "11"
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/workflows/test_spx_overlay_workflows.py
+++ b/src/tests/temporal/ngc/workflows/test_spx_overlay_workflows.py
@@ -425,7 +425,7 @@ async def test_spx_overlay_deletion_workflow(
                 "name": "delete_spx_overlay",
                 "output": {
                     "deleted_vrfs": [],
-                    "display": "No VRFs exist for Overlay ID mock_overlay_id",
+                    "display": "Deleted overlay mock_overlay_id",
                     "in_use_vrfs": [],
                 },
                 "rejecters": [],


### PR DESCRIPTION
## Description

Fix issues found by QA in the SpX overlay tenant change workflow.

- Rerunning the workflow for ports that already have the requested VRF failed in the no-op path because the parent attempted to mark a non-existent `render` stage unreachable. The workflow now marks the actual `render_tenant_config` stage unreachable and exits successfully when no device configuration changed.

- A successful tenant change could leave Nautobot showing a pending deployment. Tenant deployment applies `tenant.yaml`, but Nautobot compares deployment status against the full intended `startup.yaml` commit. The render stage now captures both commit IDs from one render snapshot; deployment loads that exact tenant version and records its paired intended commit. The SpX path requires both render IDs, validates them as numeric versions, and the API schema enforces that the pair is supplied together or omitted together for direct tenant-deploy calls.

- The workflow updated IPAM VRF bindings but did not create the overlays plugin records used by the Overlay Assignment tab. It now reconciles `OverlayAssignment` entries for the device and every requested interface. Moving a port removes its stale Spectrum-X assignment, preserves assignments for other overlay types, and records the target overlay. Reconciliation reads every paginated Nautobot result and creates the replacement before deleting stale entries, so a failed replacement leaves the old assignment intact. It also runs when the VRF is already correct, repairing incomplete prior runs without triggering another render or deploy. Deletions will ensure overlay assignments are also removed along with the overlay, as long as the VRF is not assigned to any ports.

- Fixed a race between nautobot consumer render vs the workflow API render - if nautobot consumer wins then our render API call returns an empty result which failed the workflow. Now we pull the newest render in that case, which still goes through the tenant deploy safeguards. 

- Fixed an edge case where nautobot is updated with the overlay assignment but the deploy is still pending (i.e. due to a prior failure or cancelled workflow) - the workflow would exit without deploying. Now we check for a pending deploy and run the deploy if needed. 

## Validation

- [x] Standard CI passes. 
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/28389918858

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. The SpX assignment and tenant-change guides document overlay-plugin reconciliation and verification.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs. The Temporal OpenAPI schema includes the deployment snapshot fields, numeric patterns, and pair constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
* **New Features**
  * Added automatic reconciliation of Spectrum‑X overlay-plugin overlay assignments during VRF-to-ports workflows, including stale cleanup and created/removed counts in stage output.
  * Enhanced tenant-change orchestration to dynamically skip or proceed with render/wait/deploy based on assignment changes and recorded config drift.
  * Introduced pinned tenant configuration using paired snapshot commit IDs across render/wait/deploy.
* **Bug Fixes**
  * Updated overlay deletion behavior when no VRFs exist, improving the returned outcome messaging.
  * Enforced paired validation of tenant snapshot commit IDs (both-or-neither).
* **Documentation**
  * Clarified verification to check overlay assignments for both the device and specified interfaces.
* **Tests**
  * Expanded workflow and activity coverage for reconciliation, gating, and commit-id propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->