### PR TITLE
UI updates

### DIFF
--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tables.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tables.py
@@ -16,8 +16,13 @@
 """Tables for Overlays app."""
 
 import django_tables2 as tables
+from django.conf import settings
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.http import urlencode
 from nautobot.apps.tables import BaseTable, ButtonsColumn, ToggleColumn
 from nautobot.core.tables import LinkedCountColumn
+from nautobot.core.templatetags import helpers
 from nautobot.extras.tables import StatusTableMixin
 
 from nautobot_app_overlays import models
@@ -96,6 +101,23 @@ VXLAN_VNI_TEMPLATE = """
 _OVERLAY_TYPE_COLUMNS = ["pk", "name", "status", "tenant", "location", "assignment_count", "actions"]
 
 
+class AssignmentCountColumn(LinkedCountColumn):
+    """Assignment count that always links to the filtered assignment list."""
+    def render(self, *, record, value):
+        """Render the count as a link to the filtered assignment list."""
+        if not value:
+            return helpers.placeholder(value)
+        url = reverse(self.viewname, kwargs=self.view_kwargs)
+        if self.url_params:
+            url += "?" + urlencode(
+                {
+                    key: (getattr(record, attr) or settings.FILTERS_NULL_CHOICE_VALUE)
+                    for key, attr in self.url_params.items()
+                }
+            )
+        return format_html('<a href="{}" class="badge">{}</a>', url, value)
+
+
 class OverlayTable(StatusTableMixin, BaseTable):
     """Table for displaying Overlay objects."""
 
@@ -104,7 +126,7 @@ class OverlayTable(StatusTableMixin, BaseTable):
     tenant = tables.LinkColumn()
     location = tables.LinkColumn()
     isolation_type = tables.Column()
-    assignment_count = LinkedCountColumn(
+    assignment_count = AssignmentCountColumn(
         viewname="plugins:nautobot_app_overlays:overlayassignment_list",
         url_params={"overlay": "pk"},
         verbose_name="Assignments",

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tables.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tables.py
@@ -103,6 +103,7 @@ _OVERLAY_TYPE_COLUMNS = ["pk", "name", "status", "tenant", "location", "assignme
 
 class AssignmentCountColumn(LinkedCountColumn):
     """Assignment count that always links to the filtered assignment list."""
+
     def render(self, *, record, value):
         """Render the count as a link to the filtered assignment list."""
         if not value:

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tests/test_tables.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tests/test_tables.py
@@ -15,7 +15,9 @@
 
 """Tests for Overlays tables."""
 
+from django.db.models import Count
 from django.test import RequestFactory, TestCase
+from django.urls import reverse
 from django_tables2 import RequestConfig
 
 from nautobot_app_overlays import models, tables
@@ -40,6 +42,54 @@ class OverlayTableTestCase(TestCase):
         table = tables.OverlayTable(models.Overlay.objects.all())
         RequestConfig(self.factory.get("/")).configure(table)
         self.assertEqual(len(table.rows), models.Overlay.objects.count())
+
+
+class AssignmentCountColumnTestCase(TestCase):
+    """The Assignments column always links to the filtered list, regardless of count.
+
+    Nautobot core's LinkedCountColumn links a count of 1 to the (un-templated,
+    dead-end) assignment detail page while a count > 1 links to the filtered
+    list. AssignmentCountColumn must link to the filtered list in both cases.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        create_assignment_test_data(cls)
+        cls.factory = RequestFactory()
+        # overlays[0] has 2 assignments, overlays[1] has 1, overlays[2] has 0.
+        cls.list_url = reverse("plugins:nautobot_app_overlays:overlayassignment_list")
+
+    def _rendered_cells(self):
+        """Render OverlayTable the way the list view does (annotated count).
+
+        BaseTable injects the ``assignments_list`` prefetch for the linked-count
+        column, which is what makes core's column reach for the single-record
+        detail link -- so this faithfully reproduces the buggy condition.
+        """
+        queryset = models.Overlay.objects.annotate(assignment_count=Count("assignments")).order_by("name")
+        table = tables.OverlayTable(queryset)
+        RequestConfig(self.factory.get("/")).configure(table)
+        return {row.record.pk: row.get_cell("assignment_count") for row in table.rows}
+
+    def test_single_assignment_links_to_filtered_list_not_detail(self):
+        """A count of 1 links to the filtered list, not the assignment detail page."""
+        overlay = self.overlays[1]
+        cell = self._rendered_cells()[overlay.pk]
+        self.assertIn(f"{self.list_url}?overlay={overlay.pk}", cell)
+        self.assertNotIn(self.assignments[2].get_absolute_url(), cell)
+
+    def test_multiple_assignments_link_to_filtered_list(self):
+        """A count > 1 links to the filtered list (unchanged from core)."""
+        overlay = self.overlays[0]
+        cell = self._rendered_cells()[overlay.pk]
+        self.assertIn(f"{self.list_url}?overlay={overlay.pk}", cell)
+        self.assertIn(">2<", cell)
+
+    def test_zero_assignments_render_placeholder(self):
+        """A count of 0 renders a placeholder, not a link."""
+        overlay = self.overlays[2]
+        cell = self._rendered_cells()[overlay.pk]
+        self.assertNotIn("<a ", cell)
 
 
 class OverlayAssignmentTableTestCase(TestCase):


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->
Fixed a discrepancy in the UI, where links where the count of 1 linked to a form that was different than the custom one for more than one entries. 

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->
https://github.com/NVIDIA/nv-config-manager/actions/runs/28403927032
## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the overlays list so assignment counts now display as clickable badges linking to the related assignments list with the correct overlay filter applied.
  * Empty assignment counts now render a clear placeholder instead of attempting a link.

* **Bug Fixes**
  * Fixed assignment-count badge navigation to consistently use the filtered assignments list view (including handling single vs. zero assignment cases appropriately).

* **Tests**
  * Added coverage to verify badge rendering and URL behavior across zero, single, and multiple assignment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->