### PR TITLE
feat(sonar): Run SonarQube for every mirrored upstream commit

### DIFF
--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -109,8 +109,8 @@ charts or updating downstream values.
 | `NVCM_CONTAINER_SCAN_POLICY_FILE` | URL-encoded scan policy file path |
 | `NVCM_CONTAINER_SCAN_POLICY_REF` | Ref for the scan policy file, usually `main` |
 | `SONAR_HOST_URL` | SonarQube URL |
-| `SONAR_TOKEN` | Token used for SonarQube analysis and report export |
-| `NVCM_SONAR_PROJECT_KEY` | SonarQube project key |
+| `SONAR_TOKEN` | Token authorized to analyze the SonarQube project and export its report |
+| `NVCM_SONAR_PROJECT_KEY` | SonarQube project key; configure as a protected CI/CD variable |
 
 ## Downstream Deployments
 

--- a/.gitlab/ci/sonar.yml
+++ b/.gitlab/ci/sonar.yml
@@ -34,7 +34,7 @@ sonar-scanner:
     paths:
       - "${SONAR_USER_HOME}/cache"
   script:
-    - sonar-scanner -Dsonar.host.url="${SONAR_HOST_URL}"
+    - sonar-scanner -Dsonar.host.url="${SONAR_HOST_URL}" -Dsonar.projectKey="${NVCM_SONAR_PROJECT_KEY}"
   allow_failure: true
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -47,19 +47,12 @@ sonar-scanner:
         - pyproject.toml
         - uv.lock
         - sonar-project.properties
+        - .gitlab/ci/common.yml
+        - .gitlab/ci/sonar.yml
       when: always
-    - if: $GITLAB_USER_EMAIL == $CI_PUSH_EMAIL
-      when: never
+    # Pull-mirror updates arrive as default-branch pushes. Analyze every one,
+    # including bot-authored commits and commits outside the source paths above.
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      changes:
-        - "src/**/*"
-        - "ui/**/*"
-        - "components/nautobot/**/*"
-        - "components/network-templates/**/*"
-        - "installer/**/*"
-        - pyproject.toml
-        - uv.lock
-        - sonar-project.properties
       when: always
     - when: never
 
@@ -88,19 +81,11 @@ sonarqube-vulnerability-report:
         - pyproject.toml
         - uv.lock
         - sonar-project.properties
+        - .gitlab/ci/common.yml
+        - .gitlab/ci/sonar.yml
       when: always
-    - if: $GITLAB_USER_EMAIL == $CI_PUSH_EMAIL
-      when: never
+    # Keep the SAST export paired with every default-branch analysis.
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      changes:
-        - "src/**/*"
-        - "ui/**/*"
-        - "components/nautobot/**/*"
-        - "components/network-templates/**/*"
-        - "installer/**/*"
-        - pyproject.toml
-        - uv.lock
-        - sonar-project.properties
       when: always
     - when: never
   artifacts:

--- a/.gitlab/ci/sonar.yml
+++ b/.gitlab/ci/sonar.yml
@@ -13,13 +13,22 @@ sonar-scanner:
     - job: test-mr-py
       optional: true
       artifacts: true
+    - job: test-main-py
+      optional: true
+      artifacts: true
     - job: test-mr-installer
       optional: true
       artifacts: true
     - job: test-mr-network-templates
       optional: true
       artifacts: true
+    - job: test-main-network-templates
+      optional: true
+      artifacts: true
     - job: test-mr-ui-e2e
+      optional: true
+      artifacts: true
+    - job: test-main-ui-e2e
       optional: true
       artifacts: true
   image:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,3 @@
-sonar.projectKey=SW-Cloud_CFA_NVIDIA_Config_Manager_nv-config-manager
 sonar.qualitygate.wait=true
 
 # Python version for more precise analysis


### PR DESCRIPTION
## Description

Run the GitLab Sonar scanner for commits that reach our internal mirror. All sonar access credentials should be stored in private CI variables. 

## Validation

- [x] Parsed the changed GitLab CI YAML locally.
- [x] Verified both Sonar jobs run unconditionally on the default branch.
- [x] Verified the mirror/CI-author exclusion is removed.
- [x] Verified scanner and SAST export consume the same CI-provided project key.
- [x] Confirmed no new internal project key is present in the branch contents.
- [x] Standard CI passes.
- [x] Kind integration was not run because this changes GitLab CI configuration only.

Passing Kind Integration run:

Not applicable.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] CI-rule validation covers these changes; runtime validation requires the protected GitLab variables.
- [x] Documentation is updated for the required variables.
- [x] No generated artifacts require updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI documentation to clarify SonarQube-related variable usage and recommend protected configuration where needed.

* **Bug Fixes**
  * Improved SonarQube analysis and report generation in CI so they run more consistently on default-branch commits and merge requests.
  * Expanded CI triggers to include changes to related pipeline configuration files.
  * Simplified SonarQube setup by moving project key handling into the pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->