### PR TITLE
resolve all filtering to be backend only

### DIFF
--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -2999,6 +2999,22 @@
           },
           {
             "in": "query",
+            "name": "workflow_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "in": "query",
             "name": "device_id",
             "required": false,
             "schema": {

--- a/src/nv_config_manager/temporal/api/workflow_v1.py
+++ b/src/nv_config_manager/temporal/api/workflow_v1.py
@@ -650,6 +650,7 @@ async def get_workflows(  # pylint: disable=R0913,R0914
     request: Request,
     user: str | None = None,
     workflow_type: str | None = None,
+    workflow_id: str | None = None,
     device_id: str | None = None,
     device_name: str | None = None,
     device_role: str | None = None,
@@ -673,6 +674,8 @@ async def get_workflows(  # pylint: disable=R0913,R0914
         filters.append(
             f"WorkflowType = '{_sanitize_visibility_value(workflow_type, 'workflow_type')}'"
         )
+    if workflow_id:
+        filters.append(f"WorkflowId = '{_sanitize_visibility_value(workflow_id, 'workflow_id')}'")
     if device_id:
         filters.append(
             f"{DEVICE_ID_SEARCH_ATTRIBUTE} = '{_sanitize_visibility_value(device_id, 'device_id')}'"

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -1049,6 +1049,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
         params={
             "user": "test",
             "workflow_type": "test",
+            "workflow_id": "test-id",
             "device_id": "test",
             "device_name": "test",
             "device_role": "test",
@@ -1062,6 +1063,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
     mock_client.return_value.list_workflows.assert_called_with(
         "User = 'test' and "
         "WorkflowType = 'test' and "
+        "WorkflowId = 'test-id' and "
         "DeviceID = 'test' and "
         "DeviceName = 'test' and "
         "DeviceRole = 'test' and "
@@ -1075,6 +1077,8 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
         page_size=100,
         next_page_token=None,
     )
+    filter_query = mock_client.return_value.list_workflows.call_args.args[0]
+    mock_client.return_value.count_workflows.assert_awaited_with(filter_query)
 
     rsp = client.get(
         "/v1/workflow",
@@ -1093,6 +1097,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
         params={
             "user": "test",
             "workflow_type": "test",
+            "workflow_id": "test-id",
             "device_id": "test",
             "device_name": "test",
             "device_role": "test",
@@ -1107,6 +1112,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
     mock_client.return_value.list_workflows.assert_called_with(
         "User = 'test' and "
         "WorkflowType = 'test' and "
+        "WorkflowId = 'test-id' and "
         "DeviceID = 'test' and "
         "DeviceName = 'test' and "
         "DeviceRole = 'test' and "
@@ -1126,6 +1132,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
         params={
             "user": "test",
             "workflow_type": "test",
+            "workflow_id": "test-id",
             "device_id": "test",
             "device_name": "test",
             "device_role": "test",
@@ -1140,6 +1147,7 @@ async def test_workflows(mock_rbac_config, mock_redis, mock_client):
     mock_client.return_value.list_workflows.assert_called_with(
         "User = 'test' and "
         "WorkflowType = 'test' and "
+        "WorkflowId = 'test-id' and "
         "DeviceID = 'test' and "
         "DeviceName = 'test' and "
         "DeviceRole = 'test' and "

--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -25,7 +25,6 @@ import {
   ColumnFiltersState,
   flexRender,
   getCoreRowModel,
-  getFilteredRowModel,
   getPaginationRowModel,
   RowData,
   Table as TanstackTable,
@@ -110,6 +109,7 @@ const setStoredWorkflowPageSize = (pageSize: number) => {
 };
 
 const workflowApiFilterParams: Record<string, string> = {
+  id: "workflow_id",
   search_attributes_DeviceID: "device_id",
   search_attributes_DeviceName: "device_name",
   search_attributes_DevicePlatform: "device_platform",
@@ -562,7 +562,6 @@ export function DataTable<TData, TValue>({ columns }: DataTableProps<TData, TVal
     onPaginationChange: setPagination,
     onColumnFiltersChange: handleColumnFiltersChange,
     getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
   });
 

--- a/ui/src/mocks/handlers/workflowHandlers.ts
+++ b/ui/src/mocks/handlers/workflowHandlers.ts
@@ -184,11 +184,13 @@ const filterWorkflows = (workflows: unknown[], url: URL) => {
 
   return workflows.filter((workflow) => {
     const workflowRecord = workflow as {
+      id?: string;
       pending_approval?: boolean;
       status?: string;
       workflow_type?: string;
     };
     const workflowType = url.searchParams.get("workflow_type");
+    const workflowId = url.searchParams.get("workflow_id");
     const status = url.searchParams.get("status");
     const pendingApproval =
       url.searchParams.get("pending_approval")?.toLowerCase() === "true";
@@ -200,6 +202,9 @@ const filterWorkflows = (workflows: unknown[], url: URL) => {
     if (workflowType && workflowRecord.workflow_type !== workflowType) {
       return false;
     }
+    if (workflowId && workflowRecord.id !== workflowId) {
+      return false;
+    }
     if (hideCompleted && workflowRecord.status === "COMPLETED") {
       return false;
     }
@@ -208,8 +213,8 @@ const filterWorkflows = (workflows: unknown[], url: URL) => {
     }
     if (
       status &&
-      getWorkflowDisplayStatus(workflow) !== status &&
-      !(pendingApproval && status === "RUNNING" && workflowRecord.pending_approval)
+      workflowRecord.status !== status &&
+      getWorkflowDisplayStatus(workflow) !== status
     ) {
       return false;
     }
@@ -236,9 +241,7 @@ const filterWorkflows = (workflows: unknown[], url: URL) => {
       if (!value) {
         return true;
       }
-      return getFirstSearchAttribute(workflow, attribute)
-        .toLowerCase()
-        .includes(value.toLowerCase());
+      return getFirstSearchAttribute(workflow, attribute) === value;
     });
   });
 };

--- a/ui/tests/docs-screenshots/workflowForms.spec.ts
+++ b/ui/tests/docs-screenshots/workflowForms.spec.ts
@@ -792,6 +792,7 @@ function filterWorkflows(
     ["user", "User"],
   ];
   const workflowType = url.searchParams.get("workflow_type");
+  const workflowId = url.searchParams.get("workflow_id");
   const status = url.searchParams.get("status");
   const pendingApproval =
     url.searchParams.get("pending_approval")?.toLowerCase() === "true";
@@ -810,6 +811,9 @@ function filterWorkflows(
     if (workflowType && workflow.workflow_type !== workflowType) {
       return false;
     }
+    if (workflowId && workflow.id !== workflowId) {
+      return false;
+    }
     if (hideCompleted && workflow.status === "COMPLETED") {
       return false;
     }
@@ -820,8 +824,8 @@ function filterWorkflows(
 
     if (
       status &&
-      displayStatus !== status &&
-      !(pendingApproval && status === "RUNNING" && workflow.pending_approval)
+      workflow.status !== status &&
+      displayStatus !== status
     ) {
       return false;
     }
@@ -848,9 +852,7 @@ function filterWorkflows(
         return true;
       }
 
-      return getFirstSearchAttribute(workflow, attribute)
-        .toLowerCase()
-        .includes(value.toLowerCase());
+      return getFirstSearchAttribute(workflow, attribute) === value;
     });
   });
 }

--- a/ui/tests/e2e/shared/apiMocks.ts
+++ b/ui/tests/e2e/shared/apiMocks.ts
@@ -1246,6 +1246,7 @@ export async function mockWorkflowsListEndpoint(page: Page) {
     }
 
     const workflowType = url.searchParams.get("workflow_type");
+    const workflowId = url.searchParams.get("workflow_id");
     const nextPageToken = url.searchParams.get("next_page_token");
     const limit = url.searchParams.get("limit");
     const hideCompleted =
@@ -1271,6 +1272,9 @@ export async function mockWorkflowsListEndpoint(page: Page) {
       if (workflowType && workflow.workflow_type !== workflowType) {
         return false;
       }
+      if (workflowId && workflow.id !== workflowId) {
+        return false;
+      }
       if (hideCompleted && workflow.status === "COMPLETED") {
         return false;
       }
@@ -1290,8 +1294,8 @@ export async function mockWorkflowsListEndpoint(page: Page) {
       }
       if (
         status &&
-        displayStatus !== status &&
-        !(pendingApproval && status === "RUNNING" && workflow.pending_approval)
+        workflow.status !== status &&
+        displayStatus !== status
       ) {
         return false;
       }
@@ -1326,15 +1330,23 @@ export async function mockWorkflowsListEndpoint(page: Page) {
           string,
           Array<string | number | boolean> | undefined
         >;
-        const attributeValue = String(searchAttributes[attribute]?.[0] ?? "").toLowerCase();
-        return attributeValue.includes(value.toLowerCase());
+        const attributeValue = String(searchAttributes[attribute]?.[0] ?? "");
+        return attributeValue === value;
       });
     });
-    const paginatedWorkflows = workflows.slice(
+    const responseWorkflows =
+      url.searchParams.get("status") === "RUNNING" &&
+      !url.searchParams.has("pending_approval") &&
+      workflows.length > 0
+        ? workflows.map((workflow, index) =>
+            index === 0 ? { ...workflow, pending_approval: true } : workflow
+          )
+        : workflows;
+    const paginatedWorkflows = responseWorkflows.slice(
       page * pageSize,
       (page + 1) * pageSize
     );
-    const hasMore = (page + 1) * pageSize < workflows.length;
+    const hasMore = (page + 1) * pageSize < responseWorkflows.length;
 
     await delay(100);
 
@@ -1343,9 +1355,11 @@ export async function mockWorkflowsListEndpoint(page: Page) {
       json: {
         workflows: paginatedWorkflows,
         next_page_token: hasMore ? (page + 1).toString() : null,
-        total_count: workflows.length,
+        total_count: responseWorkflows.length,
         page_count:
-          workflows.length === 0 ? 0 : Math.ceil(workflows.length / pageSize),
+          responseWorkflows.length === 0
+            ? 0
+            : Math.ceil(responseWorkflows.length / pageSize),
       },
     });
   });

--- a/ui/tests/e2e/workflowsPage.spec.ts
+++ b/ui/tests/e2e/workflowsPage.spec.ts
@@ -162,6 +162,64 @@ test.describe("Workflows Page", () => {
     await expect(page.locator("tbody tr").first()).toBeVisible();
   });
 
+  test("applies workflow ID filtering through the backend from page 2", async ({
+    page,
+  }) => {
+    await page.goto("/workflows");
+    await page.getByRole("button", { exact: true, name: "Next" }).click();
+    await expect(page.getByText(/Page 2 of \d+/)).toBeVisible();
+
+    const workflowId = (
+      await page.locator("tbody tr").last().locator("a").first().innerText()
+    ).trim();
+    const filteredResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+
+      return (
+        url.pathname.endsWith("/v1/workflow/") &&
+        url.searchParams.get("workflow_id") === workflowId &&
+        !url.searchParams.has("next_page_token")
+      );
+    });
+
+    await page
+      .locator("thead")
+      .getByRole("textbox", { name: "Search..." })
+      .first()
+      .fill(workflowId);
+    await filteredResponse;
+
+    await expect(page.getByText("Page 1 of 1")).toBeVisible();
+    await expect(page.getByText("1 workflow", { exact: true })).toBeVisible();
+    await expect(page.locator("tbody").getByText(workflowId)).toBeVisible();
+  });
+
+  test("uses exact case-sensitive workflow attribute filters", async ({
+    page,
+  }) => {
+    await page.goto("/workflows");
+
+    const siteFilter = page
+      .locator("thead th")
+      .filter({ hasText: "Site" })
+      .getByRole("textbox");
+
+    await siteFilter.fill("rno1");
+    await expect(page.getByText("No results.")).toBeVisible();
+
+    await siteFilter.fill("RNO1");
+    await expect(page.getByText("RNO1").first()).toBeVisible();
+    await page
+      .locator("thead th")
+      .filter({ hasText: "Device Name" })
+      .getByRole("textbox")
+      .fill("rno1-m04-c10-core1-cg1-tan-lab1");
+
+    await expect(page.getByText("RNO1").first()).toBeVisible();
+    await expect(page.getByText("rno1-m04-c10-core1-cg1-tan-lab1").first()).toBeVisible();
+    await expect(page.getByText("No results.")).toHaveCount(0);
+  });
+
   test("uses backend hide-completed filtering and disables header sorting", async ({
     page,
   }) => {
@@ -296,6 +354,38 @@ test.describe("Workflows Page", () => {
 
     await expect(page).toHaveURL(/\/workflows$/);
     await expect(page.getByText("LEAF1-GP1-CIN2-PDX01").first()).toBeVisible();
+  });
+
+  test("renders the backend result set without additional status filtering", async ({
+    page,
+  }) => {
+    await page.goto("/workflows");
+
+    const runningResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+
+      return (
+        url.pathname.endsWith("/v1/workflow/") &&
+        url.searchParams.get("status") === "RUNNING" &&
+        !url.searchParams.has("pending_approval")
+      );
+    });
+    await page
+      .locator("thead")
+      .getByRole("cell", { name: /Status/ })
+      .getByRole("combobox")
+      .click();
+    await page.getByRole("option", { name: "Running", exact: true }).click();
+
+    const responseBody = (await (await runningResponse).json()) as {
+      workflows: unknown[];
+    };
+    await expect(page.locator("tbody tr")).toHaveCount(
+      responseBody.workflows.length
+    );
+    await expect(
+      page.locator("tbody").getByText("Pending Approval", { exact: true }).first()
+    ).toBeVisible();
   });
 
   test("supports top-level workflow timeframe filters", async ({ page }) => {


### PR DESCRIPTION
## Description

* Resolves inconsistencies between page counts and UI rows where some filtering was bypassing the API filter, now no additional filtering is done on the front-end

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/28337460524/job/83946036133

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `workflow_id` query filtering to the workflow list API and connected it to the workflows table (column `id` → `workflow_id`).
* **Bug Fixes**
  * Updated filtering to use exact matches for workflow attributes/search (including case-sensitive behavior).
  * Aligned status filtering with the backend “display status” mapping and refreshed handling for `RUNNING` vs `pending_approval`.
  * Improved table rendering and pagination metadata to reflect the backend-filtered result set.
* **Documentation**
  * Updated the Temporal API spec to document the new `workflow_id` query parameter.
* **Tests**
  * Expanded unit and end-to-end coverage for `workflow_id`, status, and exact-match filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->