### PR TITLE
fix spec drift check on main

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -323,7 +323,7 @@ jobs:
           CHANGED_FILES: ${{ steps.generation.outputs.changed_files }}
           DRIFT: ${{ steps.generation.outputs.drift }}
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}
+          PR_NUMBER: ${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').number }}
         run: |
           set -euo pipefail
           marker="<!-- nv-config-manager-generated-api-status -->"


### PR DESCRIPTION
## Description

Fix GHA on main branch

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the public CI workflow by safely handling missing or empty pull request info when posting API status comments.
  * Prevented failures caused by invalid JSON parsing in the workflow’s PR number lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->