### PR TITLE
fix(ci): Harden GitLab pipelines against deleted mirrored branches

### DIFF
--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -12,11 +12,14 @@ stages:
   - test-airgapped
   - publish-airgapped
 
-# Switch between merge request and branch pipelines
+# Run automatic pipelines for merge requests, the default branch, and tags.
+# Mirrored feature branches can be deleted upstream while jobs are queued, so
+# do not create push pipelines for them. Non-push branch pipelines (for example,
+# manual, scheduled, or API-triggered runs) remain available.
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS && $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
       when: never
     - if: $CI_COMMIT_BRANCH
     - if: $CI_COMMIT_TAG
@@ -49,6 +52,8 @@ pipeline-status:
     - docker
   needs: []
   image: $NVCM_CI_IMAGE_ALPINE
+  variables:
+    GIT_STRATEGY: empty
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       when: always

--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -197,3 +197,10 @@ include:
       needs: *pulse-scan-needs
       rules: *pulse-scan-rules
       vault_auth_role: ""
+
+# The component's template-usage jobs only post pipeline metadata. Avoid a
+# repository checkout so they can still run after a merged source branch has
+# been deleted while its pipeline is queued.
+.track_template_usage:
+  variables:
+    GIT_STRATEGY: empty

--- a/.gitlab/ci/sonar.yml
+++ b/.gitlab/ci/sonar.yml
@@ -75,6 +75,9 @@ sonarqube-vulnerability-report:
     - job: sonar-scanner
       optional: true
   image: $NVCM_CI_IMAGE_ALPINE
+  variables:
+    # This job only calls the SonarQube API and consumes scanner artifacts.
+    GIT_STRATEGY: empty
   script:
     - apk add -q curl
     - 'curl --retry 3 --retry-delay 5 --retry-connrefused -u "${SONAR_TOKEN}:" "${SONAR_HOST_URL}/api/issues/gitlab_sast_export?projectKey=${NVCM_SONAR_PROJECT_KEY}&branch=${CI_COMMIT_BRANCH}&pullRequest=${CI_MERGE_REQUEST_IID}" -o gl-sast-sonar-report.json'


### PR DESCRIPTION
## Description

Harden the GitLab mirror pipeline against upstream feature branches being
deleted while jobs are still queued.

- skips automatic non-default-branch push pipelines while preserving GitLab
  merge request, default-branch, tag, scheduled, API, and manually launched
  branch pipelines;
- configures the shared template-usage telemetry jobs with
  `GIT_STRATEGY: empty` because they only post pipeline metadata; and
- skips repository checkout for the source-free `pipeline-status` and
  `sonarqube-vulnerability-report` jobs.

## Validation

- [x] Standard CI passes.
- [x] Kind integration is not applicable because this only changes GitLab CI
      pipeline selection and checkout behavior.

Passing Kind Integration run:

Not run; no application, image, Helm, or deployment behavior changed.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or this PR explains why tests
      are not needed.
- [x] Documentation is updated for user-facing behavior changes. No user-facing
      behavior changed.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs. No generated artifacts are
      affected.
