### PR TITLE
fix mcp endpoint for azure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -838,7 +838,36 @@ topology:
 	@echo "🌐 Deploying mock topology jobs and creating test topology..."
 	cd installer && uv run nv-config-manager-installer deploy ../$(INSTALL_CONFIG)
 
-# Install self-signed CA certificate in system keychain (macOS only)
+# Install self-signed CA certificate into the system trust store (macOS and Linux).
+# Trusts the gateway TLS cert for browsers and system tools.
+# Note: Node.js ignores the system trust store. For Node.js-based tools such as
+# Claude Code, set NODE_TLS_REJECT_UNAUTHORIZED=0 or use NODE_EXTRA_CA_CERTS
+# once the gateway cert is issued by a proper CA (CA:TRUE).
+install-cert:
+	@CERT_TMP=$$(mktemp); \
+	trap "rm -f $$CERT_TMP" EXIT INT TERM; \
+	echo "Extracting gateway TLS certificate..."; \
+	kubectl get secret -n $(KIND_SEC_NAMESPACE) nv-config-manager-gateway-tls \
+		-o jsonpath='{.data.tls\.crt}' | base64 -d > "$$CERT_TMP"; \
+	echo "Installing certificate (sudo required)..."; \
+	if [ "$$(uname)" = "Darwin" ]; then \
+		sudo security add-trusted-cert -d -r trustRoot \
+			-k /Library/Keychains/System.keychain "$$CERT_TMP"; \
+	elif [ -d /usr/local/share/ca-certificates ]; then \
+		sudo cp "$$CERT_TMP" /usr/local/share/ca-certificates/nvcm-gateway.crt && \
+		sudo update-ca-certificates; \
+	elif [ -d /etc/pki/ca-trust/source/anchors ]; then \
+		sudo cp "$$CERT_TMP" /etc/pki/ca-trust/source/anchors/nvcm-gateway.crt && \
+		sudo update-ca-trust; \
+	else \
+		echo "Unsupported OS: install the gateway cert manually into your trust store"; exit 1; \
+	fi; \
+	echo "Certificate installed."; \
+	echo ""; \
+	echo "Note: Node.js tools (e.g. Claude Code) ignore the system trust store because"; \
+	echo "      the gateway cert is self-signed with CA:FALSE. Scope the variable to"; \
+	echo "      the specific command: NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp login ..."
+
 # Remove local deployment (preserves shared operators)
 local-down:
 	@echo "🗑️  Removing NVIDIA Config Manager from local Kubernetes..."

--- a/Makefile
+++ b/Makefile
@@ -847,8 +847,13 @@ install-cert:
 	@CERT_TMP=$$(mktemp); \
 	trap "rm -f $$CERT_TMP" EXIT INT TERM; \
 	echo "Extracting gateway TLS certificate..."; \
-	kubectl get secret -n $(KIND_SEC_NAMESPACE) nv-config-manager-gateway-tls \
-		-o jsonpath='{.data.tls\.crt}' | base64 -d > "$$CERT_TMP"; \
+	if ! CERT_DATA=$$(kubectl get secret -n $(KIND_SEC_NAMESPACE) nv-config-manager-gateway-tls \
+		-o jsonpath='{.data.tls\.crt}'); then \
+		echo "Error: gateway TLS secret was not found." >&2; exit 1; \
+	fi; \
+	if [ -z "$$CERT_DATA" ] || ! printf '%s' "$$CERT_DATA" | base64 -d > "$$CERT_TMP" || [ ! -s "$$CERT_TMP" ]; then \
+		echo "Error: gateway TLS secret does not contain a valid certificate." >&2; exit 1; \
+	fi; \
 	echo "Installing certificate (sudo required)..."; \
 	if [ "$$(uname)" = "Darwin" ]; then \
 		sudo security add-trusted-cert -d -r trustRoot \

--- a/README.md
+++ b/README.md
@@ -168,6 +168,38 @@ kubectl get secret nautobot-admin -n nv-config-manager -o jsonpath='{.data.passw
 kubectl get secret nautobot-admin -n nv-config-manager -o jsonpath='{.data.api_token}' | base64 -d && echo
 ```
 
+### Connecting Claude Code MCP (`kind-up-sec`)
+
+The `kind-up-sec` environment includes the MCP server. To connect Claude Code:
+
+1. Install the TLS certificate.
+
+   ```bash
+   make install-cert
+   ```
+
+   Node.js (and Claude Code) does not use the system trust store because the gateway cert is self-signed with `CA:FALSE`. Scope the variable to the specific command rather than exporting it globally (see step 3 below).
+
+2. Add the MCP server.
+
+   ```bash
+   DISCOVERY=$(curl -s https://config-manager.local/auth/discovery)
+   CLIENT_ID=$(printf '%s' "$DISCOVERY" | jq -r '.clientId')
+   MCP_URL=$(printf '%s' "$DISCOVERY" | jq -r '.services.mcp')
+
+   claude mcp add --transport http --client-id "$CLIENT_ID" nv-config-manager "$MCP_URL"
+   ```
+
+   Using `--client-id` uses the pre-registered `nv-config-manager-cli` public client and avoids OAuth Dynamic Client Registration, which is disabled in local Keycloak.
+
+3. Authenticate.
+
+   ```bash
+   NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp login nv-config-manager
+   ```
+
+Then, log in with any pre-configured local Keycloak account: `nvcm-admin` / `nvcm-admin`, `nvcm-network` / `nvcm-network`, or `demo` / `demo`.
+
 ## Makefile Commands
 
 ```bash

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -947,8 +947,10 @@ mcp-auth.ini: |
   {{- if $enabled }}
   {{- $resourceUrl := get $oauth "resourceUrl" | default (printf "https://%s/mcp" (tpl (.Values.mcp.gateway.svcHostname | default "") .)) -}}
   {{- $resourceUrl = trimSuffix "/" (tpl $resourceUrl .) -}}
-  {{- $resourceIdentifier := get $oauth "resourceIdentifier" | default $resourceUrl -}}
-  {{- $resourceIdentifier = trimSuffix "/" (tpl $resourceIdentifier .) -}}
+  {{- $forwardResourceParameter := true -}}
+  {{- if hasKey $oauth "forwardResourceParameter" -}}
+  {{- $forwardResourceParameter = $oauth.forwardResourceParameter -}}
+  {{- end -}}
   {{- $issuerUrl := get $oauth "issuerUrl" | default .Values.oidc.issuerUrl -}}
   {{- $issuerUrl = required "mcp.auth.oauth.issuerUrl or oidc.issuerUrl is required when MCP OAuth metadata is enabled" $issuerUrl -}}
   {{- $issuerUrl = trimSuffix "/" (tpl $issuerUrl .) -}}
@@ -975,12 +977,12 @@ mcp-auth.ini: |
   {{- $scopes = list "openid" "email" "profile" -}}
   {{- end }}
   resource_url = {{ $resourceUrl }}
-  resource_identifier = {{ $resourceIdentifier }}
   issuer_url = {{ $issuerUrl }}
   client_id = {{ $clientId }}
   scopes = {{ if kindIs "string" $scopes }}{{ $scopes }}{{ else }}{{ join " " $scopes }}{{ end }}
   authorization_endpoint = {{ $authorizationEndpoint }}
   token_endpoint = {{ $tokenEndpoint }}
+  forward_resource_parameter = {{ $forwardResourceParameter }}
   {{- if $jwksUri }}
   jwks_uri = {{ $jwksUri }}
   {{- end }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -947,6 +947,8 @@ mcp-auth.ini: |
   {{- if $enabled }}
   {{- $resourceUrl := get $oauth "resourceUrl" | default (printf "https://%s/mcp" (tpl (.Values.mcp.gateway.svcHostname | default "") .)) -}}
   {{- $resourceUrl = trimSuffix "/" (tpl $resourceUrl .) -}}
+  {{- $resourceIdentifier := get $oauth "resourceIdentifier" | default $resourceUrl -}}
+  {{- $resourceIdentifier = trimSuffix "/" (tpl $resourceIdentifier .) -}}
   {{- $issuerUrl := get $oauth "issuerUrl" | default .Values.oidc.issuerUrl -}}
   {{- $issuerUrl = required "mcp.auth.oauth.issuerUrl or oidc.issuerUrl is required when MCP OAuth metadata is enabled" $issuerUrl -}}
   {{- $issuerUrl = trimSuffix "/" (tpl $issuerUrl .) -}}
@@ -973,6 +975,7 @@ mcp-auth.ini: |
   {{- $scopes = list "openid" "email" "profile" -}}
   {{- end }}
   resource_url = {{ $resourceUrl }}
+  resource_identifier = {{ $resourceIdentifier }}
   issuer_url = {{ $issuerUrl }}
   client_id = {{ $clientId }}
   scopes = {{ if kindIs "string" $scopes }}{{ $scopes }}{{ else }}{{ join " " $scopes }}{{ end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -934,7 +934,7 @@ oidc:
   clientSecretName: "oidc-client-secret"
   # OIDC scopes to request
   # Default: ["openid", "email", "profile"]
-  # For Azure AD JWT access tokens, use: ["api://{client-id}/.default", "openid", "profile"]
+  # For Azure AD JWT access tokens, use: ["openid", "email", "profile", "api://{client-id}/access"]
   scopes: []
   # Token audiences for JWT validation
   # Default: uses clientId as audience
@@ -1905,6 +1905,10 @@ mcp:
       # enabled: true
       # Defaults to https://<svc-mcp-hostname>/mcp
       resourceUrl: ""
+      # OAuth resource identifier advertised in protected-resource metadata.
+      # Defaults to resourceUrl. For Azure AD, set this to the API Application ID URI
+      # that owns the configured API scopes, for example api://{client-id}.
+      resourceIdentifier: ""
       # Defaults to oidc.issuerUrl.
       issuerUrl: ""
       # Defaults to oidc.cliClientId, then oidc.clientId.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1898,6 +1898,9 @@ mcp:
         - /.well-known/oauth-protected-resource
         - /.well-known/oauth-protected-resource/mcp
         - /.well-known/oauth-authorization-server
+        - /oauth/authorize
+        - /oauth/callback
+        - /oauth/token
   auth:
     oauth:
       # Defaults to oidc.enabled when unset. Set false to disable MCP OAuth
@@ -1905,10 +1908,11 @@ mcp:
       # enabled: true
       # Defaults to https://<svc-mcp-hostname>/mcp
       resourceUrl: ""
-      # OAuth resource identifier advertised in protected-resource metadata.
-      # Defaults to resourceUrl. For Azure AD, set this to the API Application ID URI
-      # that owns the configured API scopes, for example api://{client-id}.
-      resourceIdentifier: ""
+      # Forward RFC 8707 resource parameters to the upstream authorization server.
+      # Set false for Entra v2 applications whose immutable Application ID URI differs
+      # from resourceUrl; MCP will proxy OAuth requests, omit resource upstream, and
+      # use https://<svc-mcp-hostname>/oauth/callback as the fixed redirect URI.
+      forwardResourceParameter: true
       # Defaults to oidc.issuerUrl.
       issuerUrl: ""
       # Defaults to oidc.cliClientId, then oidc.clientId.

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -102,7 +102,7 @@ Clients that expect OAuth Dynamic Client Registration and do not let you provide
 #### Provider examples
 
 <AccordionGroup>
-  <Accordion title="Keycloak direct OAuth">
+  <Accordion title="Keycloak">
     Keep the default Helm setting:
 
     ```yaml
@@ -127,7 +127,7 @@ Clients that expect OAuth Dynamic Client Registration and do not let you provide
     pass the preconfigured client ID when adding the server.
   </Accordion>
 
-  <Accordion title="Microsoft Entra ID compatibility bridge">
+  <Accordion title="Microsoft Entra ID">
     Microsoft Entra ID v2 can reject a token request when the RFC 8707 `resource` parameter
     contains the HTTPS MCP resource while the requested API scopes use a different Application ID
     URI, such as `api://<application-id>`. Use the MCP compatibility bridge for this configuration:
@@ -170,9 +170,7 @@ https://config-manager.example.com/auth/discovery
 
 For example:
 
-```text
-Connect to the NVIDIA Config Manager MCP server. Discover the MCP endpoint and auth details from https://config-manager.example.com/auth/discovery. Do not start a local MCP server.
-```
+> Connect to the NVIDIA Config Manager MCP server. Discover the MCP endpoint and auth details from `https://config-manager.example.com/auth/discovery`. Do not start a local MCP server.
 
 The discovery response tells the client which remote MCP endpoint to use and whether bearer authentication is required. In SSO-enabled environments, the MCP tools act with the signed-in user's bearer token. They do not switch to broader service credentials for Config Manager APIs.
 

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -43,14 +43,13 @@ Remote MCP clients with native OAuth support can authenticate directly against t
 
 The OAuth client ID is required. Config Manager does not support OAuth Dynamic Client Registration, so the client must be configured with the public/native OIDC client ID from the Config Manager auth discovery endpoint.
 
-Get the client ID, MCP URL, and scopes from `/auth/discovery`:
+Get the client ID and MCP URL from `/auth/discovery`:
 
 ```sh
 DISCOVERY_JSON=$(curl -fsS https://config-manager.example.com/auth/discovery)
 
 CLIENT_ID=$(printf '%s' "$DISCOVERY_JSON" | jq -r '.clientId')
 MCP_URL=$(printf '%s' "$DISCOVERY_JSON" | jq -r '.services.mcp')
-SCOPES=$(printf '%s' "$DISCOVERY_JSON" | jq -r '.scopes | join(",")')
 ```
 
 The response includes the same fields directly:
@@ -74,17 +73,80 @@ codex mcp add nv-config-manager \
   --url "$MCP_URL" \
   --oauth-client-id "$CLIENT_ID"
 
-codex mcp login nv-config-manager --scopes "$SCOPES"
+codex mcp login nv-config-manager
 ```
 
-If your deployment requires an OAuth resource parameter, include the MCP endpoint as the resource:
+Do not set `--oauth-resource` unless the deployment administrator explicitly requires an
+override. The MCP protected-resource metadata supplies the resource identifier and the server
+handles provider-specific forwarding behavior.
+
+#### Keycloak
+
+Keycloak uses the direct OAuth pattern. Keep the default Helm setting:
+
+```yaml
+mcp:
+  auth:
+    oauth:
+      forwardResourceParameter: true
+```
+
+The MCP protected-resource metadata advertises the HTTPS MCP endpoint as `resource` and the
+Keycloak realm as its authorization server. OAuth requests go directly to Keycloak, including
+the RFC 8707 `resource` parameter supplied by the MCP client.
+
+Create a public/native Keycloak client for MCP clients and allow its loopback redirect URIs. For
+Codex, the redirect URI has the following form and includes an ephemeral port and per-login path:
+
+```text
+http://127.0.0.1:<port>/callback/<login-id>
+```
+
+Configure an appropriate Keycloak redirect URI pattern, such as `http://127.0.0.1:*`, and pass
+the preconfigured client ID when adding the server:
 
 ```sh
 codex mcp add nv-config-manager \
   --url "$MCP_URL" \
-  --oauth-client-id "$CLIENT_ID" \
-  --oauth-resource "$MCP_URL"
+  --oauth-client-id "$CLIENT_ID"
 ```
+
+#### Microsoft Entra ID
+
+Microsoft Entra ID v2 can reject a token request when the RFC 8707 `resource` parameter contains
+the HTTPS MCP resource while the requested API scopes use a different Application ID URI, such as
+`api://<application-id>`. Use the MCP compatibility bridge for this configuration:
+
+```yaml
+mcp:
+  auth:
+    oauth:
+      forwardResourceParameter: false
+```
+
+The compatibility bridge preserves the RFC 9728 metadata contract: `resource` remains the HTTPS
+MCP endpoint. It advertises OAuth endpoints on the MCP origin, removes `resource` before forwarding
+authorization and token requests to Entra, and leaves the configured API scopes unchanged.
+
+Codex generates a different loopback callback path for each login. The bridge presents one fixed
+HTTPS callback to Entra, then relays the authorization response to Codex's loopback listener while
+preserving OAuth state and PKCE. Register this exact redirect URI on the Entra public client:
+
+```text
+https://svc-mcp.<hostname>/oauth/callback
+```
+
+Add the server with the preconfigured Entra public-client ID and without `--oauth-resource`:
+
+```sh
+codex mcp add nv-config-manager \
+  --url "$MCP_URL" \
+  --oauth-client-id "$CLIENT_ID"
+```
+
+The callback relay accepts Codex loopback callbacks using `127.0.0.1`, an explicit port, and a
+`/callback/<login-id>` path. Other native MCP clients should use the direct provider pattern unless
+their callback format is supported by the bridge.
 
 For Claude Code, add the HTTP MCP server with the same client ID:
 
@@ -106,7 +168,7 @@ For other MCP clients, configure:
 | URL | `https://svc-mcp.<hostname>/mcp`, or the endpoint from `/auth/discovery` |
 | OAuth flow | Authorization Code with PKCE |
 | Client ID | Required; use `clientId` from `/auth/discovery` |
-| Scopes | Use the scopes in the OAuth metadata; the default is `openid email profile` |
+| Resource forwarding | Provider-specific; enabled for direct providers such as Keycloak and disabled by the Entra compatibility bridge |
 
 Clients that expect OAuth Dynamic Client Registration and do not let you provide a client ID cannot complete the native OAuth flow. Use the `nvcm-mcp-cli` helper and bearer-token configuration for those clients.
 
@@ -185,4 +247,6 @@ For the best results, connect both MCP servers: use the deployment MCP server fo
 - External Nautobot deployments may use a configured read-only Nautobot token for MCP Nautobot queries.
 - OAuth discovery metadata does not register clients. Native OAuth MCP clients must use a preconfigured public/native OIDC client ID.
 - Native OAuth MCP clients should not use an OIDC client secret.
+- Protected-resource metadata always advertises the HTTPS MCP endpoint as its RFC 9728 `resource`.
+- Entra compatibility mode changes upstream request forwarding, not the resource advertised in metadata.
 - Token values should be treated as secrets and kept out of documentation, logs, and committed configuration.

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -76,78 +76,6 @@ codex mcp add nv-config-manager \
 codex mcp login nv-config-manager
 ```
 
-Do not set `--oauth-resource` unless the deployment administrator explicitly requires an
-override. The MCP protected-resource metadata supplies the resource identifier and the server
-handles provider-specific forwarding behavior.
-
-#### Keycloak
-
-Keycloak uses the direct OAuth pattern. Keep the default Helm setting:
-
-```yaml
-mcp:
-  auth:
-    oauth:
-      forwardResourceParameter: true
-```
-
-The MCP protected-resource metadata advertises the HTTPS MCP endpoint as `resource` and the
-Keycloak realm as its authorization server. OAuth requests go directly to Keycloak, including
-the RFC 8707 `resource` parameter supplied by the MCP client.
-
-Create a public/native Keycloak client for MCP clients and allow its loopback redirect URIs. For
-Codex, the redirect URI has the following form and includes an ephemeral port and per-login path:
-
-```text
-http://127.0.0.1:<port>/callback/<login-id>
-```
-
-Configure an appropriate Keycloak redirect URI pattern, such as `http://127.0.0.1:*`, and pass
-the preconfigured client ID when adding the server:
-
-```sh
-codex mcp add nv-config-manager \
-  --url "$MCP_URL" \
-  --oauth-client-id "$CLIENT_ID"
-```
-
-#### Microsoft Entra ID
-
-Microsoft Entra ID v2 can reject a token request when the RFC 8707 `resource` parameter contains
-the HTTPS MCP resource while the requested API scopes use a different Application ID URI, such as
-`api://<application-id>`. Use the MCP compatibility bridge for this configuration:
-
-```yaml
-mcp:
-  auth:
-    oauth:
-      forwardResourceParameter: false
-```
-
-The compatibility bridge preserves the RFC 9728 metadata contract: `resource` remains the HTTPS
-MCP endpoint. It advertises OAuth endpoints on the MCP origin, removes `resource` before forwarding
-authorization and token requests to Entra, and leaves the configured API scopes unchanged.
-
-Codex generates a different loopback callback path for each login. The bridge presents one fixed
-HTTPS callback to Entra, then relays the authorization response to Codex's loopback listener while
-preserving OAuth state and PKCE. Register this exact redirect URI on the Entra public client:
-
-```text
-https://svc-mcp.<hostname>/oauth/callback
-```
-
-Add the server with the preconfigured Entra public-client ID and without `--oauth-resource`:
-
-```sh
-codex mcp add nv-config-manager \
-  --url "$MCP_URL" \
-  --oauth-client-id "$CLIENT_ID"
-```
-
-The callback relay accepts Codex loopback callbacks using `127.0.0.1`, an explicit port, and a
-`/callback/<login-id>` path. Other native MCP clients should use the direct provider pattern unless
-their callback format is supported by the bridge.
-
 For Claude Code, add the HTTP MCP server with the same client ID:
 
 ```sh
@@ -168,9 +96,69 @@ For other MCP clients, configure:
 | URL | `https://svc-mcp.<hostname>/mcp`, or the endpoint from `/auth/discovery` |
 | OAuth flow | Authorization Code with PKCE |
 | Client ID | Required; use `clientId` from `/auth/discovery` |
-| Resource forwarding | Provider-specific; enabled for direct providers such as Keycloak and disabled by the Entra compatibility bridge |
 
 Clients that expect OAuth Dynamic Client Registration and do not let you provide a client ID cannot complete the native OAuth flow. Use the `nvcm-mcp-cli` helper and bearer-token configuration for those clients.
+
+#### Provider examples
+
+<AccordionGroup>
+  <Accordion title="Keycloak direct OAuth">
+    Keep the default Helm setting:
+
+    ```yaml
+    mcp:
+      auth:
+        oauth:
+          forwardResourceParameter: true
+    ```
+
+    The MCP protected-resource metadata advertises the HTTPS MCP endpoint as `resource` and the
+    Keycloak realm as its authorization server. OAuth requests go directly to Keycloak, including
+    the RFC 8707 `resource` parameter supplied by the MCP client.
+
+    Create a public/native Keycloak client for MCP clients and allow its loopback redirect URIs.
+    DCR-oriented MCP CLIs can use a redirect URI with an ephemeral port and per-login path:
+
+    ```text
+    http://127.0.0.1:<port>/callback/<login-id>
+    ```
+
+    Configure an appropriate Keycloak redirect URI pattern, such as `http://127.0.0.1:*`, and
+    pass the preconfigured client ID when adding the server.
+  </Accordion>
+
+  <Accordion title="Microsoft Entra ID compatibility bridge">
+    Microsoft Entra ID v2 can reject a token request when the RFC 8707 `resource` parameter
+    contains the HTTPS MCP resource while the requested API scopes use a different Application ID
+    URI, such as `api://<application-id>`. Use the MCP compatibility bridge for this configuration:
+
+    ```yaml
+    mcp:
+      auth:
+        oauth:
+          forwardResourceParameter: false
+    ```
+
+    The compatibility bridge preserves the RFC 9728 metadata contract: `resource` remains the
+    HTTPS MCP endpoint. It advertises OAuth endpoints on the MCP origin, removes `resource` before
+    forwarding authorization and token requests to Entra, and leaves the configured API scopes
+    unchanged.
+
+    DCR-oriented MCP CLIs can generate a different loopback callback path for each login. The
+    bridge presents one fixed HTTPS callback to Entra, then relays the authorization response to
+    the MCP CLI's loopback listener while preserving OAuth state and PKCE. Register this exact
+    redirect URI on the Entra public client:
+
+    ```text
+    https://svc-mcp.<hostname>/oauth/callback
+    ```
+
+    Add the server with the preconfigured Entra public-client ID and without `--oauth-resource`.
+    The callback relay accepts loopback callbacks using `127.0.0.1`, an explicit port, and a
+    `/callback/<login-id>` path. Other native MCP clients should use the direct provider pattern
+    unless their callback format is supported by the bridge.
+  </Accordion>
+</AccordionGroup>
 
 ### Use discovery directly
 

--- a/installer/src/nv_config_manager_installer/helm_values.py
+++ b/installer/src/nv_config_manager_installer/helm_values.py
@@ -878,8 +878,10 @@ def build_values(
     values["rbac"] = _build_rbac(config)
     values["configStore"] = {"enabled": svc.config_store, "client": {"useInternalEndpoint": True}}
     has_nautobot = svc.nautobot or bool(svc.external_nautobot_url)
+    mcp_forward_resource = config.sso.provider != SSOProvider.AZURE
     values["mcp"] = {
         "enabled": has_nautobot and svc.temporal and svc.config_store and svc.dhcp,
+        "auth": {"oauth": {"forwardResourceParameter": mcp_forward_resource}},
     }
     values["nautobot"] = _build_nautobot(config)
 

--- a/scripts/install-security-dependencies
+++ b/scripts/install-security-dependencies
@@ -643,6 +643,7 @@ spec:
               "protocol": "openid-connect",
               "redirectUris": ["http://localhost:*", "http://127.0.0.1:*"],
               "webOrigins": ["*"],
+              "optionalClientScopes": ["offline_access"],
               "attributes": {
                 "access.token.lifespan": "3600",
                 "pkce.code.challenge.method": "S256"

--- a/src/nv_config_manager/common/oidc.py
+++ b/src/nv_config_manager/common/oidc.py
@@ -286,7 +286,8 @@ class OIDCAuth:
             issuer_url: OIDC issuer URL (e.g., https://login.microsoftonline.com/<tenant>/v2.0)
             client_id: OIDC application (client) ID.
             redirect_port: Local port for OAuth callback (default: 8765).
-            scopes: OAuth scopes to request. Defaults to api://<client_id>/.default + openid + profile.
+            scopes: OAuth scopes to request. Defaults to provider-appropriate
+                interactive login scopes.
             token_file: Path for cached token storage. Defaults to ~/.nv-config-manager/token.json.
             verify: Whether to verify TLS certificates, or a CA bundle path.
         """
@@ -356,7 +357,7 @@ class OIDCAuth:
         """Return provider-appropriate default scopes."""
         if self._is_azure_issuer():
             # Request app-specific scope to get a token for THIS app, not Microsoft Graph.
-            return [f"api://{self.client_id}/.default", "openid", "profile"]
+            return ["openid", "email", "profile", f"api://{self.client_id}/access"]
         return ["openid", "profile", "email"]
 
     def _metadata_endpoint(self, key: str) -> str | None:

--- a/src/nv_config_manager/mcp/main.py
+++ b/src/nv_config_manager/mcp/main.py
@@ -35,8 +35,16 @@ from nv_config_manager.mcp.oauth_metadata import (
     authorization_server_metadata,
     protected_resource_metadata,
 )
+from nv_config_manager.mcp.oauth_proxy import (
+    proxy_authorization_callback,
+    proxy_authorization_request,
+    proxy_token_request,
+)
 from nv_config_manager.mcp.settings import (
     AUTHORIZATION_SERVER_METADATA_PATH,
+    OAUTH_AUTHORIZE_PATH,
+    OAUTH_CALLBACK_PATH,
+    OAUTH_TOKEN_PATH,
     MCPOAuthSettings,
     MCPSettings,
 )
@@ -93,7 +101,11 @@ def create_app(
     resource_metadata_url = ""
     if resolved_oauth_settings.enabled:
         resource_metadata_url = resolved_oauth_settings.resource_metadata_url
-        unauthenticated_paths = unauthenticated_paths | resolved_oauth_settings.well_known_paths
+        unauthenticated_paths = (
+            unauthenticated_paths
+            | resolved_oauth_settings.well_known_paths
+            | resolved_oauth_settings.oauth_proxy_paths
+        )
     return ServiceAuthMiddleware(
         RequestAuthMiddleware(
             create_mcp_server(settings, resolved_oauth_settings).streamable_http_app()
@@ -135,6 +147,32 @@ def _register_oauth_metadata_routes(server: FastMCP, settings: MCPOAuthSettings)
             authorization_server_metadata(settings),
             headers={"Cache-Control": "no-store"},
         )
+
+    if not settings.forward_resource_parameter:
+
+        @server.custom_route(
+            OAUTH_AUTHORIZE_PATH,
+            methods=["GET"],
+            include_in_schema=False,
+        )
+        async def oauth_authorize_proxy(request: Request) -> Response:
+            return await proxy_authorization_request(request, settings)
+
+        @server.custom_route(
+            OAUTH_CALLBACK_PATH,
+            methods=["GET"],
+            include_in_schema=False,
+        )
+        async def oauth_callback_proxy(request: Request) -> Response:
+            return await proxy_authorization_callback(request)
+
+        @server.custom_route(
+            OAUTH_TOKEN_PATH,
+            methods=["POST"],
+            include_in_schema=False,
+        )
+        async def oauth_token_proxy(request: Request) -> Response:
+            return await proxy_token_request(request, settings)
 
 
 def main() -> None:

--- a/src/nv_config_manager/mcp/oauth_metadata.py
+++ b/src/nv_config_manager/mcp/oauth_metadata.py
@@ -23,9 +23,12 @@ from nv_config_manager.mcp.settings import MCPOAuthSettings
 
 def protected_resource_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:
     """Build RFC 9728 protected resource metadata for the MCP endpoint."""
+    authorization_server = settings.issuer_url
+    if not settings.forward_resource_parameter:
+        authorization_server = settings.authorization_server_url
     metadata: dict[str, Any] = {
-        "resource": settings.resource_identifier,
-        "authorization_servers": [settings.issuer_url],
+        "resource": settings.resource_url,
+        "authorization_servers": [authorization_server],
         "bearer_methods_supported": ["header"],
         "resource_name": "NVIDIA Config Manager MCP",
     }
@@ -38,10 +41,17 @@ def protected_resource_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:
 
 def authorization_server_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:
     """Build OAuth authorization server metadata backed by the configured IdP."""
+    issuer = settings.issuer_url
+    authorization_endpoint = settings.authorization_endpoint
+    token_endpoint = settings.token_endpoint
+    if not settings.forward_resource_parameter:
+        issuer = settings.authorization_server_url
+        authorization_endpoint = settings.authorization_proxy_url
+        token_endpoint = settings.token_proxy_url
     metadata: dict[str, Any] = {
-        "issuer": settings.issuer_url,
-        "authorization_endpoint": settings.authorization_endpoint,
-        "token_endpoint": settings.token_endpoint,
+        "issuer": issuer,
+        "authorization_endpoint": authorization_endpoint,
+        "token_endpoint": token_endpoint,
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "token_endpoint_auth_methods_supported": ["none"],

--- a/src/nv_config_manager/mcp/oauth_metadata.py
+++ b/src/nv_config_manager/mcp/oauth_metadata.py
@@ -24,7 +24,7 @@ from nv_config_manager.mcp.settings import MCPOAuthSettings
 def protected_resource_metadata(settings: MCPOAuthSettings) -> dict[str, Any]:
     """Build RFC 9728 protected resource metadata for the MCP endpoint."""
     metadata: dict[str, Any] = {
-        "resource": settings.resource_url,
+        "resource": settings.resource_identifier,
         "authorization_servers": [settings.issuer_url],
         "bearer_methods_supported": ["header"],
         "resource_name": "NVIDIA Config Manager MCP",

--- a/src/nv_config_manager/mcp/oauth_proxy.py
+++ b/src/nv_config_manager/mcp/oauth_proxy.py
@@ -28,7 +28,7 @@ from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from nv_config_manager.mcp.settings import MCPOAuthSettings
 
-_DCR_MCP_CLI_CALLBACK_PATH = re.compile(r"/callback/[A-Za-z0-9_-]+")
+_DCR_MCP_CLI_CALLBACK_PATH = re.compile(r"/callback(?:/[A-Za-z0-9_-]+)?")
 
 
 async def proxy_authorization_request(
@@ -144,6 +144,9 @@ def _merge_query_params(url: str, params: tuple[tuple[str, str], ...]) -> str:
     return parsed._replace(query=query).geturl()
 
 
+_RFC8252_LOOPBACK_HOSTNAMES = {"127.0.0.1", "::1", "localhost"}
+
+
 def _is_dcr_mcp_cli_loopback_uri(value: str) -> bool:
     parsed = urlparse(value)
     try:
@@ -152,9 +155,8 @@ def _is_dcr_mcp_cli_loopback_uri(value: str) -> bool:
         return False
     return (
         parsed.scheme == "http"
-        and parsed.hostname == "127.0.0.1"
+        and parsed.hostname in _RFC8252_LOOPBACK_HOSTNAMES
         and port is not None
-        and parsed.netloc == f"127.0.0.1:{port}"
         and _DCR_MCP_CLI_CALLBACK_PATH.fullmatch(parsed.path) is not None
         and not parsed.params
         and not parsed.query

--- a/src/nv_config_manager/mcp/oauth_proxy.py
+++ b/src/nv_config_manager/mcp/oauth_proxy.py
@@ -22,13 +22,13 @@ import re
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse
 
-import httpx
+import aiohttp
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from nv_config_manager.mcp.settings import MCPOAuthSettings
 
-_CODEX_CALLBACK_PATH = re.compile(r"/callback/[A-Za-z0-9_-]+")
+_DCR_MCP_CLI_CALLBACK_PATH = re.compile(r"/callback/[A-Za-z0-9_-]+")
 
 
 async def proxy_authorization_request(
@@ -41,7 +41,11 @@ async def proxy_authorization_request(
 
     redirect_uris = request.query_params.getlist("redirect_uri")
     states = request.query_params.getlist("state")
-    if len(redirect_uris) != 1 or len(states) != 1 or not _is_codex_loopback_uri(redirect_uris[0]):
+    if (
+        len(redirect_uris) != 1
+        or len(states) != 1
+        or not _is_dcr_mcp_cli_loopback_uri(redirect_uris[0])
+    ):
         return JSONResponse({"error": "invalid_request"}, status_code=400)
 
     upstream_params = tuple(
@@ -52,12 +56,12 @@ async def proxy_authorization_request(
         ("redirect_uri", settings.callback_proxy_url),
         ("state", _encode_relay_state(redirect_uris[0], states[0])),
     )
-    upstream_url = httpx.URL(settings.authorization_endpoint).copy_merge_params(upstream_params)
-    return RedirectResponse(str(upstream_url), status_code=302)
+    upstream_url = _merge_query_params(settings.authorization_endpoint, upstream_params)
+    return RedirectResponse(upstream_url, status_code=302)
 
 
 async def proxy_authorization_callback(request: Request) -> Response:
-    """Relay an upstream authorization response to Codex's loopback callback."""
+    """Relay an upstream authorization response to an MCP CLI loopback callback."""
     states = request.query_params.getlist("state")
     if len(states) != 1:
         return JSONResponse({"error": "invalid_request"}, status_code=400)
@@ -70,8 +74,8 @@ async def proxy_authorization_callback(request: Request) -> Response:
     callback_params = tuple(
         (key, value) for key, value in request.query_params.multi_items() if key != "state"
     ) + (("state", client_state),)
-    callback_url = httpx.URL(callback_uri).copy_merge_params(callback_params)
-    return RedirectResponse(str(callback_url), status_code=302)
+    callback_url = _merge_query_params(callback_uri, callback_params)
+    return RedirectResponse(callback_url, status_code=302)
 
 
 async def proxy_token_request(
@@ -88,7 +92,9 @@ async def proxy_token_request(
         return JSONResponse({"error": "invalid_client"}, status_code=400)
 
     redirect_uris = [value for key, value in params if key == "redirect_uri"]
-    if redirect_uris and (len(redirect_uris) != 1 or not _is_codex_loopback_uri(redirect_uris[0])):
+    if redirect_uris and (
+        len(redirect_uris) != 1 or not _is_dcr_mcp_cli_loopback_uri(redirect_uris[0])
+    ):
         return JSONResponse({"error": "invalid_request"}, status_code=400)
 
     upstream_body = urlencode(
@@ -103,31 +109,42 @@ async def proxy_token_request(
         doseq=True,
     )
     try:
-        async with httpx.AsyncClient(timeout=30) as client:
-            upstream_response = await client.post(
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as client:
+            async with client.post(
                 settings.token_endpoint,
-                content=upstream_body,
+                data=upstream_body,
                 headers={
                     "Accept": request.headers.get("accept", "application/json"),
                     "Content-Type": "application/x-www-form-urlencoded",
                 },
-            )
-    except httpx.HTTPError:
+            ) as upstream_response:
+                response_content = await upstream_response.read()
+                response_status = upstream_response.status
+                response_headers = {
+                    key: value
+                    for key in ("content-type", "cache-control", "pragma")
+                    if (value := upstream_response.headers.get(key))
+                }
+    except (aiohttp.ClientError, TimeoutError):
         return JSONResponse({"error": "temporarily_unavailable"}, status_code=502)
 
-    response_headers = {
-        key: value
-        for key in ("content-type", "cache-control", "pragma")
-        if (value := upstream_response.headers.get(key))
-    }
     return Response(
-        content=upstream_response.content,
-        status_code=upstream_response.status_code,
+        content=response_content,
+        status_code=response_status,
         headers=response_headers,
     )
 
 
-def _is_codex_loopback_uri(value: str) -> bool:
+def _merge_query_params(url: str, params: tuple[tuple[str, str], ...]) -> str:
+    parsed = urlparse(url)
+    query = urlencode(
+        [*parse_qsl(parsed.query, keep_blank_values=True), *params],
+        doseq=True,
+    )
+    return parsed._replace(query=query).geturl()
+
+
+def _is_dcr_mcp_cli_loopback_uri(value: str) -> bool:
     parsed = urlparse(value)
     try:
         port = parsed.port
@@ -138,7 +155,7 @@ def _is_codex_loopback_uri(value: str) -> bool:
         and parsed.hostname == "127.0.0.1"
         and port is not None
         and parsed.netloc == f"127.0.0.1:{port}"
-        and _CODEX_CALLBACK_PATH.fullmatch(parsed.path) is not None
+        and _DCR_MCP_CLI_CALLBACK_PATH.fullmatch(parsed.path) is not None
         and not parsed.params
         and not parsed.query
         and not parsed.fragment
@@ -167,7 +184,7 @@ def _decode_relay_state(value: str) -> tuple[str, str] | None:
     if (
         not isinstance(callback_uri, str)
         or not isinstance(client_state, str)
-        or not _is_codex_loopback_uri(callback_uri)
+        or not _is_dcr_mcp_cli_loopback_uri(callback_uri)
     ):
         return None
     return callback_uri, client_state

--- a/src/nv_config_manager/mcp/oauth_proxy.py
+++ b/src/nv_config_manager/mcp/oauth_proxy.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OAuth compatibility proxy for providers that reject RFC 8707 resource parameters."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse
+
+import httpx
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+
+from nv_config_manager.mcp.settings import MCPOAuthSettings
+
+_CODEX_CALLBACK_PATH = re.compile(r"/callback/[A-Za-z0-9_-]+")
+
+
+async def proxy_authorization_request(
+    request: Request,
+    settings: MCPOAuthSettings,
+) -> Response:
+    """Redirect an authorization request upstream without its resource parameter."""
+    if request.query_params.getlist("client_id") != [settings.client_id]:
+        return JSONResponse({"error": "invalid_client"}, status_code=400)
+
+    redirect_uris = request.query_params.getlist("redirect_uri")
+    states = request.query_params.getlist("state")
+    if len(redirect_uris) != 1 or len(states) != 1 or not _is_codex_loopback_uri(redirect_uris[0]):
+        return JSONResponse({"error": "invalid_request"}, status_code=400)
+
+    upstream_params = tuple(
+        (key, value)
+        for key, value in request.query_params.multi_items()
+        if key not in {"resource", "redirect_uri", "state"}
+    ) + (
+        ("redirect_uri", settings.callback_proxy_url),
+        ("state", _encode_relay_state(redirect_uris[0], states[0])),
+    )
+    upstream_url = httpx.URL(settings.authorization_endpoint).copy_merge_params(upstream_params)
+    return RedirectResponse(str(upstream_url), status_code=302)
+
+
+async def proxy_authorization_callback(request: Request) -> Response:
+    """Relay an upstream authorization response to Codex's loopback callback."""
+    states = request.query_params.getlist("state")
+    if len(states) != 1:
+        return JSONResponse({"error": "invalid_request"}, status_code=400)
+
+    relay_state = _decode_relay_state(states[0])
+    if relay_state is None:
+        return JSONResponse({"error": "invalid_request"}, status_code=400)
+
+    callback_uri, client_state = relay_state
+    callback_params = tuple(
+        (key, value) for key, value in request.query_params.multi_items() if key != "state"
+    ) + (("state", client_state),)
+    callback_url = httpx.URL(callback_uri).copy_merge_params(callback_params)
+    return RedirectResponse(str(callback_url), status_code=302)
+
+
+async def proxy_token_request(
+    request: Request,
+    settings: MCPOAuthSettings,
+) -> Response:
+    """Forward a token request upstream without its resource parameter."""
+    try:
+        params = parse_qsl((await request.body()).decode("utf-8"), keep_blank_values=True)
+    except UnicodeDecodeError:
+        return JSONResponse({"error": "invalid_request"}, status_code=400)
+
+    if [value for key, value in params if key == "client_id"] != [settings.client_id]:
+        return JSONResponse({"error": "invalid_client"}, status_code=400)
+
+    redirect_uris = [value for key, value in params if key == "redirect_uri"]
+    if redirect_uris and (len(redirect_uris) != 1 or not _is_codex_loopback_uri(redirect_uris[0])):
+        return JSONResponse({"error": "invalid_request"}, status_code=400)
+
+    upstream_body = urlencode(
+        [
+            (
+                key,
+                settings.callback_proxy_url if key == "redirect_uri" else value,
+            )
+            for key, value in params
+            if key != "resource"
+        ],
+        doseq=True,
+    )
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            upstream_response = await client.post(
+                settings.token_endpoint,
+                content=upstream_body,
+                headers={
+                    "Accept": request.headers.get("accept", "application/json"),
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+            )
+    except httpx.HTTPError:
+        return JSONResponse({"error": "temporarily_unavailable"}, status_code=502)
+
+    response_headers = {
+        key: value
+        for key in ("content-type", "cache-control", "pragma")
+        if (value := upstream_response.headers.get(key))
+    }
+    return Response(
+        content=upstream_response.content,
+        status_code=upstream_response.status_code,
+        headers=response_headers,
+    )
+
+
+def _is_codex_loopback_uri(value: str) -> bool:
+    parsed = urlparse(value)
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme == "http"
+        and parsed.hostname == "127.0.0.1"
+        and port is not None
+        and parsed.netloc == f"127.0.0.1:{port}"
+        and _CODEX_CALLBACK_PATH.fullmatch(parsed.path) is not None
+        and not parsed.params
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _encode_relay_state(callback_uri: str, client_state: str) -> str:
+    payload = json.dumps(
+        {"redirect_uri": callback_uri, "state": client_state},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def _decode_relay_state(value: str) -> tuple[str, str] | None:
+    try:
+        payload: Any = json.loads(
+            base64.urlsafe_b64decode(value + "=" * (-len(value) % 4)).decode("utf-8")
+        )
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    callback_uri = payload.get("redirect_uri")
+    client_state = payload.get("state")
+    if (
+        not isinstance(callback_uri, str)
+        or not isinstance(client_state, str)
+        or not _is_codex_loopback_uri(callback_uri)
+    ):
+        return None
+    return callback_uri, client_state

--- a/src/nv_config_manager/mcp/settings.py
+++ b/src/nv_config_manager/mcp/settings.py
@@ -80,6 +80,7 @@ class MCPOAuthSettings:
 
     enabled: bool
     resource_url: str = ""
+    resource_identifier: str = ""
     issuer_url: str = ""
     client_id: str = ""
     scopes: tuple[str, ...] = ()
@@ -96,9 +97,14 @@ class MCPOAuthSettings:
         if not enabled:
             return cls(enabled=False)
 
+        resource_url = _normalized_required_url(config, "resource_url")
         settings = cls(
             enabled=True,
-            resource_url=_normalized_required_url(config, "resource_url"),
+            resource_url=resource_url,
+            resource_identifier=_normalize_url(
+                _get_value(config, "mcp.oauth", "resource_identifier", "")
+            )
+            or resource_url,
             issuer_url=_normalized_required_url(config, "issuer_url"),
             client_id=_get_required(config, "mcp.oauth", "client_id").strip(),
             scopes=_parse_scopes(_get_value(config, "mcp.oauth", "scopes", "")),

--- a/src/nv_config_manager/mcp/settings.py
+++ b/src/nv_config_manager/mcp/settings.py
@@ -88,6 +88,10 @@ class MCPOAuthSettings:
     token_endpoint: str = ""
     jwks_uri: str = ""
 
+    def __post_init__(self) -> None:
+        if not self.resource_identifier and self.resource_url:
+            object.__setattr__(self, "resource_identifier", self.resource_url)
+
     @classmethod
     def from_config(cls, config: ConfigParser | None = None) -> MCPOAuthSettings:
         """Resolve MCP OAuth discovery metadata from mcp-auth.ini."""
@@ -103,8 +107,7 @@ class MCPOAuthSettings:
             resource_url=resource_url,
             resource_identifier=_normalize_url(
                 _get_value(config, "mcp.oauth", "resource_identifier", "")
-            )
-            or resource_url,
+            ),
             issuer_url=_normalized_required_url(config, "issuer_url"),
             client_id=_get_required(config, "mcp.oauth", "client_id").strip(),
             scopes=_parse_scopes(_get_value(config, "mcp.oauth", "scopes", "")),

--- a/src/nv_config_manager/mcp/settings.py
+++ b/src/nv_config_manager/mcp/settings.py
@@ -28,6 +28,9 @@ MCP_AUTH_CONFIG_ENV_VAR = "NV_CONFIG_MANAGER_MCP_AUTH_INI"
 DEFAULT_MCP_AUTH_CONFIG_PATH = "/etc/nv-config-manager/mcp-auth.ini"
 PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource"
 AUTHORIZATION_SERVER_METADATA_PATH = "/.well-known/oauth-authorization-server"
+OAUTH_AUTHORIZE_PATH = "/oauth/authorize"
+OAUTH_CALLBACK_PATH = "/oauth/callback"
+OAUTH_TOKEN_PATH = "/oauth/token"
 
 
 @dataclass(frozen=True)
@@ -80,17 +83,13 @@ class MCPOAuthSettings:
 
     enabled: bool
     resource_url: str = ""
-    resource_identifier: str = ""
     issuer_url: str = ""
     client_id: str = ""
     scopes: tuple[str, ...] = ()
     authorization_endpoint: str = ""
     token_endpoint: str = ""
     jwks_uri: str = ""
-
-    def __post_init__(self) -> None:
-        if not self.resource_identifier and self.resource_url:
-            object.__setattr__(self, "resource_identifier", self.resource_url)
+    forward_resource_parameter: bool = True
 
     @classmethod
     def from_config(cls, config: ConfigParser | None = None) -> MCPOAuthSettings:
@@ -101,19 +100,18 @@ class MCPOAuthSettings:
         if not enabled:
             return cls(enabled=False)
 
-        resource_url = _normalized_required_url(config, "resource_url")
         settings = cls(
             enabled=True,
-            resource_url=resource_url,
-            resource_identifier=_normalize_url(
-                _get_value(config, "mcp.oauth", "resource_identifier", "")
-            ),
+            resource_url=_normalized_resource_url(config),
             issuer_url=_normalized_required_url(config, "issuer_url"),
             client_id=_get_required(config, "mcp.oauth", "client_id").strip(),
             scopes=_parse_scopes(_get_value(config, "mcp.oauth", "scopes", "")),
             authorization_endpoint=_normalized_required_url(config, "authorization_endpoint"),
             token_endpoint=_normalized_required_url(config, "token_endpoint"),
             jwks_uri=_normalize_url(_get_value(config, "mcp.oauth", "jwks_uri", "")),
+            forward_resource_parameter=_get_bool(
+                config, "mcp.oauth", "forward_resource_parameter", True
+            ),
         )
         if not settings.client_id:
             raise ValueError("Missing required MCP OAuth config value [mcp.oauth] client_id")
@@ -137,6 +135,34 @@ class MCPOAuthSettings:
             return ""
         parsed = urlparse(self.resource_url)
         return f"{parsed.scheme}://{parsed.netloc}"
+
+    @property
+    def authorization_proxy_url(self) -> str:
+        """Return the MCP-origin OAuth authorization compatibility endpoint."""
+        if not self.authorization_server_url:
+            return ""
+        return f"{self.authorization_server_url}{OAUTH_AUTHORIZE_PATH}"
+
+    @property
+    def token_proxy_url(self) -> str:
+        """Return the MCP-origin OAuth token compatibility endpoint."""
+        if not self.authorization_server_url:
+            return ""
+        return f"{self.authorization_server_url}{OAUTH_TOKEN_PATH}"
+
+    @property
+    def callback_proxy_url(self) -> str:
+        """Return the fixed upstream OAuth callback used by the compatibility proxy."""
+        if not self.authorization_server_url:
+            return ""
+        return f"{self.authorization_server_url}{OAUTH_CALLBACK_PATH}"
+
+    @property
+    def oauth_proxy_paths(self) -> frozenset[str]:
+        """Return unauthenticated OAuth proxy paths when compatibility mode is enabled."""
+        if not self.enabled or self.forward_resource_parameter:
+            return frozenset()
+        return frozenset({OAUTH_AUTHORIZE_PATH, OAUTH_CALLBACK_PATH, OAUTH_TOKEN_PATH})
 
     @property
     def well_known_paths(self) -> frozenset[str]:
@@ -241,6 +267,17 @@ def _normalized_required_url(config: ConfigParser, key: str) -> str:
     parsed = urlparse(value)
     if not parsed.scheme or not parsed.netloc:
         raise ValueError(f"Invalid MCP OAuth URL value [mcp.oauth] {key}: {value}")
+    return value
+
+
+def _normalized_resource_url(config: ConfigParser) -> str:
+    value = _normalized_required_url(config, "resource_url")
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or parsed.query or parsed.fragment:
+        raise ValueError(
+            "Invalid MCP OAuth URL value [mcp.oauth] resource_url: "
+            "must use https and contain no query or fragment"
+        )
     return value
 
 

--- a/src/tests/common/test_oidc.py
+++ b/src/tests/common/test_oidc.py
@@ -303,7 +303,7 @@ def test_azure_fallback_keeps_azure_paths_and_scope(
     assert auth._get_token_endpoint() == (
         "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token"
     )
-    assert auth.scopes == ["api://client-id/.default", "openid", "profile"]
+    assert auth.scopes == ["openid", "email", "profile", "api://client-id/access"]
 
 
 def test_generic_oidc_fallback_uses_issuer_relative_paths(

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -275,8 +275,38 @@ def test_oauth_compatibility_proxy_uses_local_issuer_and_strips_resource(
 @pytest.mark.parametrize(
     "redirect_uri",
     [
-        "https://127.0.0.1:8765/callback/id",
+        "http://127.0.0.1:8765/callback/id",
+        "http://127.0.0.1:8765/callback",
         "http://localhost:8765/callback/id",
+        "http://localhost:8765/callback",
+        "http://[::1]:8765/callback/id",
+        "http://[::1]:8765/callback",
+    ],
+)
+def test_oauth_compatibility_proxy_accepts_rfc8252_loopback_redirects(
+    redirect_uri: str,
+) -> None:
+    with TestClient(
+        create_app(_settings(), _oauth_settings(forward_resource_parameter=False)),
+        base_url="https://svc-mcp.config-manager.local",
+        follow_redirects=False,
+    ) as client:
+        response = client.get(
+            "/oauth/authorize",
+            params={
+                "client_id": "nvcm-cli",
+                "state": "state-value",
+                "redirect_uri": redirect_uri,
+            },
+        )
+
+    assert response.status_code == 302
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "https://127.0.0.1:8765/callback/id",
         "http://127.0.0.1:8765/not-a-callback/id",
         "http://127.0.0.1:8765/callback/id?next=https://example.test",
     ],

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 from __future__ import annotations
 
+from urllib.parse import parse_qs, urlparse
+
+import httpx
 import pytest
 from fastapi import HTTPException
 from starlette.testclient import TestClient
@@ -138,6 +141,151 @@ def test_oauth_metadata_endpoints_bypass_service_auth(monkeypatch: pytest.Monkey
     }
 
 
+def test_oauth_compatibility_proxy_uses_local_issuer_and_strips_resource(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token_request: dict[str, object] = {}
+    codex_callback = "http://127.0.0.1:8765/callback/codex-callback-id"
+
+    class StubAsyncClient:
+        def __init__(self, timeout: int) -> None:
+            assert timeout == 30
+
+        async def __aenter__(self) -> StubAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            content: str,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            token_request.update(url=url, content=content, headers=headers)
+            return httpx.Response(
+                200,
+                json={"access_token": "redacted", "token_type": "Bearer"},
+                headers={"Cache-Control": "no-store"},
+            )
+
+    monkeypatch.setattr("nv_config_manager.mcp.oauth_proxy.httpx.AsyncClient", StubAsyncClient)
+    oauth_settings = _oauth_settings(forward_resource_parameter=False)
+
+    with TestClient(
+        create_app(_settings(), oauth_settings),
+        base_url="https://svc-mcp.config-manager.local",
+    ) as client:
+        protected_response = client.get("/.well-known/oauth-protected-resource/mcp")
+        auth_server_response = client.get("/.well-known/oauth-authorization-server")
+        authorize_response = client.get(
+            "/oauth/authorize",
+            params={
+                "client_id": "nvcm-cli",
+                "scope": "openid api://nvcm-api/access",
+                "state": "state-value",
+                "redirect_uri": codex_callback,
+                "resource": "https://svc-mcp.config-manager.local/mcp",
+            },
+            follow_redirects=False,
+        )
+        upstream_state = parse_qs(urlparse(authorize_response.headers["location"]).query)["state"][
+            0
+        ]
+        callback_response = client.get(
+            "/oauth/callback",
+            params={
+                "code": "code-value",
+                "state": upstream_state,
+                "session_state": "session-value",
+            },
+            follow_redirects=False,
+        )
+        token_response = client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "nvcm-cli",
+                "code": "code-value",
+                "redirect_uri": codex_callback,
+                "resource": "https://svc-mcp.config-manager.local/mcp",
+            },
+        )
+        invalid_client_response = client.post(
+            "/oauth/token",
+            data={"grant_type": "authorization_code", "client_id": "other-client"},
+        )
+
+    assert protected_response.json()["resource"] == ("https://svc-mcp.config-manager.local/mcp")
+    assert protected_response.json()["authorization_servers"] == [
+        "https://svc-mcp.config-manager.local"
+    ]
+    assert auth_server_response.json()["issuer"] == "https://svc-mcp.config-manager.local"
+    assert auth_server_response.json()["authorization_endpoint"] == (
+        "https://svc-mcp.config-manager.local/oauth/authorize"
+    )
+    assert auth_server_response.json()["token_endpoint"] == (
+        "https://svc-mcp.config-manager.local/oauth/token"
+    )
+
+    redirect_query = parse_qs(urlparse(authorize_response.headers["location"]).query)
+    assert authorize_response.status_code == 302
+    assert "resource" not in redirect_query
+    assert redirect_query["scope"] == ["openid api://nvcm-api/access"]
+    assert redirect_query["redirect_uri"] == ["https://svc-mcp.config-manager.local/oauth/callback"]
+    assert redirect_query["state"] != ["state-value"]
+
+    callback_location = urlparse(callback_response.headers["location"])
+    assert callback_response.status_code == 302
+    assert f"{callback_location.scheme}://{callback_location.netloc}{callback_location.path}" == (
+        codex_callback
+    )
+    assert parse_qs(callback_location.query) == {
+        "code": ["code-value"],
+        "session_state": ["session-value"],
+        "state": ["state-value"],
+    }
+
+    assert token_response.status_code == 200
+    assert token_response.json()["access_token"] == "redacted"
+    assert token_request["url"] == "https://idp.example.test/realms/nvcm/token"
+    token_params = parse_qs(str(token_request["content"]))
+    assert "resource" not in token_params
+    assert token_params["code"] == ["code-value"]
+    assert token_params["redirect_uri"] == ["https://svc-mcp.config-manager.local/oauth/callback"]
+    assert invalid_client_response.status_code == 400
+    assert invalid_client_response.json() == {"error": "invalid_client"}
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "https://127.0.0.1:8765/callback/id",
+        "http://localhost:8765/callback/id",
+        "http://127.0.0.1:8765/not-a-callback/id",
+        "http://127.0.0.1:8765/callback/id?next=https://example.test",
+    ],
+)
+def test_oauth_compatibility_proxy_rejects_non_codex_redirects(redirect_uri: str) -> None:
+    with TestClient(
+        create_app(_settings(), _oauth_settings(forward_resource_parameter=False)),
+        base_url="https://svc-mcp.config-manager.local",
+    ) as client:
+        response = client.get(
+            "/oauth/authorize",
+            params={
+                "client_id": "nvcm-cli",
+                "state": "state-value",
+                "redirect_uri": redirect_uri,
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"error": "invalid_request"}
+
+
 def test_configured_oauth_metadata_path_bypasses_service_auth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -158,19 +306,6 @@ def test_configured_oauth_metadata_path_bypasses_service_auth(
 
     assert response.status_code == 200
     assert response.json()["resource"] == "https://svc-mcp.config-manager.local/custom/mcp"
-
-
-def test_oauth_metadata_can_advertise_distinct_resource_identifier() -> None:
-    oauth_settings = _oauth_settings(resource_identifier="api://nvcm-api")
-
-    with TestClient(
-        create_app(_settings(), oauth_settings),
-        base_url="https://svc-mcp.config-manager.local",
-    ) as client:
-        response = client.get("/.well-known/oauth-protected-resource/mcp")
-
-    assert response.status_code == 200
-    assert response.json()["resource"] == "api://nvcm-api"
 
 
 def test_oauth_metadata_endpoints_not_registered_when_disabled() -> None:
@@ -240,16 +375,16 @@ def _settings() -> MCPSettings:
 
 def _oauth_settings(
     resource_url: str = "https://svc-mcp.config-manager.local/mcp",
-    resource_identifier: str = "",
+    forward_resource_parameter: bool = True,
 ) -> MCPOAuthSettings:
     return MCPOAuthSettings(
         enabled=True,
         resource_url=resource_url,
-        resource_identifier=resource_identifier,
         issuer_url="https://idp.example.test/realms/nvcm",
         client_id="nvcm-cli",
         scopes=("openid", "email", "profile"),
         authorization_endpoint="https://idp.example.test/realms/nvcm/auth",
         token_endpoint="https://idp.example.test/realms/nvcm/token",
         jwks_uri="https://idp.example.test/realms/nvcm/certs",
+        forward_resource_parameter=forward_resource_parameter,
     )

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from urllib.parse import parse_qs, urlparse
 
-import httpx
 import pytest
 from fastapi import HTTPException
 from starlette.testclient import TestClient
@@ -145,33 +144,47 @@ def test_oauth_compatibility_proxy_uses_local_issuer_and_strips_resource(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     token_request: dict[str, object] = {}
-    codex_callback = "http://127.0.0.1:8765/callback/codex-callback-id"
+    mcp_cli_callback = "http://127.0.0.1:8765/callback/mcp-cli-callback-id"
 
-    class StubAsyncClient:
-        def __init__(self, timeout: int) -> None:
-            assert timeout == 30
+    class StubResponse:
+        status = 200
+        headers = {
+            "Content-Type": "application/json",
+            "Cache-Control": "no-store",
+        }
 
-        async def __aenter__(self) -> StubAsyncClient:
+        async def __aenter__(self) -> StubResponse:
             return self
 
         async def __aexit__(self, *args: object) -> None:
             return None
 
-        async def post(
+        async def read(self) -> bytes:
+            return b'{"access_token":"redacted","token_type":"Bearer"}'
+
+    class StubClientSession:
+        def __init__(self, *, timeout: object) -> None:
+            assert getattr(timeout, "total") == 30
+
+        async def __aenter__(self) -> StubClientSession:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        def post(
             self,
             url: str,
             *,
-            content: str,
+            data: str,
             headers: dict[str, str],
-        ) -> httpx.Response:
-            token_request.update(url=url, content=content, headers=headers)
-            return httpx.Response(
-                200,
-                json={"access_token": "redacted", "token_type": "Bearer"},
-                headers={"Cache-Control": "no-store"},
-            )
+        ) -> StubResponse:
+            token_request.update(url=url, content=data, headers=headers)
+            return StubResponse()
 
-    monkeypatch.setattr("nv_config_manager.mcp.oauth_proxy.httpx.AsyncClient", StubAsyncClient)
+    monkeypatch.setattr(
+        "nv_config_manager.mcp.oauth_proxy.aiohttp.ClientSession", StubClientSession
+    )
     oauth_settings = _oauth_settings(forward_resource_parameter=False)
 
     with TestClient(
@@ -186,7 +199,7 @@ def test_oauth_compatibility_proxy_uses_local_issuer_and_strips_resource(
                 "client_id": "nvcm-cli",
                 "scope": "openid api://nvcm-api/access",
                 "state": "state-value",
-                "redirect_uri": codex_callback,
+                "redirect_uri": mcp_cli_callback,
                 "resource": "https://svc-mcp.config-manager.local/mcp",
             },
             follow_redirects=False,
@@ -209,7 +222,7 @@ def test_oauth_compatibility_proxy_uses_local_issuer_and_strips_resource(
                 "grant_type": "authorization_code",
                 "client_id": "nvcm-cli",
                 "code": "code-value",
-                "redirect_uri": codex_callback,
+                "redirect_uri": mcp_cli_callback,
                 "resource": "https://svc-mcp.config-manager.local/mcp",
             },
         )
@@ -240,7 +253,7 @@ def test_oauth_compatibility_proxy_uses_local_issuer_and_strips_resource(
     callback_location = urlparse(callback_response.headers["location"])
     assert callback_response.status_code == 302
     assert f"{callback_location.scheme}://{callback_location.netloc}{callback_location.path}" == (
-        codex_callback
+        mcp_cli_callback
     )
     assert parse_qs(callback_location.query) == {
         "code": ["code-value"],
@@ -268,7 +281,9 @@ def test_oauth_compatibility_proxy_uses_local_issuer_and_strips_resource(
         "http://127.0.0.1:8765/callback/id?next=https://example.test",
     ],
 )
-def test_oauth_compatibility_proxy_rejects_non_codex_redirects(redirect_uri: str) -> None:
+def test_oauth_compatibility_proxy_rejects_non_dcr_mcp_cli_redirects(
+    redirect_uri: str,
+) -> None:
     with TestClient(
         create_app(_settings(), _oauth_settings(forward_resource_parameter=False)),
         base_url="https://svc-mcp.config-manager.local",

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -240,12 +240,12 @@ def _settings() -> MCPSettings:
 
 def _oauth_settings(
     resource_url: str = "https://svc-mcp.config-manager.local/mcp",
-    resource_identifier: str | None = None,
+    resource_identifier: str = "",
 ) -> MCPOAuthSettings:
     return MCPOAuthSettings(
         enabled=True,
         resource_url=resource_url,
-        resource_identifier=resource_identifier or resource_url,
+        resource_identifier=resource_identifier,
         issuer_url="https://idp.example.test/realms/nvcm",
         client_id="nvcm-cli",
         scopes=("openid", "email", "profile"),

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -160,6 +160,19 @@ def test_configured_oauth_metadata_path_bypasses_service_auth(
     assert response.json()["resource"] == "https://svc-mcp.config-manager.local/custom/mcp"
 
 
+def test_oauth_metadata_can_advertise_distinct_resource_identifier() -> None:
+    oauth_settings = _oauth_settings(resource_identifier="api://nvcm-api")
+
+    with TestClient(
+        create_app(_settings(), oauth_settings),
+        base_url="https://svc-mcp.config-manager.local",
+    ) as client:
+        response = client.get("/.well-known/oauth-protected-resource/mcp")
+
+    assert response.status_code == 200
+    assert response.json()["resource"] == "api://nvcm-api"
+
+
 def test_oauth_metadata_endpoints_not_registered_when_disabled() -> None:
     client = TestClient(create_app(_settings(), MCPOAuthSettings(enabled=False)))
 
@@ -227,10 +240,12 @@ def _settings() -> MCPSettings:
 
 def _oauth_settings(
     resource_url: str = "https://svc-mcp.config-manager.local/mcp",
+    resource_identifier: str | None = None,
 ) -> MCPOAuthSettings:
     return MCPOAuthSettings(
         enabled=True,
         resource_url=resource_url,
+        resource_identifier=resource_identifier or resource_url,
         issuer_url="https://idp.example.test/realms/nvcm",
         client_id="nvcm-cli",
         scopes=("openid", "email", "profile"),

--- a/src/tests/mcp/test_settings.py
+++ b/src/tests/mcp/test_settings.py
@@ -99,6 +99,7 @@ def test_mcp_oauth_settings_parse_metadata_config() -> None:
 
     assert settings.enabled is True
     assert settings.resource_url == "https://svc-mcp.example.test/mcp"
+    assert settings.resource_identifier == "https://svc-mcp.example.test/mcp"
     assert settings.issuer_url == "https://idp.example.test/realms/nvcm"
     assert settings.client_id == "nvcm-cli"
     assert settings.scopes == ("openid", "email", "profile")
@@ -112,6 +113,20 @@ def test_mcp_oauth_settings_parse_metadata_config() -> None:
         "/.well-known/oauth-protected-resource/mcp",
         "/.well-known/oauth-authorization-server",
     }
+
+
+def test_mcp_oauth_settings_accepts_distinct_resource_identifier() -> None:
+    config = _oauth_config()
+    config["mcp.oauth"]["resource_identifier"] = "api://client-id/"
+
+    settings = MCPOAuthSettings.from_config(config)
+
+    assert settings.resource_url == "https://svc-mcp.example.test/mcp"
+    assert settings.resource_identifier == "api://client-id"
+    assert (
+        settings.resource_metadata_url
+        == "https://svc-mcp.example.test/.well-known/oauth-protected-resource/mcp"
+    )
 
 
 def test_mcp_oauth_well_known_paths_follow_resource_url_path() -> None:

--- a/src/tests/mcp/test_settings.py
+++ b/src/tests/mcp/test_settings.py
@@ -94,6 +94,15 @@ def test_mcp_oauth_settings_disabled_without_section() -> None:
     assert settings.enabled is False
 
 
+def test_mcp_oauth_settings_direct_construction_defaults_resource_identifier() -> None:
+    settings = MCPOAuthSettings(
+        enabled=True,
+        resource_url="https://svc-mcp.example.test/mcp",
+    )
+
+    assert settings.resource_identifier == "https://svc-mcp.example.test/mcp"
+
+
 def test_mcp_oauth_settings_parse_metadata_config() -> None:
     settings = MCPOAuthSettings.from_config(_oauth_config())
 

--- a/src/tests/mcp/test_settings.py
+++ b/src/tests/mcp/test_settings.py
@@ -94,21 +94,11 @@ def test_mcp_oauth_settings_disabled_without_section() -> None:
     assert settings.enabled is False
 
 
-def test_mcp_oauth_settings_direct_construction_defaults_resource_identifier() -> None:
-    settings = MCPOAuthSettings(
-        enabled=True,
-        resource_url="https://svc-mcp.example.test/mcp",
-    )
-
-    assert settings.resource_identifier == "https://svc-mcp.example.test/mcp"
-
-
 def test_mcp_oauth_settings_parse_metadata_config() -> None:
     settings = MCPOAuthSettings.from_config(_oauth_config())
 
     assert settings.enabled is True
     assert settings.resource_url == "https://svc-mcp.example.test/mcp"
-    assert settings.resource_identifier == "https://svc-mcp.example.test/mcp"
     assert settings.issuer_url == "https://idp.example.test/realms/nvcm"
     assert settings.client_id == "nvcm-cli"
     assert settings.scopes == ("openid", "email", "profile")
@@ -117,6 +107,8 @@ def test_mcp_oauth_settings_parse_metadata_config() -> None:
         == "https://svc-mcp.example.test/.well-known/oauth-protected-resource/mcp"
     )
     assert settings.authorization_server_url == "https://svc-mcp.example.test"
+    assert settings.forward_resource_parameter is True
+    assert settings.oauth_proxy_paths == frozenset()
     assert settings.well_known_paths == {
         "/.well-known/oauth-protected-resource",
         "/.well-known/oauth-protected-resource/mcp",
@@ -124,18 +116,21 @@ def test_mcp_oauth_settings_parse_metadata_config() -> None:
     }
 
 
-def test_mcp_oauth_settings_accepts_distinct_resource_identifier() -> None:
+def test_mcp_oauth_settings_supports_resource_parameter_compatibility_proxy() -> None:
     config = _oauth_config()
-    config["mcp.oauth"]["resource_identifier"] = "api://client-id/"
+    config["mcp.oauth"]["forward_resource_parameter"] = "false"
 
     settings = MCPOAuthSettings.from_config(config)
 
-    assert settings.resource_url == "https://svc-mcp.example.test/mcp"
-    assert settings.resource_identifier == "api://client-id"
-    assert (
-        settings.resource_metadata_url
-        == "https://svc-mcp.example.test/.well-known/oauth-protected-resource/mcp"
-    )
+    assert settings.forward_resource_parameter is False
+    assert settings.authorization_proxy_url == "https://svc-mcp.example.test/oauth/authorize"
+    assert settings.callback_proxy_url == "https://svc-mcp.example.test/oauth/callback"
+    assert settings.token_proxy_url == "https://svc-mcp.example.test/oauth/token"
+    assert settings.oauth_proxy_paths == {
+        "/oauth/authorize",
+        "/oauth/callback",
+        "/oauth/token",
+    }
 
 
 def test_mcp_oauth_well_known_paths_follow_resource_url_path() -> None:
@@ -155,9 +150,18 @@ def test_mcp_oauth_well_known_paths_follow_resource_url_path() -> None:
     }
 
 
-def test_mcp_oauth_settings_requires_valid_urls_when_enabled() -> None:
+@pytest.mark.parametrize(
+    "resource_url",
+    [
+        "svc-mcp.example.test/mcp",
+        "http://svc-mcp.example.test/mcp",
+        "https://svc-mcp.example.test/mcp?tenant=test",
+        "https://svc-mcp.example.test/mcp#fragment",
+    ],
+)
+def test_mcp_oauth_settings_requires_rfc_9728_resource_url(resource_url: str) -> None:
     config = _oauth_config()
-    config["mcp.oauth"]["resource_url"] = "svc-mcp.example.test/mcp"
+    config["mcp.oauth"]["resource_url"] = resource_url
 
     with pytest.raises(ValueError, match="resource_url"):
         MCPOAuthSettings.from_config(config)


### PR DESCRIPTION
## Description

Updated MCP OAuth metadata to support Azure AD resource identifiers separately from the MCP endpoint URL. The chart now renders mcp.auth.oauth.resourceIdentifier into mcp-auth.ini, and the MCP protected-resource metadata advertises that value as resource while still using resourceUrl for the actual MCP endpoint/metadata path.

This fixes Azure rejecting MCP auth with AADSTS9010010 when clients send resource=https://svc-mcp.../mcp alongside api://... scopes. 

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/28418767146/job/84207319266

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added `forwardResourceParameter` OAuth setting, including a compatibility-proxy mode that strips RFC 8707 `resource`, adjusts redirects, and routes `/oauth/authorize`, `/oauth/callback`, and `/oauth/token`.
  * Installer config now derives forwarding behavior from the selected SSO provider.

* **Bug Fixes**
  * OAuth protected-resource and authorization-server metadata now matches the active forwarding mode.
  * Updated Azure OIDC default scopes and tightened `resource_url` validation (RFC 9728 rules).

* **Documentation**
  * Refreshed MCP OAuth guidance (including Entra compatibility) and added Claude Code MCP setup steps.

* **Chores**
  * `make install-cert` now installs the gateway TLS certificate on macOS and Linux trust stores.
  * Keycloak CLI client now optionally includes `offline_access`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->