### PR TITLE
fix(mcp): add local development setup guide and supporting changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -838,7 +838,28 @@ topology:
 	@echo "🌐 Deploying mock topology jobs and creating test topology..."
 	cd installer && uv run nv-config-manager-installer deploy ../$(INSTALL_CONFIG)
 
-# Install self-signed CA certificate in system keychain (macOS only)
+# Install self-signed CA certificate in system keychain (macOS only).
+# Trusts the gateway TLS cert for browsers and system tools.
+# Note: Node.js ignores the macOS keychain. For Node.js-based tools such as
+# Claude Code, set NODE_TLS_REJECT_UNAUTHORIZED=0 or use NODE_EXTRA_CA_CERTS
+# once the gateway cert is issued by a proper CA (CA:TRUE).
+install-cert:
+	@if [ "$$(uname)" != "Darwin" ]; then \
+		echo "install-cert is only supported on macOS"; exit 1; \
+	fi
+	@echo "Extracting gateway TLS certificate..."
+	@kubectl get secret -n $(KIND_SEC_NAMESPACE) nv-config-manager-gateway-tls \
+		-o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/nvcm-gateway.crt
+	@echo "Installing certificate to system keychain (sudo required)..."
+	@sudo security add-trusted-cert -d -r trustRoot \
+		-k /Library/Keychains/System.keychain /tmp/nvcm-gateway.crt
+	@rm -f /tmp/nvcm-gateway.crt
+	@echo "Certificate installed."
+	@echo ""
+	@echo "Note: Node.js tools (e.g. Claude Code) require NODE_TLS_REJECT_UNAUTHORIZED=0"
+	@echo "      because the gateway cert is self-signed with CA:FALSE."
+	@echo "      Add to your shell profile: export NODE_TLS_REJECT_UNAUTHORIZED=0"
+
 # Remove local deployment (preserves shared operators)
 local-down:
 	@echo "🗑️  Removing NVIDIA Config Manager from local Kubernetes..."

--- a/Makefile
+++ b/Makefile
@@ -844,28 +844,29 @@ topology:
 # Claude Code, set NODE_TLS_REJECT_UNAUTHORIZED=0 or use NODE_EXTRA_CA_CERTS
 # once the gateway cert is issued by a proper CA (CA:TRUE).
 install-cert:
-	@echo "Extracting gateway TLS certificate..."
-	@kubectl get secret -n $(KIND_SEC_NAMESPACE) nv-config-manager-gateway-tls \
-		-o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/nvcm-gateway.crt
-	@echo "Installing certificate (sudo required)..."
-	@if [ "$$(uname)" = "Darwin" ]; then \
+	@CERT_TMP=$$(mktemp); \
+	trap "rm -f $$CERT_TMP" EXIT INT TERM; \
+	echo "Extracting gateway TLS certificate..."; \
+	kubectl get secret -n $(KIND_SEC_NAMESPACE) nv-config-manager-gateway-tls \
+		-o jsonpath='{.data.tls\.crt}' | base64 -d > "$$CERT_TMP"; \
+	echo "Installing certificate (sudo required)..."; \
+	if [ "$$(uname)" = "Darwin" ]; then \
 		sudo security add-trusted-cert -d -r trustRoot \
-			-k /Library/Keychains/System.keychain /tmp/nvcm-gateway.crt; \
+			-k /Library/Keychains/System.keychain "$$CERT_TMP"; \
 	elif [ -d /usr/local/share/ca-certificates ]; then \
-		sudo cp /tmp/nvcm-gateway.crt /usr/local/share/ca-certificates/nvcm-gateway.crt && \
+		sudo cp "$$CERT_TMP" /usr/local/share/ca-certificates/nvcm-gateway.crt && \
 		sudo update-ca-certificates; \
 	elif [ -d /etc/pki/ca-trust/source/anchors ]; then \
-		sudo cp /tmp/nvcm-gateway.crt /etc/pki/ca-trust/source/anchors/nvcm-gateway.crt && \
+		sudo cp "$$CERT_TMP" /etc/pki/ca-trust/source/anchors/nvcm-gateway.crt && \
 		sudo update-ca-trust; \
 	else \
-		echo "Unsupported OS: install /tmp/nvcm-gateway.crt manually into your trust store"; exit 1; \
-	fi
-	@rm -f /tmp/nvcm-gateway.crt
-	@echo "Certificate installed."
-	@echo ""
-	@echo "Note: Node.js tools (e.g. Claude Code) require NODE_TLS_REJECT_UNAUTHORIZED=0"
-	@echo "      because the gateway cert is self-signed with CA:FALSE."
-	@echo "      Add to your shell profile: export NODE_TLS_REJECT_UNAUTHORIZED=0"
+		echo "Unsupported OS: install the gateway cert manually into your trust store"; exit 1; \
+	fi; \
+	echo "Certificate installed."; \
+	echo ""; \
+	echo "Note: Node.js tools (e.g. Claude Code) ignore the system trust store because"; \
+	echo "      the gateway cert is self-signed with CA:FALSE. Scope the variable to"; \
+	echo "      the specific command: NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp login ..."
 
 # Remove local deployment (preserves shared operators)
 local-down:

--- a/Makefile
+++ b/Makefile
@@ -838,21 +838,28 @@ topology:
 	@echo "🌐 Deploying mock topology jobs and creating test topology..."
 	cd installer && uv run nv-config-manager-installer deploy ../$(INSTALL_CONFIG)
 
-# Install self-signed CA certificate in system keychain (macOS only).
+# Install self-signed CA certificate into the system trust store (macOS and Linux).
 # Trusts the gateway TLS cert for browsers and system tools.
-# Note: Node.js ignores the macOS keychain. For Node.js-based tools such as
+# Note: Node.js ignores the system trust store. For Node.js-based tools such as
 # Claude Code, set NODE_TLS_REJECT_UNAUTHORIZED=0 or use NODE_EXTRA_CA_CERTS
 # once the gateway cert is issued by a proper CA (CA:TRUE).
 install-cert:
-	@if [ "$$(uname)" != "Darwin" ]; then \
-		echo "install-cert is only supported on macOS"; exit 1; \
-	fi
 	@echo "Extracting gateway TLS certificate..."
 	@kubectl get secret -n $(KIND_SEC_NAMESPACE) nv-config-manager-gateway-tls \
 		-o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/nvcm-gateway.crt
-	@echo "Installing certificate to system keychain (sudo required)..."
-	@sudo security add-trusted-cert -d -r trustRoot \
-		-k /Library/Keychains/System.keychain /tmp/nvcm-gateway.crt
+	@echo "Installing certificate (sudo required)..."
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		sudo security add-trusted-cert -d -r trustRoot \
+			-k /Library/Keychains/System.keychain /tmp/nvcm-gateway.crt; \
+	elif [ -d /usr/local/share/ca-certificates ]; then \
+		sudo cp /tmp/nvcm-gateway.crt /usr/local/share/ca-certificates/nvcm-gateway.crt && \
+		sudo update-ca-certificates; \
+	elif [ -d /etc/pki/ca-trust/source/anchors ]; then \
+		sudo cp /tmp/nvcm-gateway.crt /etc/pki/ca-trust/source/anchors/nvcm-gateway.crt && \
+		sudo update-ca-trust; \
+	else \
+		echo "Unsupported OS: install /tmp/nvcm-gateway.crt manually into your trust store"; exit 1; \
+	fi
 	@rm -f /tmp/nvcm-gateway.crt
 	@echo "Certificate installed."
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -168,6 +168,42 @@ kubectl get secret nautobot-admin -n nv-config-manager -o jsonpath='{.data.passw
 kubectl get secret nautobot-admin -n nv-config-manager -o jsonpath='{.data.api_token}' | base64 -d && echo
 ```
 
+### Connecting Claude Code MCP (`kind-up-sec`)
+
+The `kind-up-sec` environment includes the MCP server. To connect Claude Code:
+
+**1. Install the TLS certificate**
+
+```bash
+make install-cert
+```
+
+Node.js (and Claude Code) does not use the macOS keychain. Add this to your shell profile:
+
+```bash
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+**2. Add the MCP server**
+
+```bash
+DISCOVERY=$(curl -s https://config-manager.local/auth/discovery)
+CLIENT_ID=$(printf '%s' "$DISCOVERY" | jq -r '.clientId')
+MCP_URL=$(printf '%s' "$DISCOVERY" | jq -r '.services.mcp')
+
+claude mcp add --transport http --client-id "$CLIENT_ID" nv-config-manager "$MCP_URL"
+```
+
+Using `--client-id` uses the pre-registered `nv-config-manager-cli` public client and avoids OAuth Dynamic Client Registration, which is disabled in local Keycloak.
+
+**3. Authenticate**
+
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp login nv-config-manager
+```
+
+Log in with any pre-configured local Keycloak account: `nvcm-admin` / `nvcm-admin`, `nvcm-network` / `nvcm-network`, or `demo` / `demo`.
+
 ## Makefile Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -172,33 +172,33 @@ kubectl get secret nautobot-admin -n nv-config-manager -o jsonpath='{.data.api_t
 
 The `kind-up-sec` environment includes the MCP server. To connect Claude Code:
 
-**1. Install the TLS certificate**
+1. Install the TLS certificate.
 
-```bash
-make install-cert
-```
+   ```bash
+   make install-cert
+   ```
 
-Node.js (and Claude Code) does not use the system trust store because the gateway cert is self-signed with `CA:FALSE`. Scope the variable to the specific command rather than exporting it globally (see step 3 below).
+   Node.js (and Claude Code) does not use the system trust store because the gateway cert is self-signed with `CA:FALSE`. Scope the variable to the specific command rather than exporting it globally (see step 3 below).
 
-**2. Add the MCP server**
+2. Add the MCP server.
 
-```bash
-DISCOVERY=$(curl -s https://config-manager.local/auth/discovery)
-CLIENT_ID=$(printf '%s' "$DISCOVERY" | jq -r '.clientId')
-MCP_URL=$(printf '%s' "$DISCOVERY" | jq -r '.services.mcp')
+   ```bash
+   DISCOVERY=$(curl -s https://config-manager.local/auth/discovery)
+   CLIENT_ID=$(printf '%s' "$DISCOVERY" | jq -r '.clientId')
+   MCP_URL=$(printf '%s' "$DISCOVERY" | jq -r '.services.mcp')
 
-claude mcp add --transport http --client-id "$CLIENT_ID" nv-config-manager "$MCP_URL"
-```
+   claude mcp add --transport http --client-id "$CLIENT_ID" nv-config-manager "$MCP_URL"
+   ```
 
-Using `--client-id` uses the pre-registered `nv-config-manager-cli` public client and avoids OAuth Dynamic Client Registration, which is disabled in local Keycloak.
+   Using `--client-id` uses the pre-registered `nv-config-manager-cli` public client and avoids OAuth Dynamic Client Registration, which is disabled in local Keycloak.
 
-**3. Authenticate**
+3. Authenticate.
 
-```bash
-NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp login nv-config-manager
-```
+   ```bash
+   NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp login nv-config-manager
+   ```
 
-Log in with any pre-configured local Keycloak account: `nvcm-admin` / `nvcm-admin`, `nvcm-network` / `nvcm-network`, or `demo` / `demo`.
+Then, log in with any pre-configured local Keycloak account: `nvcm-admin` / `nvcm-admin`, `nvcm-network` / `nvcm-network`, or `demo` / `demo`.
 
 ## Makefile Commands
 

--- a/README.md
+++ b/README.md
@@ -178,11 +178,7 @@ The `kind-up-sec` environment includes the MCP server. To connect Claude Code:
 make install-cert
 ```
 
-Node.js (and Claude Code) does not use the macOS keychain. Add this to your shell profile:
-
-```bash
-export NODE_TLS_REJECT_UNAUTHORIZED=0
-```
+Node.js (and Claude Code) does not use the system trust store because the gateway cert is self-signed with `CA:FALSE`. Scope the variable to the specific command rather than exporting it globally (see step 3 below).
 
 **2. Add the MCP server**
 

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -174,6 +174,63 @@ For example:
 
 The discovery response tells the client which remote MCP endpoint to use and whether bearer authentication is required. In SSO-enabled environments, the MCP tools act with the signed-in user's bearer token. They do not switch to broader service credentials for Config Manager APIs.
 
+## Local Development (`kind-up-sec`)
+
+The `make kind-up-sec` environment runs Keycloak for SSO and exposes the MCP server on `svc-mcp.config-manager.local`. Follow these steps to connect Claude Code to a local deployment.
+
+### Prerequisites
+
+Ensure `/etc/hosts` includes the following entries (run `make kind-up-sec` output will remind you if any are missing):
+
+```text
+127.0.0.1 config-manager.local keycloak.config-manager.local
+127.0.0.1 svc-mcp.config-manager.local
+```
+
+### Install the TLS certificate
+
+Install the gateway certificate so browsers trust the local TLS endpoint:
+
+```sh
+make install-cert
+```
+
+Node.js-based tools, including Claude Code, do not use the macOS keychain. Set this environment variable in your shell profile so that Claude Code can reach the local endpoints:
+
+```sh
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+### Add the MCP server to Claude Code
+
+Fetch the pre-registered client ID and MCP URL from the local discovery endpoint, then add the server using the HTTP transport:
+
+```sh
+DISCOVERY=$(curl -s https://config-manager.local/auth/discovery)
+CLIENT_ID=$(printf '%s' "$DISCOVERY" | jq -r '.clientId')
+MCP_URL=$(printf '%s' "$DISCOVERY" | jq -r '.services.mcp')
+
+claude mcp add --transport http --client-id "$CLIENT_ID" nv-config-manager "$MCP_URL"
+```
+
+Using `--client-id` tells Claude Code to use the pre-registered `nv-config-manager-cli` public client instead of attempting OAuth Dynamic Client Registration, which is disabled in local Keycloak.
+
+### Authenticate
+
+```sh
+NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp login nv-config-manager
+```
+
+A browser window opens to the local Keycloak login. Use any of the pre-configured local accounts:
+
+| Username | Password | Roles |
+| :------- | :------- | :---- |
+| `nvcm-admin` | `nvcm-admin` | Admin + network |
+| `nvcm-network` | `nvcm-network` | Network operator |
+| `demo` | `demo` | Network operator |
+
+After login, start Claude Code from the repo directory. The `nv-config-manager` MCP tools will be available in the session.
+
 ## Client Settings
 
 Use these settings when configuring a client manually:

--- a/docs/overview/mcp.mdx
+++ b/docs/overview/mcp.mdx
@@ -174,63 +174,6 @@ For example:
 
 The discovery response tells the client which remote MCP endpoint to use and whether bearer authentication is required. In SSO-enabled environments, the MCP tools act with the signed-in user's bearer token. They do not switch to broader service credentials for Config Manager APIs.
 
-## Local Development (`kind-up-sec`)
-
-The `make kind-up-sec` environment runs Keycloak for SSO and exposes the MCP server on `svc-mcp.config-manager.local`. Follow these steps to connect Claude Code to a local deployment.
-
-### Prerequisites
-
-Ensure `/etc/hosts` includes the following entries (run `make kind-up-sec` output will remind you if any are missing):
-
-```text
-127.0.0.1 config-manager.local keycloak.config-manager.local
-127.0.0.1 svc-mcp.config-manager.local
-```
-
-### Install the TLS certificate
-
-Install the gateway certificate so browsers trust the local TLS endpoint:
-
-```sh
-make install-cert
-```
-
-Node.js-based tools, including Claude Code, do not use the macOS keychain. Set this environment variable in your shell profile so that Claude Code can reach the local endpoints:
-
-```sh
-export NODE_TLS_REJECT_UNAUTHORIZED=0
-```
-
-### Add the MCP server to Claude Code
-
-Fetch the pre-registered client ID and MCP URL from the local discovery endpoint, then add the server using the HTTP transport:
-
-```sh
-DISCOVERY=$(curl -s https://config-manager.local/auth/discovery)
-CLIENT_ID=$(printf '%s' "$DISCOVERY" | jq -r '.clientId')
-MCP_URL=$(printf '%s' "$DISCOVERY" | jq -r '.services.mcp')
-
-claude mcp add --transport http --client-id "$CLIENT_ID" nv-config-manager "$MCP_URL"
-```
-
-Using `--client-id` tells Claude Code to use the pre-registered `nv-config-manager-cli` public client instead of attempting OAuth Dynamic Client Registration, which is disabled in local Keycloak.
-
-### Authenticate
-
-```sh
-NODE_TLS_REJECT_UNAUTHORIZED=0 claude mcp login nv-config-manager
-```
-
-A browser window opens to the local Keycloak login. Use any of the pre-configured local accounts:
-
-| Username | Password | Roles |
-| :------- | :------- | :---- |
-| `nvcm-admin` | `nvcm-admin` | Admin + network |
-| `nvcm-network` | `nvcm-network` | Network operator |
-| `demo` | `demo` | Network operator |
-
-After login, start Claude Code from the repo directory. The `nv-config-manager` MCP tools will be available in the session.
-
 ## Client Settings
 
 Use these settings when configuring a client manually:

--- a/installer/src/nv_config_manager_installer/helm_values.py
+++ b/installer/src/nv_config_manager_installer/helm_values.py
@@ -878,8 +878,10 @@ def build_values(
     values["rbac"] = _build_rbac(config)
     values["configStore"] = {"enabled": svc.config_store, "client": {"useInternalEndpoint": True}}
     has_nautobot = svc.nautobot or bool(svc.external_nautobot_url)
+    mcp_forward_resource = config.sso.provider != SSOProvider.AZURE
     values["mcp"] = {
         "enabled": has_nautobot and svc.temporal and svc.config_store and svc.dhcp,
+        "auth": {"oauth": {"forwardResourceParameter": mcp_forward_resource}},
     }
     values["nautobot"] = _build_nautobot(config)
 

--- a/scripts/install-security-dependencies
+++ b/scripts/install-security-dependencies
@@ -643,6 +643,7 @@ spec:
               "protocol": "openid-connect",
               "redirectUris": ["http://localhost:*", "http://127.0.0.1:*"],
               "webOrigins": ["*"],
+              "optionalClientScopes": ["offline_access"],
               "attributes": {
                 "access.token.lifespan": "3600",
                 "pkce.code.challenge.method": "S256"

--- a/src/nv_config_manager/mcp/oauth_proxy.py
+++ b/src/nv_config_manager/mcp/oauth_proxy.py
@@ -28,7 +28,7 @@ from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from nv_config_manager.mcp.settings import MCPOAuthSettings
 
-_DCR_MCP_CLI_CALLBACK_PATH = re.compile(r"/callback/[A-Za-z0-9_-]+")
+_DCR_MCP_CLI_CALLBACK_PATH = re.compile(r"/callback(?:/[A-Za-z0-9_-]+)?")
 
 
 async def proxy_authorization_request(

--- a/src/nv_config_manager/mcp/oauth_proxy.py
+++ b/src/nv_config_manager/mcp/oauth_proxy.py
@@ -144,6 +144,9 @@ def _merge_query_params(url: str, params: tuple[tuple[str, str], ...]) -> str:
     return parsed._replace(query=query).geturl()
 
 
+_RFC8252_LOOPBACK_HOSTNAMES = {"127.0.0.1", "::1", "localhost"}
+
+
 def _is_dcr_mcp_cli_loopback_uri(value: str) -> bool:
     parsed = urlparse(value)
     try:
@@ -152,9 +155,8 @@ def _is_dcr_mcp_cli_loopback_uri(value: str) -> bool:
         return False
     return (
         parsed.scheme == "http"
-        and parsed.hostname == "127.0.0.1"
+        and parsed.hostname in _RFC8252_LOOPBACK_HOSTNAMES
         and port is not None
-        and parsed.netloc == f"127.0.0.1:{port}"
         and _DCR_MCP_CLI_CALLBACK_PATH.fullmatch(parsed.path) is not None
         and not parsed.params
         and not parsed.query

--- a/src/tests/mcp/test_main.py
+++ b/src/tests/mcp/test_main.py
@@ -275,8 +275,38 @@ def test_oauth_compatibility_proxy_uses_local_issuer_and_strips_resource(
 @pytest.mark.parametrize(
     "redirect_uri",
     [
-        "https://127.0.0.1:8765/callback/id",
+        "http://127.0.0.1:8765/callback/id",
+        "http://127.0.0.1:8765/callback",
         "http://localhost:8765/callback/id",
+        "http://localhost:8765/callback",
+        "http://[::1]:8765/callback/id",
+        "http://[::1]:8765/callback",
+    ],
+)
+def test_oauth_compatibility_proxy_accepts_rfc8252_loopback_redirects(
+    redirect_uri: str,
+) -> None:
+    with TestClient(
+        create_app(_settings(), _oauth_settings(forward_resource_parameter=False)),
+        base_url="https://svc-mcp.config-manager.local",
+        follow_redirects=False,
+    ) as client:
+        response = client.get(
+            "/oauth/authorize",
+            params={
+                "client_id": "nvcm-cli",
+                "state": "state-value",
+                "redirect_uri": redirect_uri,
+            },
+        )
+
+    assert response.status_code == 302
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "https://127.0.0.1:8765/callback/id",
         "http://127.0.0.1:8765/not-a-callback/id",
         "http://127.0.0.1:8765/callback/id?next=https://example.test",
     ],


### PR DESCRIPTION
## Description

- Implement `make install-cert` Makefile target to extract and install the gateway TLS cert to the macOS keychain; document NODE_TLS_REJECT_UNAUTHORIZED=0 workaround for Node.js tools 
- Add `offline_access` as an optional Keycloak scope on the nv-config-manager-cli client so Claude Code can request refresh tokens during MCP login
- Add a "Local Development (kind-up-sec)" section to docs/overview/mcp.mdx covering /etc/hosts entries, cert install, claude mcp add with --client-id to avoid dynamic registration, and local Keycloak credentials
## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/28480554281

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Expanded `make install-cert` to install the gateway TLS certificate into the host trust store on both macOS and Linux, with updated Node.js TLS guidance for this certificate setup.
  * Updated MCP Helm configuration to support forwarding the resource parameter for non-Azure SSO environments.
* **Bug Fixes**
  * Broadened DCR MCP CLI redirect URI validation to accept additional RFC 8252 loopback patterns (including localhost and IPv6).
* **Documentation**
  * Added “Connecting Claude Code MCP (`kind-up-sec`)” instructions.
* **Tests**
  * Expanded redirect URI test coverage for the new RFC 8252 variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->