### PR TITLE
harden edge cases on ufm drift

### DIFF
--- a/src/nv_config_manager/temporal/ngc/activities/ib_nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/ib_nautobot.py
@@ -744,7 +744,7 @@ class CleanupEmptyPartitionInput(BaseModel):
     overlay_name: str
     pkey_id: str
     pkey: str
-    ufm_partition_empty: bool
+    ufm_partition_empty: bool = False
 
 
 class CleanupEmptyPartitionOutput(StageOutput):

--- a/src/nv_config_manager/temporal/ngc/activities/ib_nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/ib_nautobot.py
@@ -733,12 +733,18 @@ def _is_auto_created_overlay_name(overlay_name: str, pkey: str) -> bool:
 
 
 class CleanupEmptyPartitionInput(BaseModel):
-    """Parameters for reconciling Nautobot after a PKey partition empties out."""
+    """Parameters for reconciling Nautobot after a PKey partition empties out.
+
+    ``ufm_partition_empty`` is the verified UFM state (404 or zero members). The
+    Nautobot PKey/Overlay are only deleted when UFM agrees the partition is
+    empty, so untracked UFM-only members can't be silently orphaned.
+    """
 
     overlay_id: str
     overlay_name: str
     pkey_id: str
     pkey: str
+    ufm_partition_empty: bool
 
 
 class CleanupEmptyPartitionOutput(StageOutput):
@@ -756,7 +762,9 @@ async def cleanup_empty_pkey_partition(
     """Delete the Nautobot InfiniBandPKey and auto-created Overlay once empty.
 
     UFM auto-removes a PKey partition when its last member leaves.
-    After assignments are removed, this reconciles Nautobot.
+    After assignments are removed, this reconciles Nautobot -- but only when the
+    UFM partition is also verified empty, so UFM-only members (drift Nautobot
+    never tracked) don't get orphaned as a live partition with no Nautobot record.
     If the overlay was auto-created and has no other PKeys, it is also deleted.
     """
     client = NautobotClient()
@@ -774,6 +782,23 @@ async def cleanup_empty_pkey_partition(
                 display=(
                     f"Overlay {input.overlay_id} still has {len(remaining)} member(s); "
                     "leaving PKey and Overlay in place"
+                ),
+            )
+
+        if not input.ufm_partition_empty:
+            log.warning(
+                "PKey %s has no Nautobot assignments but its UFM partition still has "
+                "members; leaving Nautobot PKey/Overlay in place to avoid orphaning "
+                "untracked UFM members",
+                input.pkey,
+            )
+            return CleanupEmptyPartitionOutput(
+                partition_empty=False,
+                pkey_deleted=False,
+                overlay_deleted=False,
+                display=(
+                    f"PKey {input.pkey} still has untracked members on UFM; "
+                    "leaving Nautobot PKey and Overlay in place"
                 ),
             )
 

--- a/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
+++ b/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
@@ -345,10 +345,13 @@ class FetchPKeyMembersInput(BaseModel):
 
 
 class FetchPKeyMembersOutput(StageOutput):
-    """Current GUID members of a PKey partition."""
+    """Current state of a PKey partition on UFM."""
 
     pkey: str
+    exists: bool = True
     guids: list[str]
+    memberships: list[str] = []
+    ip_over_ib: bool | None = None
 
 
 class RemoveGuidsInput(BaseModel):
@@ -369,32 +372,59 @@ class RemoveGuidsOutput(StageOutput):
 
 @activity.defn
 async def fetch_pkey_members(input: FetchPKeyMembersInput) -> FetchPKeyMembersOutput:
-    """Fetch the current GUID member list for a PKey from UFM."""
+    """Read a PKey partition's current members and settings from UFM.
+
+    Tolerates a 404 by returning ``exists=False`` so callers reconciling against
+    UFM can treat a missing partition as empty without special-casing the error.
+    """
     log.info("Fetching members for PKey %s on UFM at %s", input.pkey, input.host)
 
-    async with UFMClient(host=input.host, site=input.site) as client:
-        pkey_data = await client.request(
-            "GET",
-            f"/resources/pkeys/{input.pkey}",
-            params={"guids_data": "true"},
+    try:
+        async with UFMClient(host=input.host, site=input.site) as client:
+            pkey_data = await client.request(
+                "GET",
+                f"/resources/pkeys/{input.pkey}",
+                params={"guids_data": "true"},
+            )
+    except UFMClientError as e:
+        if e.status_code != 404:
+            raise
+        log.info("PKey %s does not exist on UFM", input.pkey)
+        return FetchPKeyMembersOutput(
+            pkey=input.pkey,
+            exists=False,
+            guids=[],
+            memberships=[],
+            ip_over_ib=None,
+            display=f"PKey {input.pkey} does not exist on UFM",
         )
 
     if not isinstance(pkey_data, dict):
         raise ApplicationError(
-            f"PKey {input.pkey} not found on UFM at {input.host}",
+            f"PKey {input.pkey} returned an unexpected response from UFM at {input.host}",
             non_retryable=True,
         )
 
     raw_guids = pkey_data.get("guids", [])
-    guids = [
-        (entry["guid"] if isinstance(entry, dict) else str(entry)).lower() for entry in raw_guids
-    ]
+    guids: list[str] = []
+    memberships: list[str] = []
+    for entry in raw_guids:
+        if isinstance(entry, dict):
+            guids.append(str(entry.get("guid", "")).lower())
+            memberships.append(str(entry.get("membership", "")).lower())
+        else:
+            guids.append(str(entry).lower())
+            memberships.append("")
 
+    ip_over_ib = pkey_data.get("ip_over_ib")
     log.info("PKey %s has %d current member(s): %s", input.pkey, len(guids), guids)
 
     return FetchPKeyMembersOutput(
         pkey=input.pkey,
+        exists=True,
         guids=guids,
+        memberships=memberships,
+        ip_over_ib=ip_over_ib if isinstance(ip_over_ib, bool) else None,
         display=f"PKey {input.pkey} has {len(guids)} current member(s)",
     )
 
@@ -582,11 +612,19 @@ class VerifyPKeyMembersAbsentInput(BaseModel):
 
 
 class VerifyPKeyMembersAbsentOutput(StageOutput):
-    """Result of a PKey membership-removal verification."""
+    """Result of a PKey membership-removal verification.
+
+    ``partition_exists`` is False when UFM 404s (the partition is gone), and
+    ``remaining_member_count`` reports how many members UFM still holds. Together
+    they let the delete workflow decide whether the partition is truly empty
+    before reconciling Nautobot, rather than inferring it from Nautobot alone.
+    """
 
     pkey: str
     verified: bool
     still_present_guids: list[str]
+    partition_exists: bool = True
+    remaining_member_count: int = 0
 
 
 @activity.defn
@@ -618,6 +656,8 @@ async def verify_pkey_members_absent(
             pkey=input.pkey,
             verified=True,
             still_present_guids=[],
+            partition_exists=False,
+            remaining_member_count=0,
             display=f"PKey {input.pkey} no longer exists on UFM; all members absent",
         )
 
@@ -645,6 +685,8 @@ async def verify_pkey_members_absent(
         pkey=input.pkey,
         verified=True,
         still_present_guids=[],
+        partition_exists=True,
+        remaining_member_count=len(present_set),
         display=(
             f"All {len(input.forbidden_guids)} GUID(s) confirmed absent from PKey {input.pkey}"
         ),

--- a/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
+++ b/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
@@ -624,7 +624,7 @@ class VerifyPKeyMembersAbsentOutput(StageOutput):
     verified: bool
     still_present_guids: list[str]
     partition_exists: bool = True
-    remaining_member_count: int = 0
+    remaining_member_count: int | None = None
 
 
 @activity.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_delete.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_delete.py
@@ -268,6 +268,7 @@ class IBPKeyMemberDeleteWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
 
         pkey: str
         verified: bool
+        partition_empty: bool
 
     @stage_executor("verify_removed")
     async def verify_removed(
@@ -285,9 +286,11 @@ class IBPKeyMemberDeleteWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
             start_to_close_timeout=timedelta(minutes=2),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
+        partition_empty = (not result.partition_exists) or result.remaining_member_count == 0
         return self.VerifyRemovedStageOutput(
             pkey=result.pkey,
             verified=result.verified,
+            partition_empty=partition_empty,
             display=result.display,
         )
 
@@ -338,6 +341,7 @@ class IBPKeyMemberDeleteWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
         overlay_name: str
         pkey_id: str
         pkey: str
+        ufm_partition_empty: bool
 
     class CleanupPartitionStageOutput(StageOutput):
         """Cleanup Partition Stage Output."""
@@ -361,6 +365,7 @@ class IBPKeyMemberDeleteWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
                 overlay_name=stage_input.overlay_name,
                 pkey_id=stage_input.pkey_id,
                 pkey=stage_input.pkey,
+                ufm_partition_empty=stage_input.ufm_partition_empty,
             ),
             start_to_close_timeout=timedelta(minutes=2),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
@@ -431,6 +436,7 @@ class IBPKeyMemberDeleteWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
                 overlay_name=context.overlay_name,
                 pkey_id=context.pkey_id,
                 pkey=context.pkey,
+                ufm_partition_empty=verify_output.partition_empty,
             )
         )
 

--- a/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_delete.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_delete.py
@@ -286,7 +286,12 @@ class IBPKeyMemberDeleteWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
             start_to_close_timeout=timedelta(minutes=2),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
-        partition_empty = (not result.partition_exists) or result.remaining_member_count == 0
+        if not result.partition_exists:
+            partition_empty = True
+        elif result.remaining_member_count is None:
+            partition_empty = False
+        else:
+            partition_empty = result.remaining_member_count == 0
         return self.VerifyRemovedStageOutput(
             pkey=result.pkey,
             verified=result.verified,

--- a/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_update.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_update.py
@@ -47,10 +47,13 @@ with workflow.unsafe.imports_passed_through():
         sync_pkey_assignments,
     )
     from nv_config_manager.temporal.ngc.activities.ib_pkey import (
+        FetchPKeyMembersInput,
+        FetchPKeyMembersOutput,
         SetGuidsInput,
         SetGuidsOutput,
         VerifyPKeyMembersInput,
         VerifyPKeyMembersOutput,
+        fetch_pkey_members,
         set_pkey_members,
         verify_pkey_members,
     )
@@ -73,8 +76,13 @@ def _format_diff_lines(
     ifaces_to_add: list[ResolvedInterface],
     ifaces_to_remove: list[ResolvedInterface],
     guids_unchanged: list[str],
+    ufm_only_removals: list[str] | None = None,
 ) -> str:
-    """Format a human-readable diff with device/interface/GUID per member."""
+    """Format a human-readable diff with device/interface/GUID per member.
+
+    ``ufm_only_removals`` are GUIDs present on UFM but absent from Nautobot; the
+    exact-set PUT will drop them, so they are surfaced explicitly for approval.
+    """
     lines: list[str] = [f"**PKey {pkey} membership diff:**"]
 
     lines.append(f"- Add {len(ifaces_to_add)} member(s):")
@@ -90,6 +98,15 @@ def _format_diff_lines(
             lines.append(f"    - Remove PKey {pkey} from {r.device}/{r.interface} (GUID {r.guid})")
     else:
         lines.append("    (none)")
+
+    ufm_only_removals = ufm_only_removals or []
+    if ufm_only_removals:
+        lines.append(
+            f"- Remove {len(ufm_only_removals)} untracked UFM-only member(s) "
+            "(present on UFM, not in Nautobot):"
+        )
+        for guid in ufm_only_removals:
+            lines.append(f"    - Remove PKey {pkey} from GUID {guid} (untracked on UFM)")
 
     lines.append(f"- Unchanged: {len(guids_unchanged)} member(s)")
     return "\n".join(lines)
@@ -290,6 +307,8 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
     class QueryCurrentStageInput(StageInput):
         """Query Current Stage Input."""
 
+        host: str
+        site: str | None
         pkey: str
         overlay_id: str
         resolved: list[ResolvedInterface]
@@ -305,6 +324,8 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
         ifaces_to_remove: list[ResolvedInterface]
         ifaces_unchanged: list[ResolvedInterface]
         membership_changed: bool
+        ufm_only_removals: list[str]
+        ufm_ip_over_ib: bool | None
 
     @stage_executor("query_current")
     async def query_current(self, stage_input: QueryCurrentStageInput) -> QueryCurrentStageOutput:
@@ -355,11 +376,26 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
                     non_retryable=True,
                 )
 
+        ufm_state: FetchPKeyMembersOutput = await workflow.execute_activity(
+            fetch_pkey_members,
+            FetchPKeyMembersInput(
+                host=stage_input.host,
+                site=stage_input.site,
+                pkey=stage_input.pkey,
+            ),
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+        )
+        desired_guid_set = {r.guid.lower() for r in stage_input.resolved}
+        tracked_removals = {g.lower() for g in guids_to_remove}
+        ufm_only_removals = sorted(set(ufm_state.guids) - desired_guid_set - tracked_removals)
+
         display = _format_diff_lines(
             pkey=stage_input.pkey,
             ifaces_to_add=ifaces_to_add,
             ifaces_to_remove=ifaces_to_remove,
             guids_unchanged=guids_unchanged,
+            ufm_only_removals=ufm_only_removals,
         )
 
         return self.QueryCurrentStageOutput(
@@ -371,6 +407,8 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
             ifaces_to_remove=ifaces_to_remove,
             ifaces_unchanged=ifaces_unchanged,
             membership_changed=membership_changed,
+            ufm_only_removals=ufm_only_removals,
+            ufm_ip_over_ib=ufm_state.ip_over_ib if ufm_state.exists else None,
             display=display,
         )
 
@@ -385,6 +423,7 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
         ifaces_to_add: list[ResolvedInterface]
         ifaces_to_remove: list[ResolvedInterface]
         guids_unchanged: list[str]
+        ufm_only_removals: list[str]
 
     class ValidateDiffStageOutput(StageOutput):
         """Validate Diff Stage Output."""
@@ -393,10 +432,14 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
 
     @stage_executor("validate_diff")
     async def validate_diff(self, stage_input: ValidateDiffStageInput) -> ValidateDiffStageOutput:
-        """Gate on approval when the diff contains removals; auto-approve additions-only."""
+        """Gate on approval when the diff drops any UFM member; auto-approve additions-only.
+
+        Removals include both Nautobot-tracked members and untracked UFM-only
+        members, since the exact-set PUT drops both.
+        """
         stage_name = "validate_diff"
 
-        if not stage_input.ifaces_to_remove:
+        if not stage_input.ifaces_to_remove and not stage_input.ufm_only_removals:
             self.get_stage_by_name(stage_name).requires_approval = False
             return self.ValidateDiffStageOutput(
                 approved=True,
@@ -412,6 +455,7 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
             ifaces_to_add=stage_input.ifaces_to_add,
             ifaces_to_remove=stage_input.ifaces_to_remove,
             guids_unchanged=stage_input.guids_unchanged,
+            ufm_only_removals=stage_input.ufm_only_removals,
         )
 
         output = self.ValidateDiffStageOutput(approved=False, display=display)
@@ -600,6 +644,8 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
 
         query_output = await self.query_current(
             self.QueryCurrentStageInput(
+                host=context.host,
+                site=context.site,
                 pkey=context.pkey,
                 overlay_id=context.overlay_id,
                 resolved=resolve_output.resolved,
@@ -612,6 +658,7 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
                 ifaces_to_add=query_output.ifaces_to_add,
                 ifaces_to_remove=query_output.ifaces_to_remove,
                 guids_unchanged=query_output.guids_unchanged,
+                ufm_only_removals=query_output.ufm_only_removals,
             )
         )
 
@@ -643,6 +690,13 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
 
         desired_guids = [r.guid for r in resolve_output.resolved]
         desired_memberships = [r.membership for r in resolve_output.resolved]
+        # Preserve the partition's existing ip_over_ib instead of forcing the
+        # input default onto an already-configured partition.
+        ip_over_ib = (
+            query_output.ufm_ip_over_ib
+            if query_output.ufm_ip_over_ib is not None
+            else workflow_input.ip_over_ib
+        )
         await self.update_ufm(
             self.UpdateUFMStageInput(
                 host=context.host,
@@ -653,7 +707,7 @@ class IBPKeyMemberUpdateWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
                 guids_to_add=query_output.guids_to_add,
                 guids_to_remove=query_output.guids_to_remove,
                 membership_changed=query_output.membership_changed,
-                ip_over_ib=workflow_input.ip_over_ib,
+                ip_over_ib=ip_over_ib,
             )
         )
 

--- a/src/tests/temporal/activities/test_ib_nautobot.py
+++ b/src/tests/temporal/activities/test_ib_nautobot.py
@@ -501,9 +501,7 @@ class TestCleanupEmptyPkeyPartition:
         with aioresponses() as m:
             m.get(_NB_ASSIGNMENTS, payload={"results": []})
 
-            result = await cleanup_empty_pkey_partition(
-                self._input(ufm_partition_empty=False)
-            )
+            result = await cleanup_empty_pkey_partition(self._input(ufm_partition_empty=False))
 
             assert result.partition_empty is False
             assert result.pkey_deleted is False

--- a/src/tests/temporal/activities/test_ib_nautobot.py
+++ b/src/tests/temporal/activities/test_ib_nautobot.py
@@ -465,12 +465,18 @@ class TestIsAutoCreatedOverlayName:
 class TestCleanupEmptyPkeyPartition:
     """Post-removal reconciliation of orphaned Nautobot PKey/Overlay records."""
 
-    def _input(self, *, overlay_name: str = "ib-pkey-overlay-0x8001") -> CleanupEmptyPartitionInput:
+    def _input(
+        self,
+        *,
+        overlay_name: str = "ib-pkey-overlay-0x8001",
+        ufm_partition_empty: bool = True,
+    ) -> CleanupEmptyPartitionInput:
         return CleanupEmptyPartitionInput(
             overlay_id=OVERLAY_UUID,
             overlay_name=overlay_name,
             pkey_id=PKEY_UUID,
             pkey="0x8001",
+            ufm_partition_empty=ufm_partition_empty,
         )
 
     @pytest.mark.asyncio
@@ -480,6 +486,24 @@ class TestCleanupEmptyPkeyPartition:
             m.get(_NB_ASSIGNMENTS, payload={"results": [{"id": "assign-1"}]})
 
             result = await cleanup_empty_pkey_partition(self._input())
+
+            assert result.partition_empty is False
+            assert result.pkey_deleted is False
+            assert result.overlay_deleted is False
+
+    @pytest.mark.asyncio
+    async def test_nautobot_empty_but_ufm_not_empty_keeps_records(self, mock_nb_config):
+        """Nautobot has no assignments, but UFM still holds untracked members.
+
+        The partition is live on UFM, so deleting the Nautobot PKey/Overlay would
+        orphan it. Cleanup must leave both in place.
+        """
+        with aioresponses() as m:
+            m.get(_NB_ASSIGNMENTS, payload={"results": []})
+
+            result = await cleanup_empty_pkey_partition(
+                self._input(ufm_partition_empty=False)
+            )
 
             assert result.partition_empty is False
             assert result.pkey_deleted is False

--- a/src/tests/temporal/activities/test_ib_pkey_member.py
+++ b/src/tests/temporal/activities/test_ib_pkey_member.py
@@ -383,6 +383,8 @@ class TestVerifyPKeyMembersAbsent:
 
         assert result.verified is True
         assert result.still_present_guids == []
+        assert result.partition_exists is True
+        assert result.remaining_member_count == 0
 
     @pytest.mark.asyncio
     async def test_auto_removed_pkey_is_verified_absent(self, mock_ufm_config):
@@ -400,6 +402,30 @@ class TestVerifyPKeyMembersAbsent:
 
         assert result.verified is True
         assert result.still_present_guids == []
+        assert result.partition_exists is False
+        assert result.remaining_member_count == 0
+
+    @pytest.mark.asyncio
+    async def test_reports_remaining_untracked_members(self, mock_ufm_config):
+        """Forbidden GUIDs gone, but other members remain: partition is NOT empty."""
+        with aioresponses() as m:
+            m.get(
+                _pkey_url("0x0005"),
+                payload={"guids": [{"guid": GUID_2, "membership": "full"}]},
+            )
+
+            result = await verify_pkey_members_absent(
+                VerifyPKeyMembersAbsentInput(
+                    host="ufm.example.com",
+                    pkey="0x0005",
+                    forbidden_guids=[GUID_1],
+                )
+            )
+
+        assert result.verified is True
+        assert result.still_present_guids == []
+        assert result.partition_exists is True
+        assert result.remaining_member_count == 1
 
     @pytest.mark.asyncio
     async def test_still_present_raises_retryable(self, mock_ufm_config):

--- a/src/tests/temporal/activities/test_ib_pkey_member.py
+++ b/src/tests/temporal/activities/test_ib_pkey_member.py
@@ -35,6 +35,7 @@ from nv_config_manager.temporal.ngc.activities.ib_nautobot import (
 from nv_config_manager.temporal.ngc.activities.ib_pkey import (
     AddGuidsInput,
     VerifyPKeyMembersAbsentInput,
+    VerifyPKeyMembersAbsentOutput,
     VerifyPKeyMembersInput,
     add_guids_to_pkey,
     verify_pkey_members,
@@ -404,6 +405,22 @@ class TestVerifyPKeyMembersAbsent:
         assert result.still_present_guids == []
         assert result.partition_exists is False
         assert result.remaining_member_count == 0
+
+    def test_legacy_payload_defaults_remaining_count_to_unknown(self):
+        """A payload missing remaining_member_count loads as None, not a proven 0.
+
+        Guards backward-compat: in-flight outputs serialized before the field
+        existed must not be mistaken for an empty partition.
+        """
+        legacy = VerifyPKeyMembersAbsentOutput(
+            pkey="0x0005",
+            verified=True,
+            still_present_guids=[],
+            display="legacy",
+        )
+
+        assert legacy.partition_exists is True
+        assert legacy.remaining_member_count is None
 
     @pytest.mark.asyncio
     async def test_reports_remaining_untracked_members(self, mock_ufm_config):

--- a/src/tests/temporal/ngc/activities/test_ib_pkey_update.py
+++ b/src/tests/temporal/ngc/activities/test_ib_pkey_update.py
@@ -30,6 +30,7 @@ import pytest
 from aioresponses import CallbackResult, aioresponses
 from temporalio.exceptions import ApplicationError
 
+from nv_config_manager.temporal.client.ufm import UFMClientError
 from nv_config_manager.temporal.common.secrets import clear_secrets_cache
 from nv_config_manager.temporal.ngc.activities.ib_nautobot import (
     FetchPKeyAssignmentsInput,
@@ -188,6 +189,17 @@ class TestFetchPKeyMembers:
         assert result.guids == []
         assert result.memberships == []
         assert result.ip_over_ib is None
+
+    @pytest.mark.asyncio
+    async def test_non_404_error_propagates(self, mock_ufm_config):
+        """Only 404 is tolerated; other UFM errors must surface, not read as empty."""
+        with aioresponses() as m:
+            m.get(_pkey_members_url("0x0005"), status=500, payload={"error": "boom"})
+
+            with pytest.raises(UFMClientError):
+                await fetch_pkey_members(
+                    FetchPKeyMembersInput(host="ufm.example.com", pkey="0x0005")
+                )
 
     @pytest.mark.asyncio
     async def test_returns_memberships_and_ip_over_ib(self, mock_ufm_config):

--- a/src/tests/temporal/ngc/activities/test_ib_pkey_update.py
+++ b/src/tests/temporal/ngc/activities/test_ib_pkey_update.py
@@ -164,14 +164,54 @@ class TestFetchPKeyMembers:
         assert result.guids == []
 
     @pytest.mark.asyncio
-    async def test_pkey_not_found_raises(self, mock_ufm_config):
+    async def test_unexpected_response_raises(self, mock_ufm_config):
+        """A non-dict UFM body (not a 404) is a hard error."""
         with aioresponses() as m:
             m.get(_pkey_members_url("0x0005"), payload=None)
 
-            with pytest.raises(ApplicationError, match="not found"):
+            with pytest.raises(ApplicationError, match="unexpected response"):
                 await fetch_pkey_members(
                     FetchPKeyMembersInput(host="ufm.example.com", pkey="0x0005")
                 )
+
+    @pytest.mark.asyncio
+    async def test_pkey_404_reports_not_exists(self, mock_ufm_config):
+        """A 404 is tolerated: the partition is reported as missing and empty."""
+        with aioresponses() as m:
+            m.get(_pkey_members_url("0x0005"), status=404)
+
+            result = await fetch_pkey_members(
+                FetchPKeyMembersInput(host="ufm.example.com", pkey="0x0005")
+            )
+
+        assert result.exists is False
+        assert result.guids == []
+        assert result.memberships == []
+        assert result.ip_over_ib is None
+
+    @pytest.mark.asyncio
+    async def test_returns_memberships_and_ip_over_ib(self, mock_ufm_config):
+        """Membership per GUID and the partition ip_over_ib flag are surfaced."""
+        with aioresponses() as m:
+            m.get(
+                _pkey_members_url("0x0005"),
+                payload={
+                    "guids": [
+                        {"guid": GUID_1, "membership": "full"},
+                        {"guid": GUID_2, "membership": "limited"},
+                    ],
+                    "ip_over_ib": False,
+                },
+            )
+
+            result = await fetch_pkey_members(
+                FetchPKeyMembersInput(host="ufm.example.com", pkey="0x0005")
+            )
+
+        assert result.exists is True
+        assert result.guids == [GUID_1, GUID_2]
+        assert result.memberships == ["full", "limited"]
+        assert result.ip_over_ib is False
 
     @pytest.mark.asyncio
     async def test_handles_plain_string_guids(self, mock_ufm_config):

--- a/src/tests/temporal/ngc/workflows/test_ib_pkey_member_update.py
+++ b/src/tests/temporal/ngc/workflows/test_ib_pkey_member_update.py
@@ -34,6 +34,7 @@ from nv_config_manager.temporal.ngc.activities.ib_nautobot import (
     sync_pkey_assignments,
 )
 from nv_config_manager.temporal.ngc.activities.ib_pkey import (
+    fetch_pkey_members,
     set_pkey_members,
     verify_pkey_members,
 )
@@ -130,10 +131,20 @@ _ALL_ACTIVITIES = [
     resolve_guids_to_interfaces,
     fetch_pkey_assignments,
     sync_pkey_assignments,
+    fetch_pkey_members,
     set_pkey_members,
     verify_pkey_members,
     publish_nats,
 ]
+
+
+def _stub_ufm_current(m: aioresponses, pkey: str, payload: dict) -> None:
+    """Stub the query_current UFM read (fetch_pkey_members) for a pkey.
+
+    Registered before the verify_ufm GET so aioresponses serves it to the
+    earlier query_current request (FIFO per URL).
+    """
+    m.get(_pkey_verify_url(pkey), payload=payload)
 
 
 def _pkey_verify_url(pkey: str) -> str:
@@ -198,6 +209,7 @@ async def test_additions_only_auto_approved(mock_all_configs, time_skipping_env)
 
                 # Stage 2: query current
                 m.get(_NB_ASSIGNMENTS, payload={"results": []})
+                _stub_ufm_current(m, "0x0005", {"guids": []})
 
                 # Stage 3: validate_diff auto-approved
 
@@ -276,6 +288,7 @@ async def test_per_interface_membership_sent_to_ufm(mock_all_configs, time_skipp
                     [(IFACE_UUID_1, GUID_1), (IFACE_UUID_2, GUID_2)],
                 )
                 m.get(_NB_ASSIGNMENTS, payload={"results": []})
+                _stub_ufm_current(m, "0x0005", {"guids": []})
 
                 _stub_status(m)
                 m.get(_NB_ASSIGNMENTS, payload={"results": []})
@@ -337,6 +350,7 @@ async def test_per_guid_membership_sent_to_ufm(mock_all_configs, time_skipping_e
                 stub_graphql_resolve_ib_context(m, pkey="0x0005", overlay_id=OVERLAY_UUID)
                 stub_graphql_resolve_guids(m, [(GUID_1, IFACE_UUID_1), (GUID_2, IFACE_UUID_2)])
                 m.get(_NB_ASSIGNMENTS, payload={"results": []})
+                _stub_ufm_current(m, "0x0005", {"guids": []})
 
                 _stub_status(m)
                 m.get(_NB_ASSIGNMENTS, payload={"results": []})
@@ -414,6 +428,8 @@ async def test_idempotent_put_when_desired_matches_current(mock_all_configs, tim
                         ]
                     },
                 )
+                # UFM already holds exactly the desired member -> no UFM-only removals
+                _stub_ufm_current(m, "0x0005", {"guids": [{"guid": GUID_1, "membership": "full"}]})
 
                 # Stage 3: validate_diff auto-approved
 
@@ -497,6 +513,7 @@ async def test_membership_only_change_sent_to_ufm(mock_all_configs, time_skippin
 
                 # query_current: member already present with membership "full"
                 m.get(_NB_ASSIGNMENTS, payload=current_assignment)
+                _stub_ufm_current(m, "0x0005", {"guids": [{"guid": GUID_1, "membership": "full"}]})
 
                 # update_nautobot: same member, membership patched full -> limited
                 _stub_status(m)
@@ -686,6 +703,8 @@ async def test_full_swap_atomically_replaces_membership(mock_all_configs, time_s
                 m.get(_NB_ASSIGNMENTS, payload={"results": [current_assignment]})
                 # query_current reverse-resolves the removal GUID via GraphQL
                 stub_graphql_resolve_guids(m, [(GUID_1, IFACE_UUID_1)])
+                # UFM holds the tracked stale member; its removal is already in the diff
+                _stub_ufm_current(m, "0x0005", {"guids": [{"guid": GUID_1, "membership": "full"}]})
 
                 # Stage 3: validate_diff -> requires approval
 
@@ -749,6 +768,7 @@ async def test_guids_only_path_resolves_via_graphql(mock_all_configs, time_skipp
                 stub_graphql_resolve_guids(m, [(GUID_1, IFACE_UUID_1)])
 
                 m.get(_NB_ASSIGNMENTS, payload={"results": []})
+                _stub_ufm_current(m, "0x0005", {"guids": []})
 
                 _stub_status(m)
                 m.get(_NB_ASSIGNMENTS, payload={"results": []})
@@ -778,3 +798,159 @@ async def test_guids_only_path_resolves_via_graphql(mock_all_configs, time_skipp
     assert result.members_added == 1
     assert result.members_removed == 0
     assert result.verified is True
+
+
+@pytest.mark.asyncio
+async def test_ufm_only_member_triggers_approval(mock_all_configs, time_skipping_env):
+    """A member present only on UFM (untracked by Nautobot) forces the approval gate.
+
+    The exact-set PUT drops it, so it must surface as a removal for approval
+    instead of being silently auto-approved off the Nautobot-only diff.
+    """
+    task_queue = str(uuid.uuid4())
+    put_bodies: list[dict] = []
+
+    def _record_set(url, **kwargs):
+        put_bodies.append(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={})
+
+    current_assignment = {
+        "results": [
+            {
+                "id": ASSIGNMENT_UUID_1,
+                "assigned_object_id": IFACE_UUID_1,
+                "guid": GUID_1,
+                "membership_type": "full",
+            }
+        ]
+    }
+
+    async with time_skipping_env() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[IBPKeyMemberUpdateWorkflow],
+            activities=_ALL_ACTIVITIES,
+        ):
+            with aioresponses() as m:
+                stub_graphql_resolve_ib_context(m, pkey="0x0005", overlay_id=OVERLAY_UUID)
+                _stub_resolve_interfaces(m, [(IFACE_UUID_1, GUID_1)])
+
+                # query_current: Nautobot tracks only GUID_1, so no tracked removals
+                m.get(_NB_ASSIGNMENTS, payload=current_assignment)
+                # UFM holds an extra untracked member GUID_2 the exact PUT would drop
+                _stub_ufm_current(
+                    m,
+                    "0x0005",
+                    {
+                        "guids": [
+                            {"guid": GUID_1, "membership": "full"},
+                            {"guid": GUID_2, "membership": "full"},
+                        ]
+                    },
+                )
+
+                # update_nautobot: unchanged
+                _stub_status(m)
+                m.get(_NB_ASSIGNMENTS, payload=current_assignment)
+
+                # update_ufm: exact PUT carries only the desired set
+                m.put(f"{UFM_BASE}/resources/pkeys/", callback=_record_set)
+
+                # verify_ufm: only the desired member remains
+                m.get(
+                    _pkey_verify_url("0x0005"),
+                    payload={"guids": [{"guid": GUID_1, "membership": "full"}]},
+                )
+
+                handle = await env.client.start_workflow(
+                    IBPKeyMemberUpdateWorkflow.run,
+                    IBPKeyMemberUpdateInput(
+                        host="ufm.example.com",
+                        pkey="0x0005",
+                        interfaces=[InterfaceRef(device="hca01", interface="mlx5_0")],
+                    ),
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+
+                # Reaching pending_approval proves the UFM-only removal was not
+                # auto-approved; an additions-only diff would never gate here.
+                await _wait_for_pending_approval(handle)
+                await handle.signal("approve", {"stage_name": "validate_diff", "user": "Test"})
+                result = await handle.result()
+
+    assert result.verified is True
+    assert result.members_removed == 0  # Nautobot tracked no removals
+    assert result.members_unchanged == 1
+    # The exact PUT carries only the desired set, dropping the untracked UFM member.
+    assert len(put_bodies) == 1
+    assert put_bodies[0].get("guids") == [GUID_1]
+
+
+@pytest.mark.asyncio
+async def test_preserves_ip_over_ib_from_ufm(mock_all_configs, time_skipping_env):
+    """The reconciling PUT preserves the partition's existing ip_over_ib from UFM."""
+    task_queue = str(uuid.uuid4())
+    put_bodies: list[dict] = []
+
+    def _record_set(url, **kwargs):
+        put_bodies.append(kwargs.get("json") or {})
+        return CallbackResult(status=200, payload={})
+
+    current_assignment = {
+        "results": [
+            {
+                "id": ASSIGNMENT_UUID_1,
+                "assigned_object_id": IFACE_UUID_1,
+                "guid": GUID_1,
+                "membership_type": "full",
+            }
+        ]
+    }
+
+    async with time_skipping_env() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[IBPKeyMemberUpdateWorkflow],
+            activities=_ALL_ACTIVITIES,
+        ):
+            with aioresponses() as m:
+                stub_graphql_resolve_ib_context(m, pkey="0x0005", overlay_id=OVERLAY_UUID)
+                _stub_resolve_interfaces(m, [(IFACE_UUID_1, GUID_1)])
+
+                m.get(_NB_ASSIGNMENTS, payload=current_assignment)
+                # UFM partition is already configured with ip_over_ib disabled
+                _stub_ufm_current(
+                    m,
+                    "0x0005",
+                    {
+                        "guids": [{"guid": GUID_1, "membership": "full"}],
+                        "ip_over_ib": False,
+                    },
+                )
+
+                _stub_status(m)
+                m.get(_NB_ASSIGNMENTS, payload=current_assignment)
+                m.put(f"{UFM_BASE}/resources/pkeys/", callback=_record_set)
+                m.get(
+                    _pkey_verify_url("0x0005"),
+                    payload={"guids": [{"guid": GUID_1, "membership": "full"}]},
+                )
+
+                result = await env.client.execute_workflow(
+                    IBPKeyMemberUpdateWorkflow.run,
+                    IBPKeyMemberUpdateInput(
+                        host="ufm.example.com",
+                        pkey="0x0005",
+                        interfaces=[InterfaceRef(device="hca01", interface="mlx5_0")],
+                        ip_over_ib=True,  # input default; UFM's False must win
+                    ),
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+
+    assert result.verified is True
+    # Despite the input requesting ip_over_ib=True, the PUT preserves UFM's False.
+    assert put_bodies[0].get("ip_over_ib") is False

--- a/src/tests/temporal/workflows/test_ib_pkey_member_delete.py
+++ b/src/tests/temporal/workflows/test_ib_pkey_member_delete.py
@@ -360,3 +360,68 @@ async def test_guids_only_path(mock_all_configs, time_skipping_env):
     assert result.members_removed == 1
     assert result.verified is True
     assert result.assignment_ids_removed == [ASSIGNMENT_UUID_1]
+
+
+@pytest.mark.asyncio
+async def test_untracked_ufm_member_blocks_cleanup(mock_all_configs, time_skipping_env):
+    """Last tracked member removed, but UFM still holds an untracked member.
+
+    The UFM partition is still live, so the Nautobot PKey/Overlay must be left in
+    place rather than orphaning the partition.
+    """
+    task_queue = str(uuid.uuid4())
+
+    async with time_skipping_env() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[IBPKeyMemberDeleteWorkflow],
+            activities=_ALL_ACTIVITIES,
+        ):
+            with aioresponses() as m:
+                stub_graphql_resolve_ib_context(m, pkey="0x0005", overlay_id=OVERLAY_UUID)
+                m.get(
+                    _NB_INTERFACES,
+                    payload={
+                        "results": [
+                            {
+                                "id": IFACE_UUID_1,
+                                "name": "mlx5_0",
+                                "custom_fields": {"ib_guid": GUID_1},
+                            }
+                        ]
+                    },
+                )
+                m.delete(_UFM_DELETE, payload={})
+                # verify_removed: GUID_1 gone, but untracked GUID_2 still present on UFM
+                m.get(
+                    _pkey_verify_url("0x0005"),
+                    payload={"guids": [{"guid": GUID_2, "membership": "full"}]},
+                )
+                m.get(
+                    _NB_ASSIGNMENTS,
+                    payload={"results": [{"id": ASSIGNMENT_UUID_1}]},
+                )
+                m.delete(f"{PLUGIN}/overlay-assignments/{ASSIGNMENT_UUID_1}/", payload={})
+                # cleanup_partition: Nautobot empty, but UFM not empty -> keep records.
+                # No PKey DELETE is registered; issuing one would fail the test.
+                m.get(_NB_ASSIGNMENTS, payload={"results": []})
+
+                result = await env.client.execute_workflow(
+                    IBPKeyMemberDeleteWorkflow.run,
+                    IBPKeyMemberDeleteInput(
+                        host="ufm.example.com",
+                        pkey="0x0005",
+                        interfaces=[InterfaceRef(device="hca01", interface="mlx5_0")],
+                    ),
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+
+    assert result.members_removed == 1
+    assert result.verified is True
+    assert result.assignment_ids_removed == [ASSIGNMENT_UUID_1]
+    # UFM still has an untracked member, so the partition is not considered empty.
+    assert result.partition_empty is False
+    assert result.pkey_deleted is False
+    assert result.overlay_deleted is False


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->
https://github.com/NVIDIA/nv-config-manager/actions/runs/28391160738
## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update/delete flows now detect UFM-only PKey members and surface them in the approval diff, using UFM membership state during reconciliation.
  * Deletion cleanup now propagates UFM “partition empty” status to decide whether to remove Nautobot PKey/overlay data.
  * PKey updates preserve UFM’s existing `ip_over_ib` during reconciliation.
* **Bug Fixes**
  * Treats UFM “PKey not found” (404) as non-existent instead of failing, and improves reconciliation logic for remaining/untracked members.
* **Tests**
  * Added/updated coverage for UFM-only blocking cleanup, empty-but-not-empty handling, and backward-compatible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->