### PR TITLE
some ergonomic fixes for site level workflows

### DIFF
--- a/bindings/go/temporal/model_site_cable_validation_input.go
+++ b/bindings/go/temporal/model_site_cable_validation_input.go
@@ -32,7 +32,7 @@ type SiteCableValidationInput struct {
 	// Device statuses used to filter the selected network devices.
 	Status []string `json:"status,omitempty"`
 	// Tenant used to filter the selected network devices.
-	Tenant *string `json:"tenant,omitempty"`
+	Tenant NullableString `json:"tenant,omitempty"`
 }
 
 type _SiteCableValidationInput SiteCableValidationInput
@@ -46,8 +46,6 @@ func NewSiteCableValidationInput(site string) *SiteCableValidationInput {
 	var raiseForInvalid bool = false
 	this.RaiseForInvalid = &raiseForInvalid
 	this.Site = site
-	var tenant string = "nsv"
-	this.Tenant = &tenant
 	return &this
 }
 
@@ -58,8 +56,6 @@ func NewSiteCableValidationInputWithDefaults() *SiteCableValidationInput {
 	this := SiteCableValidationInput{}
 	var raiseForInvalid bool = false
 	this.RaiseForInvalid = &raiseForInvalid
-	var tenant string = "nsv"
-	this.Tenant = &tenant
 	return &this
 }
 
@@ -219,37 +215,49 @@ func (o *SiteCableValidationInput) SetStatus(v []string) {
 	o.Status = v
 }
 
-// GetTenant returns the Tenant field value if set, zero value otherwise.
+// GetTenant returns the Tenant field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *SiteCableValidationInput) GetTenant() string {
-	if o == nil || IsNil(o.Tenant) {
+	if o == nil || IsNil(o.Tenant.Get()) {
 		var ret string
 		return ret
 	}
-	return *o.Tenant
+	return *o.Tenant.Get()
 }
 
 // GetTenantOk returns a tuple with the Tenant field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+
 func (o *SiteCableValidationInput) GetTenantOk() (*string, bool) {
-	if o == nil || IsNil(o.Tenant) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Tenant, true
+	return o.Tenant.Get(), o.Tenant.IsSet()
 }
 
 // HasTenant returns a boolean if a field has been set.
 func (o *SiteCableValidationInput) HasTenant() bool {
-	if o != nil && !IsNil(o.Tenant) {
+	if o != nil && o.Tenant.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetTenant gets a reference to the given string and assigns it to the Tenant field.
+// SetTenant gets a reference to the given NullableString and assigns it to the Tenant field.
 func (o *SiteCableValidationInput) SetTenant(v string) {
-	o.Tenant = &v
+	o.Tenant.Set(&v)
+}
+
+// SetTenantNil sets the value for Tenant to be an explicit nil
+func (o *SiteCableValidationInput) SetTenantNil() {
+	o.Tenant.Set(nil)
+}
+
+// UnsetTenant ensures that no value is present for Tenant, not even an explicit nil
+func (o *SiteCableValidationInput) UnsetTenant() {
+	o.Tenant.Unset()
 }
 
 func (o SiteCableValidationInput) MarshalJSON() ([]byte, error) {
@@ -275,8 +283,8 @@ func (o SiteCableValidationInput) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
-	if !IsNil(o.Tenant) {
-		toSerialize["tenant"] = o.Tenant
+	if o.Tenant.IsSet() {
+		toSerialize["tenant"] = o.Tenant.Get()
 	}
 	return toSerialize, nil
 }

--- a/bindings/go/temporal/model_site_password_rotation_input.go
+++ b/bindings/go/temporal/model_site_password_rotation_input.go
@@ -30,7 +30,7 @@ type SitePasswordRotationInput struct {
 	// Device statuses used to filter the selected network devices.
 	Status []string `json:"status,omitempty"`
 	// Tenant used to filter the selected network devices.
-	Tenant *string `json:"tenant,omitempty"`
+	Tenant NullableString `json:"tenant,omitempty"`
 }
 
 type _SitePasswordRotationInput SitePasswordRotationInput
@@ -43,8 +43,6 @@ func NewSitePasswordRotationInput(location string, selectedSecret string) *SiteP
 	this := SitePasswordRotationInput{}
 	this.Location = location
 	this.SelectedSecret = selectedSecret
-	var tenant string = "NGC"
-	this.Tenant = &tenant
 	return &this
 }
 
@@ -53,8 +51,6 @@ func NewSitePasswordRotationInput(location string, selectedSecret string) *SiteP
 // but it doesn't guarantee that properties required by API are set
 func NewSitePasswordRotationInputWithDefaults() *SitePasswordRotationInput {
 	this := SitePasswordRotationInput{}
-	var tenant string = "NGC"
-	this.Tenant = &tenant
 	return &this
 }
 
@@ -172,37 +168,49 @@ func (o *SitePasswordRotationInput) SetStatus(v []string) {
 	o.Status = v
 }
 
-// GetTenant returns the Tenant field value if set, zero value otherwise.
+// GetTenant returns the Tenant field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *SitePasswordRotationInput) GetTenant() string {
-	if o == nil || IsNil(o.Tenant) {
+	if o == nil || IsNil(o.Tenant.Get()) {
 		var ret string
 		return ret
 	}
-	return *o.Tenant
+	return *o.Tenant.Get()
 }
 
 // GetTenantOk returns a tuple with the Tenant field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+
 func (o *SitePasswordRotationInput) GetTenantOk() (*string, bool) {
-	if o == nil || IsNil(o.Tenant) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Tenant, true
+	return o.Tenant.Get(), o.Tenant.IsSet()
 }
 
 // HasTenant returns a boolean if a field has been set.
 func (o *SitePasswordRotationInput) HasTenant() bool {
-	if o != nil && !IsNil(o.Tenant) {
+	if o != nil && o.Tenant.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetTenant gets a reference to the given string and assigns it to the Tenant field.
+// SetTenant gets a reference to the given NullableString and assigns it to the Tenant field.
 func (o *SitePasswordRotationInput) SetTenant(v string) {
-	o.Tenant = &v
+	o.Tenant.Set(&v)
+}
+
+// SetTenantNil sets the value for Tenant to be an explicit nil
+func (o *SitePasswordRotationInput) SetTenantNil() {
+	o.Tenant.Set(nil)
+}
+
+// UnsetTenant ensures that no value is present for Tenant, not even an explicit nil
+func (o *SitePasswordRotationInput) UnsetTenant() {
+	o.Tenant.Unset()
 }
 
 func (o SitePasswordRotationInput) MarshalJSON() ([]byte, error) {
@@ -223,8 +231,8 @@ func (o SitePasswordRotationInput) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
-	if !IsNil(o.Tenant) {
-		toSerialize["tenant"] = o.Tenant
+	if o.Tenant.IsSet() {
+		toSerialize["tenant"] = o.Tenant.Get()
 	}
 	return toSerialize, nil
 }

--- a/bindings/go/temporal/model_validate_hardware_input.go
+++ b/bindings/go/temporal/model_validate_hardware_input.go
@@ -32,7 +32,7 @@ type ValidateHardwareInput struct {
 	// Device statuses used to filter the selected network devices.
 	Status []string `json:"status,omitempty"`
 	// Tenant used to filter the selected network devices.
-	Tenant string `json:"tenant"`
+	Tenant NullableString `json:"tenant,omitempty"`
 }
 
 type _ValidateHardwareInput ValidateHardwareInput
@@ -41,12 +41,11 @@ type _ValidateHardwareInput ValidateHardwareInput
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewValidateHardwareInput(site string, tenant string) *ValidateHardwareInput {
+func NewValidateHardwareInput(site string) *ValidateHardwareInput {
 	this := ValidateHardwareInput{}
 	var raiseForInvalid bool = false
 	this.RaiseForInvalid = &raiseForInvalid
 	this.Site = site
-	this.Tenant = tenant
 	return &this
 }
 
@@ -216,28 +215,49 @@ func (o *ValidateHardwareInput) SetStatus(v []string) {
 	o.Status = v
 }
 
-// GetTenant returns the Tenant field value
+// GetTenant returns the Tenant field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *ValidateHardwareInput) GetTenant() string {
-	if o == nil {
+	if o == nil || IsNil(o.Tenant.Get()) {
 		var ret string
 		return ret
 	}
-
-	return o.Tenant
+	return *o.Tenant.Get()
 }
 
-// GetTenantOk returns a tuple with the Tenant field value
+// GetTenantOk returns a tuple with the Tenant field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+
 func (o *ValidateHardwareInput) GetTenantOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Tenant, true
+	return o.Tenant.Get(), o.Tenant.IsSet()
 }
 
-// SetTenant sets field value
+// HasTenant returns a boolean if a field has been set.
+func (o *ValidateHardwareInput) HasTenant() bool {
+	if o != nil && o.Tenant.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetTenant gets a reference to the given NullableString and assigns it to the Tenant field.
 func (o *ValidateHardwareInput) SetTenant(v string) {
-	o.Tenant = v
+	o.Tenant.Set(&v)
+}
+
+// SetTenantNil sets the value for Tenant to be an explicit nil
+func (o *ValidateHardwareInput) SetTenantNil() {
+	o.Tenant.Set(nil)
+}
+
+// UnsetTenant ensures that no value is present for Tenant, not even an explicit nil
+func (o *ValidateHardwareInput) UnsetTenant() {
+	o.Tenant.Unset()
 }
 
 func (o ValidateHardwareInput) MarshalJSON() ([]byte, error) {
@@ -263,7 +283,9 @@ func (o ValidateHardwareInput) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
-	toSerialize["tenant"] = o.Tenant
+	if o.Tenant.IsSet() {
+		toSerialize["tenant"] = o.Tenant.Get()
+	}
 	return toSerialize, nil
 }
 
@@ -272,8 +294,7 @@ func (o *ValidateHardwareInput) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := map[string]bool{
-		"site":   false,
-		"tenant": false,
+		"site": false,
 	}
 
 	allProperties := make(map[string]interface{})

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -1277,19 +1277,7 @@
             "type": "boolean"
           },
           "roles": {
-            "default": [
-              "tan-bbr",
-              "cin-core",
-              "cin-spine",
-              "cin-leaf",
-              "tan-core",
-              "tan-spine",
-              "tan-leaf",
-              "smn-core",
-              "smn-spine",
-              "smn-leaf",
-              "smn-aggleaf"
-            ],
+            "default": [],
             "description": "Device roles used to filter the selected network devices.",
             "items": {
               "type": "string"
@@ -1304,8 +1292,8 @@
           },
           "status": {
             "default": [
-              "active",
-              "provisioning"
+              "Active",
+              "Provisioned"
             ],
             "description": "Device statuses used to filter the selected network devices.",
             "items": {
@@ -1315,10 +1303,16 @@
             "type": "array"
           },
           "tenant": {
-            "default": "nsv",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Tenant used to filter the selected network devices.",
-            "title": "Tenant",
-            "type": "string"
+            "title": "Tenant"
           }
         },
         "required": [
@@ -1336,15 +1330,7 @@
             "type": "string"
           },
           "roles": {
-            "default": [
-              "TAN-Core",
-              "TAN-Spine",
-              "TAN-Leaf",
-              "SMN-Core",
-              "SMN-Spine",
-              "SMN-Leaf",
-              "SMN-Aggleaf"
-            ],
+            "default": [],
             "description": "Device roles used to filter the selected network devices.",
             "items": {
               "type": "string"
@@ -1370,10 +1356,16 @@
             "type": "array"
           },
           "tenant": {
-            "default": "NGC",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Tenant used to filter the selected network devices.",
-            "title": "Tenant",
-            "type": "string"
+            "title": "Tenant"
           }
         },
         "required": [
@@ -1876,7 +1868,10 @@
             "type": "string"
           },
           "status": {
-            "default": [],
+            "default": [
+              "Active",
+              "Provisioned"
+            ],
             "description": "Device statuses used to filter the selected network devices.",
             "items": {
               "type": "string"
@@ -1885,14 +1880,20 @@
             "type": "array"
           },
           "tenant": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Tenant used to filter the selected network devices.",
-            "title": "Tenant",
-            "type": "string"
+            "title": "Tenant"
           }
         },
         "required": [
-          "site",
-          "tenant"
+          "site"
         ],
         "title": "ValidateHardwareInput",
         "type": "object"

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -1326,6 +1326,7 @@
         "properties": {
           "location": {
             "description": "Location containing the devices to update.",
+            "minLength": 1,
             "title": "Location",
             "type": "string"
           },

--- a/src/nv_config_manager/mcp/tools.py
+++ b/src/nv_config_manager/mcp/tools.py
@@ -330,12 +330,12 @@ def _register_workflow_starter(
     run_workflow.__name__ = workflow.tool_name
     cast(Any, run_workflow).__signature__ = _workflow_tool_signature(workflow)
     run_workflow.__doc__ = (
-        f"{workflow.description}\n\n"
+        f"{workflow.tool_description}\n\n"
         "Pass the workflow input fields shown in this tool's input schema. "
         "Use `workflow_ui_href` as the end-user Config Manager workflow link. "
         "The response includes the workflow input schema for reference."
     )
-    server.tool(name=workflow.tool_name, description=workflow.description)(run_workflow)
+    server.tool(name=workflow.tool_name, description=workflow.tool_description)(run_workflow)
 
 
 def _workflow_tool_signature(workflow: MCPWorkflow) -> inspect.Signature:

--- a/src/nv_config_manager/mcp/workflows.py
+++ b/src/nv_config_manager/mcp/workflows.py
@@ -27,6 +27,30 @@ from nv_config_manager.temporal.hello_world.workflows import (
 )
 from nv_config_manager.temporal.ngc.workflows import REGISTERED_WORKFLOWS as NGC_WORKFLOWS
 
+SITE_LEVEL_DEVICE_FILTER_FIELDS = frozenset(
+    {"site", "roles", "status", "tenant", "device_type_ids"}
+)
+DEFAULT_SITE_LEVEL_DEVICE_STATUS = ["Active", "Provisioned"]
+SITE_LEVEL_DEVICE_FILTER_PROMPT = (
+    "Site-level device filter guidance: this workflow targets every device matching "
+    "`site`, `status`, and optional `roles`, `tenant`, and `device_type_ids`; it does "
+    "not accept a single `device_id`. `status` defaults to `Active` and `Provisioned` "
+    "when the user does not provide one. If the user asks for one named device, first "
+    "resolve that device with `get_device_id`, `search_devices`, or `query_nautobot`. "
+    "Build the narrowest supported filter from the resolved Nautobot device: `site` "
+    "from the device location/site ID, `status` from the device status name if the "
+    "user did not provide status, `roles` as a one-item list containing the role name "
+    "when available, `tenant` from the tenant name when available, and "
+    "`device_type_ids` as a one-item list containing the device type ID when "
+    "available. Before starting the workflow, run `query_nautobot` with those same "
+    "filters against `devices(location:, status:, role:, tenant:, device_type:, "
+    "nv_config_manager_device_status: true)`, then tell the user how many managed "
+    "devices match, identify the requested device, and list any other matched devices "
+    "that will also be included. If no filter can match only the requested device, say "
+    "that this is a site-level workflow and get explicit confirmation before starting "
+    "it."
+)
+
 
 @dataclass(frozen=True)
 class MCPWorkflow:
@@ -37,6 +61,7 @@ class MCPWorkflow:
     description: str
     endpoint: str
     input_class: type[BaseModel]
+    tool_prompt: str | None = None
 
     @property
     def input_schema(self) -> dict[str, Any]:
@@ -59,6 +84,13 @@ class MCPWorkflow:
         else:
             schema.pop("required", None)
         return schema
+
+    @property
+    def tool_description(self) -> str:
+        """Return the full MCP tool description shown to agent clients."""
+        if not self.tool_prompt:
+            return self.description
+        return f"{self.description}\n\n{self.tool_prompt}"
 
 
 def discover_mcp_workflows() -> list[MCPWorkflow]:
@@ -86,6 +118,7 @@ def discover_mcp_workflows() -> list[MCPWorkflow]:
                 description=metadata_workflow.get_workflow_description(),
                 endpoint=endpoint,
                 input_class=input_class,
+                tool_prompt=_tool_prompt_for_input_class(input_class),
             )
         )
     return sorted(workflows, key=lambda workflow: workflow.tool_name)
@@ -101,6 +134,9 @@ def normalize_workflow_parameters(
     if "trigger" in fields and "trigger" not in normalized:
         normalized["trigger"] = "API"
 
+    if _tool_prompt_for_input_class(workflow.input_class) and not normalized.get("status"):
+        normalized["status"] = DEFAULT_SITE_LEVEL_DEVICE_STATUS.copy()
+
     for field_name, field_info in fields.items():
         if field_name in normalized:
             continue
@@ -113,6 +149,13 @@ def normalize_workflow_parameters(
 def _tool_name_from_endpoint(endpoint: str) -> str:
     slug = endpoint.strip("/").split("/")[-1]
     return f"run_{slug.replace('-', '_')}"
+
+
+def _tool_prompt_for_input_class(input_class: type[BaseModel]) -> str | None:
+    field_names = set(input_class.model_fields)
+    if SITE_LEVEL_DEVICE_FILTER_FIELDS.issubset(field_names):
+        return SITE_LEVEL_DEVICE_FILTER_PROMPT
+    return None
 
 
 def allows_none(annotation: Any) -> bool:

--- a/src/nv_config_manager/mcp/workflows.py
+++ b/src/nv_config_manager/mcp/workflows.py
@@ -134,7 +134,7 @@ def normalize_workflow_parameters(
     if "trigger" in fields and "trigger" not in normalized:
         normalized["trigger"] = "API"
 
-    if _tool_prompt_for_input_class(workflow.input_class) and not normalized.get("status"):
+    if _tool_prompt_for_input_class(workflow.input_class) and "status" not in normalized:
         normalized["status"] = DEFAULT_SITE_LEVEL_DEVICE_STATUS.copy()
 
     for field_name, field_info in fields.items():

--- a/src/nv_config_manager/temporal/client/nautobot.py
+++ b/src/nv_config_manager/temporal/client/nautobot.py
@@ -89,7 +89,7 @@ class NautobotClient(BaseNautobotClient):
         try:
             return await super().graphql_query(query, variables, timeout)
         except NautobotException as e:
-            raise ApplicationError(str(e)) from e
+            raise ApplicationError(str(e), non_retryable=True) from e
 
     async def get_device(self, fields: str, device_id: str) -> Any:
         """Query device by device UUID."""
@@ -229,9 +229,10 @@ class NautobotClient(BaseNautobotClient):
         mac_address: str | list[str] | None,
         device_ids: str | list[str] | None,
         platform: Platform | list[Platform] | None,
-    ) -> dict[str, list[str]]:
+        managed_only: bool | None,
+    ) -> dict[str, list[str] | bool]:
         """Build variables dictionary for device filtering."""
-        variables: dict[str, list[str]] = {}
+        variables: dict[str, list[str] | bool] = {}
 
         if site:
             variables["site"] = self._normalize_to_list(site)
@@ -253,6 +254,8 @@ class NautobotClient(BaseNautobotClient):
                 if isinstance(platform, list | tuple)
                 else [platform.nautobot_name]
             )
+        if managed_only is not None:
+            variables["managed_only"] = managed_only
 
         if not variables:
             raise NautobotException("Must apply at least one filter.")
@@ -290,10 +293,19 @@ class NautobotClient(BaseNautobotClient):
         mac_address: str | list[str] | None = None,
         device_ids: str | list[str] | None = None,
         platform: Platform | list[Platform] | None = None,
+        managed_only: bool | None = None,
     ) -> list[dict[str, Any]]:
         """Return a filtered list of devices."""
         variables = self._build_device_filter_variables(
-            site, status, role, tenant, device_type_id, mac_address, device_ids, platform
+            site,
+            status,
+            role,
+            tenant,
+            device_type_id,
+            mac_address,
+            device_ids,
+            platform,
+            managed_only,
         )
 
         query = (
@@ -306,7 +318,8 @@ class NautobotClient(BaseNautobotClient):
               $device_type_id: [String],
               $mac_address: [String],
               $device_ids: [String],
-              $platform: [String]
+              $platform: [String],
+              $managed_only: Boolean
             ) {
               devices(
                 location: $site,
@@ -316,7 +329,8 @@ class NautobotClient(BaseNautobotClient):
                 device_type: $device_type_id,
                 mac_address: $mac_address,
                 id: $device_ids,
-                platform: $platform
+                platform: $platform,
+                nv_config_manager_device_status: $managed_only
               ) {
         """
             f"{fields}"

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -115,6 +115,7 @@ class GetNetworkDevicesInput(BaseModel):
     deploy_enabled: bool | None = None
     backup_enabled: bool | None = None
     ztp_enabled: bool | None = None
+    managed_only: bool | None = None
     platforms: list[Platform] | None = None
 
 
@@ -143,6 +144,7 @@ async def get_network_devices(
             deploy_enabled=activity_input.deploy_enabled,
             backup_enabled=activity_input.backup_enabled,
             ztp_enabled=activity_input.ztp_enabled,
+            managed_only=activity_input.managed_only,
             platform=activity_input.platforms,
         )
     return GetNetworkDevicesOutput(devices=devices)

--- a/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
@@ -85,21 +85,8 @@ with workflow.unsafe.imports_passed_through():
 
 ACTIVITY_NO_RETRY_POLICY = RetryPolicy(maximum_attempts=1)
 DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=3)
-DEFAULT_CONFIG_MANAGER_ROLES = [
-    "tan-bbr",
-    "cin-core",
-    "cin-spine",
-    "cin-leaf",
-    "tan-core",
-    "tan-spine",
-    "tan-leaf",
-    "smn-core",
-    "smn-spine",
-    "smn-leaf",
-    "smn-aggleaf",
-]
-DEFAULT_CONFIG_MANAGER_STATUS = ["active", "provisioning"]
-DEFAULT_CONFIG_MANAGER_TENANT = "nsv"
+DEFAULT_CONFIG_MANAGER_STATUS = ["Active", "Provisioned"]
+DEFAULT_CONFIG_MANAGER_TENANT = None
 # list of search attributes to clone from parent to child
 CLONE_SEARCH_ATTRS = [
     USER_SEARCH_ATTRIBUTE,
@@ -118,14 +105,14 @@ class SiteCableValidationInput(BaseModel):
 
     site: str = Field(description="Site containing the network devices to validate.")
     roles: list[str] = Field(
-        default=DEFAULT_CONFIG_MANAGER_ROLES,
+        default=[],
         description="Device roles used to filter the selected network devices.",
     )
     status: list[str] = Field(
         default=DEFAULT_CONFIG_MANAGER_STATUS,
         description="Device statuses used to filter the selected network devices.",
     )
-    tenant: str = Field(
+    tenant: str | None = Field(
         default=DEFAULT_CONFIG_MANAGER_TENANT,
         description="Tenant used to filter the selected network devices.",
     )
@@ -212,7 +199,7 @@ class SiteCableValidationWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixi
         site: str
         roles: list[str]
         status: list[str]
-        tenant: str
+        tenant: str | None
         device_type_ids: list[str]
 
     class GetDevicesStageOutput(StageOutput):
@@ -233,6 +220,7 @@ class SiteCableValidationWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixi
                 status=stage_input.status,
                 tenant=stage_input.tenant,
                 device_type_ids=stage_input.device_type_ids,
+                managed_only=True,
                 platforms=SUPPORTED_PLATFORMS,
             ),
             start_to_close_timeout=timedelta(minutes=1),

--- a/src/nv_config_manager/temporal/ngc/workflows/cumulus_hardware_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cumulus_hardware_validation.py
@@ -971,24 +971,12 @@ class ValidateHardwareWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, A
             ]:
                 self.set_stage_state(stage_name, StateEnum.UNREACHABLE)
 
-            filter_summary = format_filter_summary(
-                workflow_input.site,
-                workflow_input.roles,
-                workflow_input.status,
-                workflow_input.tenant,
-                workflow_input.device_type_ids,
-            )
-            message = (
-                devices_to_validate_output.display
-                if devices_to_validate_output.invalid_filter
-                else f"No devices matched the hardware validation filter ({filter_summary})."
-            )
             await self.archive_results()
             return HardwareValidationResult(
                 success=False,
                 devices_validated=0,
                 total_entries=0,
-                message=message,
+                message=devices_to_validate_output.display,
             )
 
         device_output = await self.get_device_info(

--- a/src/nv_config_manager/temporal/ngc/workflows/cumulus_hardware_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cumulus_hardware_validation.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Hardware Validation Workflow Definition."""
 
+import ast
 import asyncio
 from datetime import timedelta
 from typing import Any
@@ -21,6 +22,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import ActivityError
 
 from nv_config_manager.temporal.common.decorators.workflow import run_nv_config_manager_workflow
 from nv_config_manager.temporal.common.mixins.metadata import WorkflowMetadataMixin
@@ -28,6 +30,7 @@ from nv_config_manager.temporal.common.mixins.stage import (
     StageInput,
     StageMixin,
     StageOutput,
+    StateEnum,
     stage_executor,
 )
 from nv_config_manager.temporal.common.search_attributes import SITE_SEARCH_ATTRIBUTE
@@ -55,6 +58,74 @@ with workflow.unsafe.imports_passed_through():
 
 DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=5)
 DEVICE_QUERY_START_TO_CLOSE_TIMEOUT = timedelta(seconds=30)
+DEFAULT_HARDWARE_VALIDATION_STATUS = ["Active", "Provisioned"]
+
+
+def format_filter_summary(
+    site: str,
+    roles: list[str],
+    status: list[str],
+    tenant: str | None,
+    device_type_ids: list[str],
+) -> str:
+    """Return a concise hardware validation filter summary."""
+    role_summary = roles if roles else "any"
+    tenant_summary = tenant or "any"
+    device_type_summary = device_type_ids if device_type_ids else "any"
+    return (
+        f"site={site}, roles={role_summary}, status={status}, "
+        f"tenant={tenant_summary}, device_type_ids={device_type_summary}"
+    )
+
+
+def is_device_filter_error(error_message: str) -> bool:
+    """Return whether an activity failure came from an invalid device filter."""
+    return (
+        "GraphQL error:" in error_message
+        or "GraphQL errors:" in error_message
+        or "Must apply at least one filter" in error_message
+    )
+
+
+def format_device_filter_error(error_message: str) -> str:
+    """Format a GraphQL filter validation error for workflow display."""
+    for prefix in ("GraphQL error:", "GraphQL errors:"):
+        if error_message.startswith(prefix):
+            error_message = error_message.removeprefix(prefix).strip()
+            break
+    return _format_error_value(_parse_error_literal(error_message))
+
+
+def _parse_error_literal(value: str) -> Any:
+    stripped = value.strip()
+    if not stripped.startswith(("{", "[")):
+        return stripped
+    try:
+        return ast.literal_eval(stripped)
+    except (SyntaxError, ValueError):
+        return stripped
+
+
+def _format_error_value(value: Any) -> str:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.startswith(("{", "[")):
+            parsed = _parse_error_literal(stripped)
+            if not isinstance(parsed, str) or parsed != stripped:
+                return _format_error_value(parsed)
+        return value
+    if isinstance(value, list):
+        return "; ".join(_format_error_value(item) for item in value)
+    if isinstance(value, dict):
+        parts = []
+        for key, item in value.items():
+            formatted_item = _format_error_value(item)
+            if key == "message":
+                parts.append(formatted_item)
+            else:
+                parts.append(f"{key}: {formatted_item}")
+        return "; ".join(parts)
+    return str(value)
 
 
 def analyze_error_results(
@@ -199,9 +270,13 @@ class ValidateHardwareInput(BaseModel):
         default=[], description="Device roles used to filter the selected network devices."
     )
     status: list[str] = Field(
-        default=[], description="Device statuses used to filter the selected network devices."
+        default=DEFAULT_HARDWARE_VALIDATION_STATUS,
+        description="Device statuses used to filter the selected network devices.",
     )
-    tenant: str = Field(description="Tenant used to filter the selected network devices.")
+    tenant: str | None = Field(
+        default=None,
+        description="Tenant used to filter the selected network devices.",
+    )
     device_type_ids: list[str] = Field(
         default=[], description="Device type identifiers used to filter network devices."
     )
@@ -295,13 +370,14 @@ class ValidateHardwareWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, A
         site: str
         roles: list[str]
         status: list[str]
-        tenant: str
+        tenant: str | None
         device_type_ids: list[str]
 
     class GetDevicesToValidateStageOutput(StageOutput):
         """Get Devices to Validate Stage Output."""
 
         devices: list[NetworkDeviceData]
+        invalid_filter: bool = False
 
     class GetDeviceStageInput(StageInput):
         """Get Device Stage Input."""
@@ -346,18 +422,40 @@ class ValidateHardwareWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, A
         self, stage_input: GetDevicesToValidateStageInput
     ) -> GetDevicesToValidateStageOutput:
         """Query devices based on filtering criteria."""
-        result = await workflow.execute_activity(
-            get_network_devices,
-            GetNetworkDevicesInput(
-                site=stage_input.site,
-                roles=stage_input.roles,
-                status=stage_input.status,
-                tenant=stage_input.tenant,
-                device_type_ids=stage_input.device_type_ids,
-            ),
-            start_to_close_timeout=DEVICE_QUERY_START_TO_CLOSE_TIMEOUT,
-            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+        filter_summary = format_filter_summary(
+            stage_input.site,
+            stage_input.roles,
+            stage_input.status,
+            stage_input.tenant,
+            stage_input.device_type_ids,
         )
+        try:
+            result = await workflow.execute_activity(
+                get_network_devices,
+                GetNetworkDevicesInput(
+                    site=stage_input.site,
+                    roles=stage_input.roles,
+                    status=stage_input.status,
+                    tenant=stage_input.tenant,
+                    device_type_ids=stage_input.device_type_ids,
+                    managed_only=True,
+                ),
+                start_to_close_timeout=DEVICE_QUERY_START_TO_CLOSE_TIMEOUT,
+                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            )
+        except ActivityError as exc:
+            reason = str(exc.cause) if exc.cause else str(exc)
+            if not is_device_filter_error(reason):
+                raise
+            display = (
+                f"Invalid hardware validation device filter ({filter_summary}): "
+                f"{format_device_filter_error(reason)}"
+            )
+            return self.GetDevicesToValidateStageOutput(
+                devices=[],
+                invalid_filter=True,
+                display=display,
+            )
 
         # Filter devices to only include Cumulus Linux devices
         cumulus_devices = [
@@ -365,10 +463,20 @@ class ValidateHardwareWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, A
             for device in result.devices
             if device.platform and "cumulus" in device.platform.lower()
         ]
+        if not result.devices:
+            display = f"No devices matched the specified filters ({filter_summary})."
+        elif not cumulus_devices:
+            display = (
+                "No Cumulus Linux devices matched the specified filters "
+                f"({filter_summary}). Nautobot returned {len(result.devices)} "
+                "device(s), but hardware validation only runs against Cumulus Linux devices."
+            )
+        else:
+            display = f"Found {len(cumulus_devices)} Cumulus Linux devices."
 
         return self.GetDevicesToValidateStageOutput(
             devices=cumulus_devices,
-            display=f"Found {len(cumulus_devices)} Cumulus Linux devices.",
+            display=display,
         )
 
     @stage_executor("get_device_info")
@@ -849,6 +957,39 @@ class ValidateHardwareWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, A
                 device_type_ids=workflow_input.device_type_ids,
             )
         )
+
+        if not devices_to_validate_output.devices:
+            for stage_name in [
+                "get_device_info",
+                "get_platform",
+                "get_environment_fan",
+                "get_environment_led",
+                "get_environment_psu",
+                "get_environment_voltage",
+                "get_inventory",
+                "generate_consolidated_report",
+            ]:
+                self.set_stage_state(stage_name, StateEnum.UNREACHABLE)
+
+            filter_summary = format_filter_summary(
+                workflow_input.site,
+                workflow_input.roles,
+                workflow_input.status,
+                workflow_input.tenant,
+                workflow_input.device_type_ids,
+            )
+            message = (
+                devices_to_validate_output.display
+                if devices_to_validate_output.invalid_filter
+                else f"No devices matched the hardware validation filter ({filter_summary})."
+            )
+            await self.archive_results()
+            return HardwareValidationResult(
+                success=False,
+                devices_validated=0,
+                total_entries=0,
+                message=message,
+            )
 
         device_output = await self.get_device_info(
             self.GetDeviceStageInput(devices=devices_to_validate_output.devices)

--- a/src/nv_config_manager/temporal/ngc/workflows/site_password_rotation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/site_password_rotation.py
@@ -76,7 +76,10 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class SitePasswordRotationInput(BaseModel):
     """Site Password Rotation Workflow Input Definition."""
 
-    location: str = Field(description="Location containing the devices to update.")
+    location: str = Field(
+        min_length=1,
+        description="Location containing the devices to update.",
+    )
     selected_secret: str = Field(
         description="Name of the managed secret containing the replacement password."
     )

--- a/src/nv_config_manager/temporal/ngc/workflows/site_password_rotation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/site_password_rotation.py
@@ -56,17 +56,8 @@ with workflow.unsafe.imports_passed_through():
     )
 
 # Default configurations
-DEFAULT_CONFIG_MANAGER_ROLES = [
-    "TAN-Core",
-    "TAN-Spine",
-    "TAN-Leaf",
-    "SMN-Core",
-    "SMN-Spine",
-    "SMN-Leaf",
-    "SMN-Aggleaf",
-]
 DEFAULT_CONFIG_MANAGER_STATUS = ["Active", "Provisioned"]
-DEFAULT_CONFIG_MANAGER_TENANT = "NGC"
+DEFAULT_CONFIG_MANAGER_TENANT = None
 SUPPORTED_PLATFORMS = ["cumulus", "nvos"]
 
 # Search attributes to clone from parent to child workflows
@@ -90,14 +81,14 @@ class SitePasswordRotationInput(BaseModel):
         description="Name of the managed secret containing the replacement password."
     )
     roles: list[str] = Field(
-        default=DEFAULT_CONFIG_MANAGER_ROLES,
+        default=[],
         description="Device roles used to filter the selected network devices.",
     )
     status: list[str] = Field(
         default=DEFAULT_CONFIG_MANAGER_STATUS,
         description="Device statuses used to filter the selected network devices.",
     )
-    tenant: str = Field(
+    tenant: str | None = Field(
         default=DEFAULT_CONFIG_MANAGER_TENANT,
         description="Tenant used to filter the selected network devices.",
     )
@@ -151,8 +142,8 @@ class SitePasswordRotationWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixi
         """Get Devices Stage Input."""
 
         location: str
-        roles: list[str] = DEFAULT_CONFIG_MANAGER_ROLES
-        tenant: str = DEFAULT_CONFIG_MANAGER_TENANT
+        roles: list[str] = []
+        tenant: str | None = DEFAULT_CONFIG_MANAGER_TENANT
         status: list[str] = DEFAULT_CONFIG_MANAGER_STATUS
 
     class GetDevicesStageOutput(StageOutput):
@@ -170,6 +161,7 @@ class SitePasswordRotationWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixi
                 roles=stage_input.roles,
                 tenant=stage_input.tenant,
                 status=stage_input.status,
+                managed_only=True,
             ),
             start_to_close_timeout=timedelta(minutes=2),
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,

--- a/src/tests/mcp/test_tools.py
+++ b/src/tests/mcp/test_tools.py
@@ -29,6 +29,7 @@ from nv_config_manager.mcp.workflows import MCPWorkflow
 class FakeServer:
     def __init__(self) -> None:
         self.tools: dict[str, Callable[..., Any]] = {}
+        self.tool_descriptions: dict[str, str | None] = {}
 
     def tool(
         self,
@@ -36,7 +37,9 @@ class FakeServer:
         description: str | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         def decorator(function: Callable[..., Any]) -> Callable[..., Any]:
-            self.tools[name or function.__name__] = function
+            tool_name = name or function.__name__
+            self.tools[tool_name] = function
+            self.tool_descriptions[tool_name] = description
             return function
 
         return decorator
@@ -88,6 +91,7 @@ async def test_workflow_starter_promotes_config_manager_ui_href(
         description="Run a backup.",
         endpoint="/ngc/backup",
         input_class=WorkflowInput,
+        tool_prompt="Resolve the device first.",
     )
 
     tools._register_workflow_starter(server, settings, workflow)
@@ -97,6 +101,8 @@ async def test_workflow_starter_promotes_config_manager_ui_href(
     assert result["workflow_ui_href"] == (
         "https://config-manager.example.test/workflows/workflow-123"
     )
+    assert server.tool_descriptions["run_backup"] == ("Run a backup.\n\nResolve the device first.")
+    assert "Resolve the device first." in (server.tools["run_backup"].__doc__ or "")
     assert "workflow_ui_href" in (server.tools["run_backup"].__doc__ or "")
 
 

--- a/src/tests/mcp/test_workflows.py
+++ b/src/tests/mcp/test_workflows.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 from __future__ import annotations
 
-from nv_config_manager.mcp.workflows import discover_mcp_workflows, normalize_workflow_parameters
+from nv_config_manager.mcp.workflows import (
+    DEFAULT_SITE_LEVEL_DEVICE_STATUS,
+    SITE_LEVEL_DEVICE_FILTER_PROMPT,
+    discover_mcp_workflows,
+    normalize_workflow_parameters,
+)
 from nv_config_manager.temporal.common.mixins.metadata import WorkflowMetadataMixin
 from nv_config_manager.temporal.hello_world.workflows import (
     REGISTERED_WORKFLOWS as HELLO_WORLD_WORKFLOWS,
@@ -83,3 +88,34 @@ def test_workflow_input_schema_matches_normalized_mcp_parameters() -> None:
     assert schema["properties"]["trigger"]["description"]
     assert schema["properties"]["user"]["default"] is None
     assert schema["properties"]["device_id"]["description"]
+
+
+def test_site_level_filter_workflows_include_mcp_targeting_prompt() -> None:
+    workflows = {workflow.tool_name: workflow for workflow in discover_mcp_workflows()}
+
+    for tool_name in ("run_site_cable_validation", "run_cumulus_hardware_validation"):
+        assert workflows[tool_name].tool_prompt == SITE_LEVEL_DEVICE_FILTER_PROMPT
+        assert "does not accept a single `device_id`" in workflows[tool_name].tool_description
+        assert (
+            "`status` defaults to `Active` and `Provisioned`"
+            in workflows[tool_name].tool_description
+        )
+        assert "nv_config_manager_device_status: true" in workflows[tool_name].tool_description
+        assert "how many managed devices match" in workflows[tool_name].tool_description
+
+    assert workflows["run_backup"].tool_prompt is None
+    assert SITE_LEVEL_DEVICE_FILTER_PROMPT not in workflows["run_backup"].tool_description
+
+
+def test_site_level_filter_workflows_default_reachable_statuses() -> None:
+    workflows = {workflow.tool_name: workflow for workflow in discover_mcp_workflows()}
+
+    for tool_name in ("run_site_cable_validation", "run_cumulus_hardware_validation"):
+        normalized = normalize_workflow_parameters(workflows[tool_name], {"site": "PDX01"})
+        assert normalized["site"] == "PDX01"
+        assert normalized["status"] == DEFAULT_SITE_LEVEL_DEVICE_STATUS
+
+    backup_normalized = normalize_workflow_parameters(
+        workflows["run_backup"], {"device_id": "device-1"}
+    )
+    assert "status" not in backup_normalized

--- a/src/tests/mcp/test_workflows.py
+++ b/src/tests/mcp/test_workflows.py
@@ -115,6 +115,11 @@ def test_site_level_filter_workflows_default_reachable_statuses() -> None:
         assert normalized["site"] == "PDX01"
         assert normalized["status"] == DEFAULT_SITE_LEVEL_DEVICE_STATUS
 
+        unfiltered = normalize_workflow_parameters(
+            workflows[tool_name], {"site": "PDX01", "status": []}
+        )
+        assert unfiltered["status"] == []
+
     backup_normalized = normalize_workflow_parameters(
         workflows["run_backup"], {"device_id": "device-1"}
     )

--- a/src/tests/temporal/ngc/activities/test_nautobot.py
+++ b/src/tests/temporal/ngc/activities/test_nautobot.py
@@ -16,7 +16,7 @@ import pytest
 from aioresponses import aioresponses
 from temporalio.exceptions import ApplicationError
 
-from nv_config_manager.temporal.client.nautobot import DeviceVrfInfo
+from nv_config_manager.temporal.client.nautobot import DeviceVrfInfo, NautobotClient
 from nv_config_manager.temporal.common.mixins.device import (
     DeviceBayData,
     HostDeviceData,
@@ -465,8 +465,9 @@ async def test_graphql_query_error():
         )
 
         async with NautobotClient() as client:
-            with pytest.raises(ApplicationError, match="GraphQL error"):
+            with pytest.raises(ApplicationError, match="GraphQL error") as exc_info:
                 await client.graphql_query("bad query")
+            assert exc_info.value.non_retryable is True
 
 
 @pytest.mark.asyncio
@@ -668,6 +669,28 @@ async def test_device_filter_variations():
             from nv_config_manager.temporal.common.mixins.device import Platform
 
             await client.get_devices(fields="id", platform=Platform.CUMULUS_LINUX)
+
+
+@pytest.mark.asyncio
+async def test_device_filter_managed_only_variable():
+    """Test managed_only is sent as the Nautobot managed-device GraphQL filter."""
+    with aioresponses() as m:
+        m.post(
+            "https://nautobot.example.com/api/graphql/",
+            payload={"data": {"devices": []}},
+        )
+
+        async with NautobotClient() as client:
+            await client.get_devices(fields="id", site="test-site", managed_only=True)
+
+        request_call = next(iter(m.requests.values()))[0]
+        assert request_call.kwargs["json"]["variables"] == {
+            "site": ["test-site"],
+            "managed_only": True,
+        }
+        assert (
+            "nv_config_manager_device_status: $managed_only" in request_call.kwargs["json"]["query"]
+        )
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/workflows/test_cable_validation_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_cable_validation_workflow.py
@@ -785,8 +785,8 @@ async def test_cable_validation_workflow_hostname_mismatch(_, env):
                         "smn-leaf",
                     ],
                     "site": "SITEA",
-                    "status": ["active", "provisioning"],
-                    "tenant": "nsv",
+                    "status": ["Active", "Provisioned"],
+                    "tenant": None,
                 },
                 "name": "get_devices_to_validate",
                 "output": {

--- a/src/tests/temporal/ngc/workflows/test_cumulus_hardware_validation_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_cumulus_hardware_validation_workflow.py
@@ -23,6 +23,7 @@ import pytest
 from temporalio import activity
 from temporalio.client import Client, WorkflowHandle
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import ApplicationError
 from temporalio.worker import Worker
 
 from nv_config_manager.temporal.ngc.activities.hardware_validation import (
@@ -328,6 +329,18 @@ async def mock_get_network_devices_empty(
     return GetNetworkDevicesOutput(devices=[])
 
 
+@activity.defn(name="get_network_devices")
+async def mock_get_network_devices_invalid_filter(
+    _activity_input: GetNetworkDevicesInput,
+) -> GetNetworkDevicesOutput:
+    """Mock get_network_devices activity with a Nautobot GraphQL filter error."""
+    raise ApplicationError(
+        "GraphQL error: {'tenant': "
+        "['Select a valid choice. nsv is not one of the available choices.']}",
+        non_retryable=True,
+    )
+
+
 @activity.defn(name="create_consolidated_excel_export")
 async def mock_create_consolidated_excel_export_empty(
     activity_input: CreateConsolidatedExcelInput,
@@ -412,14 +425,83 @@ async def test_cumulus_hardware_validation_workflow_no_devices(
 
         result = await handle.result()
         assert isinstance(result, HardwareValidationResult)
-        assert result.success is True
+        assert result.success is False
         assert result.devices_validated == 0
         assert result.total_entries == 0
-        assert "no devices matched the filter" in result.message
+        assert "No devices matched the hardware validation filter" in result.message
 
         stages = await handle.query("stages")
         completed_stages = [s for s in stages if s["state"] == "COMPLETE"]
-        assert len(completed_stages) == len(stages)
+        unreachable_stages = [s for s in stages if s["state"] == "UNREACHABLE"]
+        assert [stage["name"] for stage in completed_stages] == ["get_devices_to_validate"]
+        assert len(unreachable_stages) == len(stages) - 1
 
-        report_stage = next(s for s in stages if s["name"] == "generate_consolidated_report")
-        assert report_stage["output"]["total_row_count"] == 0
+        discovery_stage = next(s for s in stages if s["name"] == "get_devices_to_validate")
+        assert "No devices matched the specified filters" in discovery_stage["output"]["display"]
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
+@patch(
+    "nv_config_manager.temporal.ngc.workflows.cumulus_hardware_validation.DEFAULT_ACTIVITY_RETRY_POLICY",
+    return_value=TEST_RETRY_POLICY,
+)
+@patch(
+    "nv_config_manager.temporal.ngc.workflows.cumulus_hardware_validation.timedelta",
+    return_value=TEST_TIMEOUT,
+)
+async def test_cumulus_hardware_validation_workflow_invalid_filter(
+    _mock_timedelta,
+    _mock_retry_policy,
+    _mock_time,
+    env,
+):
+    """Test hardware validation returns a clean result for invalid Nautobot filters."""
+    task_queue_name = str(uuid.uuid4())
+    client: Client = env.client
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[ValidateHardwareWorkflow],
+        activities=[
+            mock_get_network_devices_invalid_filter,
+            mock_publish_nats,
+        ],
+    ):
+        workflow_input = ValidateHardwareInput(
+            site="test-site",
+            roles=["tor-switch"],
+            status=["active"],
+            tenant="nsv",
+            device_type_ids=[],
+            raise_for_invalid=False,
+        )
+        workflow_id = str(uuid.uuid4())
+
+        handle: WorkflowHandle = await client.start_workflow(
+            ValidateHardwareWorkflow.run,
+            workflow_input,
+            id=workflow_id,
+            task_queue=task_queue_name,
+            run_timeout=timedelta(minutes=2),
+        )
+
+        result = await handle.result()
+        assert isinstance(result, HardwareValidationResult)
+        assert result.success is False
+        assert result.devices_validated == 0
+        assert result.total_entries == 0
+        assert "Invalid hardware validation device filter" in result.message
+        assert "tenant: Select a valid choice" in result.message
+        assert "nsv is not one of the available choices" in result.message
+
+        stages = await handle.query("stages")
+        completed_stages = [s for s in stages if s["state"] == "COMPLETE"]
+        unreachable_stages = [s for s in stages if s["state"] == "UNREACHABLE"]
+        assert [stage["name"] for stage in completed_stages] == ["get_devices_to_validate"]
+        assert len(unreachable_stages) == len(stages) - 1
+
+        discovery_stage = next(s for s in stages if s["name"] == "get_devices_to_validate")
+        assert discovery_stage["output"]["invalid_filter"] is True
+        assert "tenant: Select a valid choice" in discovery_stage["output"]["display"]

--- a/src/tests/temporal/ngc/workflows/test_cumulus_hardware_validation_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_cumulus_hardware_validation_workflow.py
@@ -428,7 +428,6 @@ async def test_cumulus_hardware_validation_workflow_no_devices(
         assert result.success is False
         assert result.devices_validated == 0
         assert result.total_entries == 0
-        assert "No devices matched the hardware validation filter" in result.message
 
         stages = await handle.query("stages")
         completed_stages = [s for s in stages if s["state"] == "COMPLETE"]
@@ -438,6 +437,7 @@ async def test_cumulus_hardware_validation_workflow_no_devices(
 
         discovery_stage = next(s for s in stages if s["name"] == "get_devices_to_validate")
         assert "No devices matched the specified filters" in discovery_stage["output"]["display"]
+        assert result.message == discovery_stage["output"]["display"]
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/workflows/test_password_rotation_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_password_rotation_workflow.py
@@ -15,12 +15,15 @@
 # pylint: disable=B101,C0115,C0116
 """Test Suite for Password Rotation Workflows"""
 
+import pytest
+from pydantic import ValidationError
 from temporalio import workflow
 
 with workflow.unsafe.imports_passed_through():
     from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData
     from nv_config_manager.temporal.ngc.workflows.site_password_rotation import (
         PasswordRotationResultData,
+        SitePasswordRotationInput,
     )
 
 
@@ -48,6 +51,15 @@ TEST_DEVICE_DATA = {
         }
     },
 }
+
+
+class TestSitePasswordRotationInput:
+    """Tests for SitePasswordRotationInput validation."""
+
+    def test_location_must_not_be_empty(self):
+        """Reject an empty location before starting the workflow."""
+        with pytest.raises(ValidationError):
+            SitePasswordRotationInput(location="", selected_secret="device-password")
 
 
 class TestPasswordRotationResultData:

--- a/ui/src/app/workflows/cumulushardwarevalidationworkflow/form/cumulus-hardware-validation-form.tsx
+++ b/ui/src/app/workflows/cumulushardwarevalidationworkflow/form/cumulus-hardware-validation-form.tsx
@@ -30,17 +30,20 @@ import { useToast } from "@/components/ui/use-toast";
 import { CumulusHardwareValidationWorkflowInput } from "@/types/data-table.types";
 import { useEnvData } from "@/hooks";
 import { getErrorMessage, startWorkflow } from "@/lib/utils";
+import { DEFAULT_SITE_WORKFLOW_STATUSES } from "@/lib/workflow-defaults";
 import { WorkflowFormField } from "@/components/forms/formfield";
 
 const CumulusValidationFormSchema = z.object({
   site: z.string().trim().min(1, { message: "Site is required" }),
   roles: z.union([z.string(), z.array(z.string())])
-    .transform((val: string | string[]) => (Array.isArray(val) ? val : []))
-    .pipe(z.array(z.string()).min(1, { message: "Roles is required" })),
+    .optional()
+    .transform((val: string | string[] | undefined) => (Array.isArray(val) ? val : []))
+    .pipe(z.array(z.string())),
   status: z.union([z.string(), z.array(z.string())])
-    .transform((val: string | string[]) => (Array.isArray(val) ? val : []))
+    .optional()
+    .transform((val: string | string[] | undefined) => (Array.isArray(val) ? val : []))
     .pipe(z.array(z.string()).min(1, { message: "Device Status is required" })),
-  tenant: z.string().trim().min(1, { message: "Tenant is required" }),
+  tenant: z.string().trim().optional().default(""),
 });
 
 type CumulusValidationFormData = z.infer<typeof CumulusValidationFormSchema>;
@@ -65,12 +68,13 @@ const setMultiQueryValue = (
   form: UseFormReturn<CumulusValidationFormData>,
   queryValues: string[],
   options: QueryOption[],
-  fieldName: MultiValueField
+  fieldName: MultiValueField,
+  emptyValue: string[] = []
 ) => {
   const fieldValue = queryValues.filter((queryValue) =>
     options.some((option) => option.key === queryValue)
   );
-  form.setValue(fieldName, fieldValue);
+  form.setValue(fieldName, fieldValue.length > 0 ? fieldValue : emptyValue);
 };
 
 /** Renders the form for starting a Cumulus hardware validation workflow. */
@@ -87,6 +91,12 @@ export const CumulusHardwareValidationWorkflowForm = () => {
 
   const form = useForm<CumulusValidationFormData>({
     resolver: zodResolver(CumulusValidationFormSchema),
+    defaultValues: {
+      site: querySite || "",
+      roles: queryRoles,
+      status: queryStatuses.length > 0 ? queryStatuses : [...DEFAULT_SITE_WORKFLOW_STATUSES],
+      tenant: queryTenant || "",
+    },
   });
 
 
@@ -101,7 +111,8 @@ export const CumulusHardwareValidationWorkflowForm = () => {
         form,
         queryStatuses,
         siteCableData.statusData,
-        "status"
+        "status",
+        [...DEFAULT_SITE_WORKFLOW_STATUSES]
       );
       setSingleQueryValue(
         form,
@@ -127,7 +138,7 @@ export const CumulusHardwareValidationWorkflowForm = () => {
         site: data.site,
         roles: data.roles,
         status: data.status,
-        tenant: data.tenant,
+        tenant: data.tenant || undefined,
         // Hardcode these values, not relevant to end users
         // only for advanced scenarios
         device_type_ids: [],

--- a/ui/src/app/workflows/sitecablevalidationworkflow/form/site-cable-validation-workflow-form.tsx
+++ b/ui/src/app/workflows/sitecablevalidationworkflow/form/site-cable-validation-workflow-form.tsx
@@ -30,17 +30,21 @@ import { useToast } from "@/components/ui/use-toast";
 import { SiteCableValidationWorkflowInput } from "@/types/data-table.types";
 import { useEnvData } from "@/hooks";
 import { getErrorMessage, startWorkflow } from "@/lib/utils";
+import { DEFAULT_SITE_WORKFLOW_STATUSES } from "@/lib/workflow-defaults";
 import { WorkflowFormField } from "@/components/forms/formfield";
+
 
 const SiteCableValidationFormSchema = z.object({
   site: z.string().trim().min(1, { message: "Site is required" }),
   roles: z.union([z.string(), z.array(z.string())])
-    .transform((val) => (Array.isArray(val) ? val : []))
-    .pipe(z.array(z.string()).min(1, { message: "Roles is required" })),
+    .optional()
+    .transform((val: string | string[] | undefined) => (Array.isArray(val) ? val : []))
+    .pipe(z.array(z.string())),
   status: z.union([z.string(), z.array(z.string())])
-    .transform((val) => (Array.isArray(val) ? val : []))
+    .optional()
+    .transform((val: string | string[] | undefined) => (Array.isArray(val) ? val : []))
     .pipe(z.array(z.string()).min(1, { message: "Device Status is required" })),
-  tenant: z.string().trim().min(1, { message: "Tenant is required" }),
+  tenant: z.string().trim().optional().default(""),
 });
 
 type SiteCableValidationFormData = z.infer<typeof SiteCableValidationFormSchema>;
@@ -65,12 +69,13 @@ const setMultiQueryValue = (
   form: UseFormReturn<SiteCableValidationFormData>,
   queryValues: string[],
   options: QueryOption[],
-  fieldName: MultiValueField
+  fieldName: MultiValueField,
+  emptyValue: string[] = []
 ) => {
   const fieldValue = queryValues.filter((queryValue) =>
     options.some((option) => option.key === queryValue)
   );
-  form.setValue(fieldName, fieldValue);
+  form.setValue(fieldName, fieldValue.length > 0 ? fieldValue : emptyValue);
 };
 
 /** Renders the form for starting a site cable validation workflow. */
@@ -87,6 +92,12 @@ export const SiteCableValidationWorkflowForm = () => {
 
   const form = useForm<SiteCableValidationFormData>({
     resolver: zodResolver(SiteCableValidationFormSchema),
+    defaultValues: {
+      site: querySite || "",
+      roles: queryRoles,
+      status: queryStatuses.length > 0 ? queryStatuses : [...DEFAULT_SITE_WORKFLOW_STATUSES],
+      tenant: queryTenant || "",
+    },
   });
 
   // NOTE: might need this to change the api route look at Workflow.tsx. Revist when rest of api routes are defined.
@@ -100,7 +111,8 @@ export const SiteCableValidationWorkflowForm = () => {
         form,
         queryStatuses,
         siteCableData.statusData,
-        "status"
+        "status",
+        [...DEFAULT_SITE_WORKFLOW_STATUSES]
       );
       setSingleQueryValue(
         form,
@@ -126,7 +138,7 @@ export const SiteCableValidationWorkflowForm = () => {
         site: data.site,
         roles: data.roles,
         status: data.status,
-        tenant: data.tenant,
+        tenant: data.tenant || undefined,
         // Hardcode these values, not relevant to end users
         // only for advanced scenarios
         device_type_ids: [],

--- a/ui/src/app/workflows/sitepasswordrotationworkflow/form/site-password-rotation-workflow-form.tsx
+++ b/ui/src/app/workflows/sitepasswordrotationworkflow/form/site-password-rotation-workflow-form.tsx
@@ -29,6 +29,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { SitePasswordRotationWorkflowInput } from "@/types/data-table.types";
 import { useEnvData, useDevices } from "@/hooks";
 import { startWorkflow, sanitizeUrl } from "@/lib/utils";
+import { DEFAULT_SITE_WORKFLOW_STATUSES } from "@/lib/workflow-defaults";
 import { useRuntimeConfig } from "@/config/runtime";
 import { WorkflowFormField } from "@/components/forms/formfield";
 import { fetcher } from "@/lib/fetcher";
@@ -38,12 +39,14 @@ const SitePasswordRotationWorkflowFormSchema = z.object({
   location: z.string().trim().min(1, { message: "Location is required" }),
   selected_secret: z.string().trim().min(1, { message: "Secret is required" }),
   roles: z.union([z.string(), z.array(z.string())])
-    .transform((val: string | string[]) => (Array.isArray(val) ? val : []))
-    .pipe(z.array(z.string()).min(1, { message: "Roles is required" })),
+    .optional()
+    .transform((val: string | string[] | undefined) => (Array.isArray(val) ? val : []))
+    .pipe(z.array(z.string())),
   status: z.union([z.string(), z.array(z.string())])
-    .transform((val: string | string[]) => (Array.isArray(val) ? val : []))
+    .optional()
+    .transform((val: string | string[] | undefined) => (Array.isArray(val) ? val : []))
     .pipe(z.array(z.string()).min(1, { message: "Device Status is required" })),
-  tenant: z.string().trim().min(1, { message: "Tenant is required" }),
+  tenant: z.string().trim().optional().default(""),
 });
 
 type SitePasswordRotationFormData = z.infer<
@@ -291,7 +294,7 @@ export const SitePasswordRotationWorkflowForm = () => {
       location: queryLocation || "",
       selected_secret: querySecret || "",
       roles: queryRoles,
-      status: queryStatuses,
+      status: queryStatuses.length > 0 ? queryStatuses : [...DEFAULT_SITE_WORKFLOW_STATUSES],
       tenant: queryTenant || "",
     },
   });
@@ -365,7 +368,7 @@ export const SitePasswordRotationWorkflowForm = () => {
       selected_secret: data.selected_secret,
       roles: data.roles,
       status: data.status,
-      tenant: data.tenant,
+      tenant: data.tenant || undefined,
     };
 
     try {

--- a/ui/src/lib/workflow-defaults.ts
+++ b/ui/src/lib/workflow-defaults.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DEFAULT_SITE_WORKFLOW_STATUSES = ["Active", "Provisioned"];

--- a/ui/src/mocks/data/formData.ts
+++ b/ui/src/mocks/data/formData.ts
@@ -59,6 +59,7 @@ export const ROLES_LIST_API_RESPONSE = [
 
 export const STATUS_LIST = {
   active: "Active",
+  provisioned: "Provisioned",
   provisioning: "Provisioning",
   planned: "Planned",
   staged: "Staged",
@@ -67,6 +68,10 @@ export const STATUS_LIST_API_RESPONSE = [
   {
     id: "Active",
     name: "Active",
+  },
+  {
+    id: "Provisioned",
+    name: "Provisioned",
   },
   {
     id: "Provisioning",

--- a/ui/src/types/data-table.types.ts
+++ b/ui/src/types/data-table.types.ts
@@ -87,7 +87,7 @@ export type SiteCableValidationWorkflowInput = {
   site: string;
   roles: string[];
   status: string[];
-  tenant: string;
+  tenant?: string;
   device_type_ids: string[];
   raise_for_invalid: boolean;
 };
@@ -96,7 +96,7 @@ export type CumulusHardwareValidationWorkflowInput = {
   site: string;
   roles: string[];
   status: string[];
-  tenant: string;
+  tenant?: string;
   device_type_ids: string[];
   raise_for_invalid: boolean;
 };
@@ -141,7 +141,7 @@ export type SitePasswordRotationWorkflowInput = {
   location: string;
   selected_secret: string;
   roles: string[];
-  tenant: string;
+  tenant?: string;
   status: string[];
 };
 

--- a/ui/tests/e2e/cumulusHardwareValidationForm.spec.ts
+++ b/ui/tests/e2e/cumulusHardwareValidationForm.spec.ts
@@ -43,15 +43,13 @@ test.describe("Cumulus Hardware Validation Form", () => {
     await expect(page.getByText("Site is required")).toBeVisible({
       timeout: TEST_TIMEOUT,
     });
-    await expect(page.getByText("Roles is required")).toBeVisible({
+    await expect(page.getByText("Roles is required")).not.toBeVisible({
       timeout: TEST_TIMEOUT,
     });
-    await expect(page.getByText("Device Status is required")).toBeVisible({
-      timeout: TEST_TIMEOUT,
-    });
-    await expect(page.getByText("Tenant is required")).toBeVisible({
-      timeout: TEST_TIMEOUT,
-    });
+    await expect(page.getByText("Device Status is required")).not.toBeVisible();
+    await expect(page.getByText("Tenant is required")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: STATUS_LIST.active })).toBeVisible();
+    await expect(page.getByRole("button", { name: STATUS_LIST.provisioned })).toBeVisible();
   });
 
   test("handles URL parameters correctly and submits with those values", async ({
@@ -207,8 +205,7 @@ test.describe("Cumulus Hardware Validation Form", () => {
     ).toBeVisible({ timeout: TEST_TIMEOUT });
 
     // Test multiple selections for Device Status
-    await page.getByRole("button", { name: "Device Status" }).click();
-    await page.getByRole("dialog").getByText(STATUS_LIST.active).click();
+    await page.getByRole("button", { name: STATUS_LIST.active }).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.staged).click();
     // Click outside to close any dropdown that might be open
@@ -220,6 +217,9 @@ test.describe("Cumulus Hardware Validation Form", () => {
 
     await expect(
       page.getByRole("button", { name: STATUS_LIST.active })
+    ).toBeVisible({ timeout: TEST_TIMEOUT });
+    await expect(
+      page.getByRole("button", { name: STATUS_LIST.provisioned })
     ).toBeVisible({ timeout: TEST_TIMEOUT });
     await expect(
       page.getByRole("button", { name: STATUS_LIST.planned })
@@ -256,8 +256,7 @@ test.describe("Cumulus Hardware Validation Form", () => {
       })
       .click();
 
-    await page.getByRole("button", { name: "Device Status" }).click();
-    await page.getByRole("dialog").getByText(STATUS_LIST.active).click();
+    await page.getByRole("button", { name: STATUS_LIST.active }).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     // Click outside to close any dropdown that might be open
     await page
@@ -285,7 +284,11 @@ test.describe("Cumulus Hardware Validation Form", () => {
     expect(requestData).toEqual({
       site: SITES_LIST.pdx01,
       roles: [ROLES_LIST.leaf, ROLES_LIST.spine],
-      status: [STATUS_LIST.active, STATUS_LIST.planned],
+      status: [
+        STATUS_LIST.active,
+        STATUS_LIST.provisioned,
+        STATUS_LIST.planned,
+      ],
       tenant: TENANT_LIST.ngc,
       device_type_ids: [],
       raise_for_invalid: false,
@@ -316,15 +319,6 @@ test.describe("Cumulus Hardware Validation Form", () => {
       })
       .click();
 
-    await page.getByRole("button", { name: "Device Status" }).click();
-    await page.getByRole("dialog").getByText(STATUS_LIST.active).click();
-    // Click outside to close any dropdown that might be open
-    await page
-      .getByRole("heading", {
-        name: "New Cumulus Hardware Validation Workflow",
-      })
-      .click();
-
     await page.getByRole("button", { name: "Tenant" }).click();
     await page.getByRole("dialog").getByText(TENANT_LIST.ngc).click();
     // Click outside to close any dropdown that might be open
@@ -347,15 +341,6 @@ test.describe("Cumulus Hardware Validation Form", () => {
     // Test Site field validation
     await page.locator("form").getByRole("button", { name: "Roles" }).click();
     await page.getByRole("dialog").getByText(ROLES_LIST.leaf).click();
-    // Click outside to close any dropdown that might be open
-    await page
-      .getByRole("heading", {
-        name: "New Cumulus Hardware Validation Workflow",
-      })
-      .click();
-
-    await page.getByRole("button", { name: "Device Status" }).click();
-    await page.getByRole("dialog").getByText(STATUS_LIST.active).click();
     // Click outside to close any dropdown that might be open
     await page
       .getByRole("heading", {

--- a/ui/tests/e2e/siteCableValidationForm.spec.ts
+++ b/ui/tests/e2e/siteCableValidationForm.spec.ts
@@ -27,6 +27,14 @@ import { test, TEST_TIMEOUT } from "./shared/utils";
 const statusSelectButton = (page: Page) =>
   page.getByText("Device Status", { exact: true }).locator("..").getByRole("button");
 
+const openSelectDialog = (page: Page) =>
+  page.locator('[role="dialog"][data-state="open"]');
+
+const openStatusSelect = async (page: Page) => {
+  await statusSelectButton(page).press("Enter");
+  await expect(openSelectDialog(page)).toBeVisible({ timeout: TEST_TIMEOUT });
+};
+
 test.describe("Site Cable Validation Form", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/workflows/sitecablevalidationworkflow/form");
@@ -198,7 +206,7 @@ test.describe("Site Cable Validation Form", () => {
     ).toBeVisible({ timeout: TEST_TIMEOUT });
 
     // Test multiple selections for Device Status
-    await statusSelectButton(page).click();
+    await openStatusSelect(page);
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.staged).click();
     // Click outside to close any dropdown that might be open
@@ -241,7 +249,7 @@ test.describe("Site Cable Validation Form", () => {
       .getByRole("heading", { name: "New Site Cable Validation Workflow" })
       .click();
 
-    await statusSelectButton(page).click();
+    await openStatusSelect(page);
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     // Click outside to close any dropdown that might be open
     await page
@@ -281,6 +289,20 @@ test.describe("Site Cable Validation Form", () => {
   });
 
   test(`disables form during submission`, async ({ page }) => {
+    let markSubmissionStarted: () => void;
+    const submissionStarted = new Promise<void>((resolve) => {
+      markSubmissionStarted = resolve;
+    });
+    let releaseSubmission: () => void;
+    const submissionReleased = new Promise<void>((resolve) => {
+      releaseSubmission = resolve;
+    });
+    await page.route("**/v1/workflow/ngc/site_cable_validation", async (route) => {
+      markSubmissionStarted();
+      await submissionReleased;
+      await route.fallback();
+    });
+
     await page.getByRole("button", { name: "Site" }).click();
     await page.getByRole("dialog").getByText(SITES_LIST.pdx01).click();
     // Click outside to close any dropdown that might be open
@@ -296,7 +318,7 @@ test.describe("Site Cable Validation Form", () => {
       .getByRole("heading", { name: "New Site Cable Validation Workflow" })
       .click();
 
-    await statusSelectButton(page).click();
+    await openStatusSelect(page);
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     // Click outside to close any dropdown that might be open
     await page
@@ -311,6 +333,7 @@ test.describe("Site Cable Validation Form", () => {
       .click();
 
     await page.getByRole("button", { name: "Submit" }).click();
+    await submissionStarted;
 
     await expect(
       page.getByRole("button", { name: SITES_LIST.pdx01, exact: true })
@@ -336,6 +359,11 @@ test.describe("Site Cable Validation Form", () => {
     await expect(
       page.getByRole("button", { name: "Submitting..." })
     ).toBeDisabled();
+
+    releaseSubmission();
+    await expect(
+      page.getByRole("heading", { name: "Workflow Details" })
+    ).toBeVisible({ timeout: TEST_TIMEOUT });
   });
 
   test("displays forbidden error notification when submitting with forbidden values", async ({

--- a/ui/tests/e2e/siteCableValidationForm.spec.ts
+++ b/ui/tests/e2e/siteCableValidationForm.spec.ts
@@ -43,15 +43,13 @@ test.describe("Site Cable Validation Form", () => {
     await expect(page.getByText("Site is required")).toBeVisible({
       timeout: TEST_TIMEOUT,
     });
-    await expect(page.getByText("Roles is required")).toBeVisible({
+    await expect(page.getByText("Roles is required")).not.toBeVisible({
       timeout: TEST_TIMEOUT,
     });
-    await expect(page.getByText("Device Status is required")).toBeVisible({
-      timeout: TEST_TIMEOUT,
-    });
-    await expect(page.getByText("Tenant is required")).toBeVisible({
-      timeout: TEST_TIMEOUT,
-    });
+    await expect(page.getByText("Device Status is required")).not.toBeVisible();
+    await expect(page.getByText("Tenant is required")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: STATUS_LIST.active })).toBeVisible();
+    await expect(page.getByRole("button", { name: STATUS_LIST.provisioned })).toBeVisible();
   });
 
   test("handles URL parameters correctly and submits with those values", async ({
@@ -197,8 +195,7 @@ test.describe("Site Cable Validation Form", () => {
     ).toBeVisible({ timeout: TEST_TIMEOUT });
 
     // Test multiple selections for Device Status
-    await page.getByRole("button", { name: "Device Status" }).click();
-    await page.getByRole("dialog").getByText(STATUS_LIST.active).click();
+    await page.getByRole("button", { name: STATUS_LIST.active }).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.staged).click();
     // Click outside to close any dropdown that might be open
@@ -208,6 +205,9 @@ test.describe("Site Cable Validation Form", () => {
 
     await expect(
       page.getByRole("button", { name: STATUS_LIST.active })
+    ).toBeVisible({ timeout: TEST_TIMEOUT });
+    await expect(
+      page.getByRole("button", { name: STATUS_LIST.provisioned })
     ).toBeVisible({ timeout: TEST_TIMEOUT });
     await expect(
       page.getByRole("button", { name: STATUS_LIST.planned })
@@ -238,8 +238,7 @@ test.describe("Site Cable Validation Form", () => {
       .getByRole("heading", { name: "New Site Cable Validation Workflow" })
       .click();
 
-    await page.getByRole("button", { name: "Device Status" }).click();
-    await page.getByRole("dialog").getByText(STATUS_LIST.active).click();
+    await page.getByRole("button", { name: STATUS_LIST.active }).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     // Click outside to close any dropdown that might be open
     await page
@@ -262,7 +261,11 @@ test.describe("Site Cable Validation Form", () => {
     expect(requestData).toEqual({
       site: SITES_LIST.pdx01,
       roles: [ROLES_LIST.leaf, ROLES_LIST.spine],
-      status: [STATUS_LIST.active, STATUS_LIST.planned],
+      status: [
+        STATUS_LIST.active,
+        STATUS_LIST.provisioned,
+        STATUS_LIST.planned,
+      ],
       tenant: TENANT_LIST.nsv,
       device_type_ids: [],
       raise_for_invalid: false,
@@ -290,8 +293,7 @@ test.describe("Site Cable Validation Form", () => {
       .getByRole("heading", { name: "New Site Cable Validation Workflow" })
       .click();
 
-    await page.getByRole("button", { name: "Device Status" }).click();
-    await page.getByRole("dialog").getByText(STATUS_LIST.active).click();
+    await page.getByRole("button", { name: STATUS_LIST.active }).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     // Click outside to close any dropdown that might be open
     await page
@@ -320,6 +322,9 @@ test.describe("Site Cable Validation Form", () => {
       page.getByRole("button", { name: STATUS_LIST.active })
     ).toBeDisabled();
     await expect(
+      page.getByRole("button", { name: STATUS_LIST.provisioned })
+    ).toBeDisabled();
+    await expect(
       page.getByRole("button", { name: STATUS_LIST.planned })
     ).toBeDisabled();
     await expect(
@@ -340,12 +345,6 @@ test.describe("Site Cable Validation Form", () => {
     // Fill other required fields
     await page.locator("form").getByRole("button", { name: "Roles" }).click();
     await page.getByRole("dialog").getByText(ROLES_LIST.leaf).click();
-    await page
-      .getByRole("heading", { name: "New Site Cable Validation Workflow" })
-      .click();
-
-    await page.getByRole("button", { name: "Device Status" }).click();
-    await page.getByRole("dialog").getByText(STATUS_LIST.active).click();
     await page
       .getByRole("heading", { name: "New Site Cable Validation Workflow" })
       .click();

--- a/ui/tests/e2e/siteCableValidationForm.spec.ts
+++ b/ui/tests/e2e/siteCableValidationForm.spec.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import {
   SITES_LIST,
   ROLES_LIST,
@@ -23,6 +23,9 @@ import {
   FORBIDDEN_SITE_ID,
 } from "@/mocks/data";
 import { test, TEST_TIMEOUT } from "./shared/utils";
+
+const statusSelectButton = (page: Page) =>
+  page.getByText("Device Status", { exact: true }).locator("..").getByRole("button");
 
 test.describe("Site Cable Validation Form", () => {
   test.beforeEach(async ({ page }) => {
@@ -195,7 +198,7 @@ test.describe("Site Cable Validation Form", () => {
     ).toBeVisible({ timeout: TEST_TIMEOUT });
 
     // Test multiple selections for Device Status
-    await page.getByRole("button", { name: STATUS_LIST.active }).click();
+    await statusSelectButton(page).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.staged).click();
     // Click outside to close any dropdown that might be open
@@ -238,7 +241,7 @@ test.describe("Site Cable Validation Form", () => {
       .getByRole("heading", { name: "New Site Cable Validation Workflow" })
       .click();
 
-    await page.getByRole("button", { name: STATUS_LIST.active }).click();
+    await statusSelectButton(page).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     // Click outside to close any dropdown that might be open
     await page
@@ -293,7 +296,7 @@ test.describe("Site Cable Validation Form", () => {
       .getByRole("heading", { name: "New Site Cable Validation Workflow" })
       .click();
 
-    await page.getByRole("button", { name: STATUS_LIST.active }).click();
+    await statusSelectButton(page).click();
     await page.getByRole("dialog").getByText(STATUS_LIST.planned).click();
     // Click outside to close any dropdown that might be open
     await page


### PR DESCRIPTION
## Description

Slated for 1.3.1 release

* Add guidance for agents for site level workflows
* Make only Site and Status required on the UI for all site-level flows
* Clean up error messages for bad graphql input
* Remove bad defaults

## Validation

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow forms and API defaults now center on **Active/Provisioned**, including **Provisioned** in device-status choices.
  * Site-level filtering guidance is surfaced in workflow tool descriptions for more consistent targeting context.

* **Bug Fixes**
  * Device filtering failures (e.g., invalid filters) now return clearer, non-breaking results instead of halting execution.
  * Device discovery and validation better support **managed-only** filtering, with improved behavior when no devices match.

* **UI**
  * **Tenant** is now optional across workflow forms and submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Kind Integration

<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`d949d1d4a2d2`](https://github.com/NVIDIA/nv-config-manager/actions/runs/29351375183).
<!-- kind-integration-result:end -->
