### PR TITLE
fix: address Sonar reliability and security findings

### DIFF
--- a/.github/workflows/create-rc-tag.yml
+++ b/.github/workflows/create-rc-tag.yml
@@ -22,10 +22,6 @@ on:
         default: true
         type: boolean
 
-permissions:
-  actions: read
-  contents: read
-
 concurrency:
   group: release-tagging-${{ github.repository }}
   cancel-in-progress: false
@@ -34,6 +30,9 @@ jobs:
   validate:
     name: Validate RC Tag
     runs-on: linux-amd64-cpu4
+    permissions:
+      actions: read
+      contents: read
     outputs:
       commit: ${{ steps.resolve.outputs.commit }}
       go_tag: ${{ steps.version.outputs.go_tag }}
@@ -167,6 +166,7 @@ jobs:
           COMMIT: ${{ steps.resolve.outputs.commit }}
           GO_TAG: ${{ steps.version.outputs.go_tag }}
           RC_TAG: ${{ steps.version.outputs.rc_tag }}
+          SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           {
             echo "### RC tag request"
@@ -174,7 +174,7 @@ jobs:
             echo "- Tag: \`${RC_TAG}\`"
             echo "- Go module tag: \`${GO_TAG}\`"
             echo "- Commit: \`${COMMIT}\`"
-            echo "- Source ref: \`${{ inputs.source_ref }}\`"
+            echo "- Source ref: \`${SOURCE_REF}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   create-tag:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,6 @@ on:
       - "Makefile"
       - ".github/workflows/docs.yml"
 
-permissions:
-  contents: read
-
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,6 +25,8 @@ jobs:
   lint:
     name: Lint Docs
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     steps:
       - uses: &actions_checkout actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -138,6 +137,8 @@ jobs:
     needs: lint
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     steps:
       - uses: *actions_checkout
         with:

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -14,9 +14,6 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
-
 concurrency:
   group: kind-integration-${{ github.ref }}
   cancel-in-progress: false
@@ -37,6 +34,8 @@ jobs:
     name: Kind Integration
     if: startsWith(github.ref, 'refs/heads/pull-request/')
     runs-on: linux-amd64-cpu32m
+    permissions:
+      contents: read
     timeout-minutes: 90
     env:
       KIND_CLUSTER_NAME: nv-config-manager-${{ github.run_id }}

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -12,9 +12,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
-
 concurrency:
   group: release-tagging-${{ github.repository }}
   cancel-in-progress: false
@@ -23,6 +20,8 @@ jobs:
   validate:
     name: Validate Promotion
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     outputs:
       commit: ${{ steps.resolve.outputs.commit }}
       go_source_tag: ${{ steps.resolve.outputs.go_source_tag }}

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -6,9 +6,6 @@ on:
       - main
       - "pull-request/*"
 
-permissions:
-  contents: read
-
 concurrency:
   group: public-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -22,6 +19,8 @@ jobs:
   python-lint:
     name: Python Lint And Types
     runs-on: linux-amd64-cpu8
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup proxy cache
@@ -53,6 +52,8 @@ jobs:
   nautobot-app-overlays:
     name: Nautobot Overlays Lint And Build
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -78,6 +79,8 @@ jobs:
   nautobot-nv-config-manager:
     name: Nautobot NV Config Manager Lint And Build
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -103,6 +106,8 @@ jobs:
   spdx:
     name: SPDX Headers
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup proxy cache
@@ -131,6 +136,8 @@ jobs:
   python-tests:
     name: Python Tests
     runs-on: linux-amd64-cpu16
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup proxy cache
@@ -159,6 +166,8 @@ jobs:
   installer-tests:
     name: Installer Tests
     runs-on: linux-amd64-cpu8
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup proxy cache
@@ -183,6 +192,8 @@ jobs:
   network-template-tests:
     name: Network Template Tests
     runs-on: linux-amd64-cpu8
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup proxy cache
@@ -204,6 +215,8 @@ jobs:
   go-lint:
     name: Go Module Check
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup proxy cache
@@ -221,6 +234,8 @@ jobs:
   helm:
     name: Helm Lint And Template
     runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup proxy cache
@@ -380,6 +395,8 @@ jobs:
   ui-lint:
     name: UI Lint
     runs-on: linux-amd64-cpu8
+    permissions:
+      contents: read
     container:
       image: mcr.microsoft.com/playwright:v1.56.1-noble
     env:
@@ -402,6 +419,8 @@ jobs:
   ui-e2e:
     name: UI Build And E2E
     runs-on: linux-amd64-cpu16
+    permissions:
+      contents: read
     container:
       image: mcr.microsoft.com/playwright:v1.56.1-noble
     env:

--- a/.gitlab/ci/build.yml
+++ b/.gitlab/ci/build.yml
@@ -47,7 +47,9 @@
     - docker info
     - docker version
     - uname -m
-    - eval "$(bash .gitlab/ci/scripts/image_target_env.sh)"
+    - |
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
+      eval "$image_target_exports"
     - image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
     - test -n "$image_token" || (echo "Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset" && exit 1)
     - printf '%s' "$image_token" | docker login -u "$NVCM_IMAGE_USERNAME" --password-stdin "$NVCM_IMAGE_REGISTRY"
@@ -88,7 +90,9 @@
     - docker version
     - echo "Setting up QEMU for cross-arch builds..."
     - docker run --rm --privileged tonistiigi/binfmt --install all
-    - eval "$(bash .gitlab/ci/scripts/image_target_env.sh)"
+    - |
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
+      eval "$image_target_exports"
     - image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
     - test -n "$image_token" || (echo "Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset" && exit 1)
     - printf '%s' "$image_token" | docker login -u "$NVCM_IMAGE_USERNAME" --password-stdin "$NVCM_IMAGE_REGISTRY"
@@ -181,7 +185,9 @@ docker-manifest-mr:
     DOCKER_DRIVER: overlay2
   before_script:
     - apk add -q make bash git
-    - eval "$(bash .gitlab/ci/scripts/image_target_env.sh)"
+    - |
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
+      eval "$image_target_exports"
     - image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
     - test -n "$image_token" || (echo "Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset" && exit 1)
     - printf '%s' "$image_token" | docker login -u "$NVCM_IMAGE_USERNAME" --password-stdin "$NVCM_IMAGE_REGISTRY"
@@ -278,7 +284,9 @@ docker-manifest-main:
     DOCKER_DRIVER: overlay2
   before_script:
     - apk add -q make bash git
-    - eval "$(bash .gitlab/ci/scripts/image_target_env.sh)"
+    - |
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
+      eval "$image_target_exports"
     - image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
     - test -n "$image_token" || (echo "Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset" && exit 1)
     - printf '%s' "$image_token" | docker login -u "$NVCM_IMAGE_USERNAME" --password-stdin "$NVCM_IMAGE_REGISTRY"

--- a/.gitlab/ci/deploy.yml
+++ b/.gitlab/ci/deploy.yml
@@ -156,7 +156,8 @@ deploy-to-test:
       
       echo "   Pipeline: ${CI_PIPELINE_SOURCE}"
       echo "   Branch/MR: ${CI_COMMIT_REF_NAME}"
-      eval "$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/image_target_env.sh" "${NVCM_VALUES_IMAGE_TARGET:-}")"
+      image_target_exports="$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/image_target_env.sh" "${NVCM_VALUES_IMAGE_TARGET:-}")" || exit $?
+      eval "$image_target_exports"
       IMAGE_TARGET_TOKEN="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
       if [ -z "$IMAGE_TARGET_TOKEN" ]; then
         echo "❌ Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset"
@@ -429,7 +430,8 @@ deploy-to-test01:
       
       echo "   Pipeline: ${CI_PIPELINE_SOURCE}"
       echo "   Branch/MR: ${CI_COMMIT_REF_NAME}"
-      eval "$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/image_target_env.sh" "${NVCM_VALUES_IMAGE_TARGET:-}")"
+      image_target_exports="$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/image_target_env.sh" "${NVCM_VALUES_IMAGE_TARGET:-}")" || exit $?
+      eval "$image_target_exports"
       IMAGE_TARGET_TOKEN="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
       if [ -z "$IMAGE_TARGET_TOKEN" ]; then
         echo "❌ Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset"

--- a/.gitlab/ci/release.yml
+++ b/.gitlab/ci/release.yml
@@ -56,7 +56,8 @@ helm-publish-mr:
       set -e  # Exit on error
       
       # Update image repositories/tags to match MR-built images.
-      eval "$(bash .gitlab/ci/scripts/image_target_env.sh "${NVCM_VALUES_IMAGE_TARGET:-}")"
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh "${NVCM_VALUES_IMAGE_TARGET:-}")" || exit $?
+      eval "$image_target_exports"
       echo "📝 Updating image repositories to ${NVCM_IMAGE_REPOSITORY} and tags to ${CI_COMMIT_SHORT_SHA}..."
       bash .gitlab/ci/scripts/update_helm_image_values.sh deploy/helm/values.yaml "$NVCM_IMAGE_REPOSITORY" "$CI_COMMIT_SHORT_SHA"
       echo "✅ Image repositories and tags updated"
@@ -187,7 +188,8 @@ helm-publish-release:
       helm dependency build "${CHART_PATH}"
 
       # Package with semver version
-      eval "$(bash .gitlab/ci/scripts/image_target_env.sh "${NVCM_VALUES_IMAGE_TARGET:-}")"
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh "${NVCM_VALUES_IMAGE_TARGET:-}")" || exit $?
+      eval "$image_target_exports"
       echo "📝 Updating image repositories to ${NVCM_IMAGE_REPOSITORY} and tags to ${NEW_VERSION}..."
       bash .gitlab/ci/scripts/update_helm_image_values.sh deploy/helm/values.yaml "$NVCM_IMAGE_REPOSITORY" "$NEW_VERSION"
 
@@ -244,7 +246,9 @@ update-version:
   before_script:
     - apk add --no-cache bash git yq
     - until docker info > /dev/null 2>&1; do echo "Waiting for docker to start..."; sleep 5; done
-    - eval "$(bash .gitlab/ci/scripts/image_target_env.sh)"
+    - |
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
+      eval "$image_target_exports"
     - export IMAGE_REPOSITORY_BASE="$NVCM_IMAGE_REPOSITORY"
     - image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
     - test -n "$image_token" || (echo "Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset" && exit 1)
@@ -442,7 +446,9 @@ promote-docker-images:
   before_script:
     - apk add --no-cache bash
     - until docker info > /dev/null 2>&1; do echo "Waiting for docker to start..."; sleep 5; done
-    - eval "$(bash .gitlab/ci/scripts/image_target_env.sh)"
+    - |
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
+      eval "$image_target_exports"
     - export IMAGE_REPOSITORY_BASE="$NVCM_IMAGE_REPOSITORY"
     - image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
     - test -n "$image_token" || (echo "Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset" && exit 1)
@@ -503,7 +509,8 @@ promote-helm-chart:
       yq -i '.version = "'${PROMOTE_VERSION}'"' deploy/helm/Chart.yaml
       yq -i '.appVersion = "'${PROMOTE_VERSION}'"' deploy/helm/Chart.yaml
       # Update image repositories/tags to stable version
-      eval "$(bash .gitlab/ci/scripts/image_target_env.sh "${NVCM_VALUES_IMAGE_TARGET:-}")"
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh "${NVCM_VALUES_IMAGE_TARGET:-}")" || exit $?
+      eval "$image_target_exports"
       bash .gitlab/ci/scripts/update_helm_image_values.sh deploy/helm/values.yaml "$NVCM_IMAGE_REPOSITORY" "$PROMOTE_VERSION"
       
       CHART_PATH="deploy/helm"

--- a/.gitlab/ci/scripts/image_target_env.sh
+++ b/.gitlab/ci/scripts/image_target_env.sh
@@ -6,12 +6,14 @@ trim() {
   value="${value#"${value%%[![:space:]]*}"}"
   value="${value%"${value##*[![:space:]]}"}"
   printf '%s' "$value"
+  return 0
 }
 
 shell_export() {
   local name="$1"
   local value="$2"
   printf 'export %s=%q\n' "$name" "$value"
+  return 0
 }
 
 parse_options() {
@@ -20,7 +22,7 @@ parse_options() {
   local -n username_ref="$3"
 
   if [[ -z "$options" ]]; then
-    return
+    return 0
   fi
 
   local raw_option option key value
@@ -39,6 +41,7 @@ parse_options() {
         ;;
     esac
   done
+  return 0
 }
 
 select_target() {
@@ -61,7 +64,7 @@ select_target() {
     NVCM_SELECTED_IMAGE_TOKEN_VAR="${NVCM_IMAGE_TOKEN_VAR:-NGC_REGISTRY_TOKEN}"
     NVCM_SELECTED_IMAGE_REGISTRY="${NVCM_IMAGE_REGISTRY:-${NVCM_SELECTED_IMAGE_REPOSITORY%%/*}}"
     NVCM_SELECTED_IMAGE_USERNAME="${NVCM_IMAGE_USERNAME:-\$oauthtoken}"
-    return
+    return 0
   fi
 
   local raw_line line name repository token_var options registry username
@@ -93,7 +96,7 @@ select_target() {
     NVCM_SELECTED_IMAGE_TOKEN_VAR="$token_var"
     NVCM_SELECTED_IMAGE_REGISTRY="${registry:-${NVCM_SELECTED_IMAGE_REPOSITORY%%/*}}"
     NVCM_SELECTED_IMAGE_USERNAME="${username:-\$oauthtoken}"
-    return
+    return 0
   done <<< "$records"
 
   if [[ -n "$requested_name" ]]; then
@@ -101,7 +104,7 @@ select_target() {
   else
     echo "NVCM_IMAGE_TARGETS does not contain any usable records." >&2
   fi
-  exit 1
+  return 1
 }
 
 target_name="${1:-${NVCM_IMAGE_TARGET:-}}"

--- a/.gitlab/ci/sonar.yml
+++ b/.gitlab/ci/sonar.yml
@@ -107,7 +107,8 @@ sonarqube-vulnerability-report:
       trap 'rm -f "$auth_config"' EXIT
       chmod 600 "$auth_config"
       printf 'user = "%s:"\n' "$SONAR_TOKEN" > "$auth_config"
-      curl --fail-with-body --silent --show-error --retry 3 --retry-delay 5 --retry-connrefused --config "$auth_config" "${SONAR_HOST_URL}/api/issues/gitlab_sast_export?projectKey=${NVCM_SONAR_PROJECT_KEY}&branch=${CI_COMMIT_BRANCH}&pullRequest=${CI_MERGE_REQUEST_IID}" -o gl-sast-sonar-report.json
+      sonar_host_url="${SONAR_HOST_URL%/}"
+      curl --fail-with-body --silent --show-error --retry 3 --retry-delay 5 --retry-connrefused --config "$auth_config" "${sonar_host_url}/api/issues/gitlab_sast_export?projectKey=${NVCM_SONAR_PROJECT_KEY}&branch=${CI_COMMIT_BRANCH}&pullRequest=${CI_MERGE_REQUEST_IID}" -o gl-sast-sonar-report.json
     - 'jq -e ''.version and (.vulnerabilities | type == "array")'' gl-sast-sonar-report.json >/dev/null'
   allow_failure: true
   rules:

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -39,7 +39,8 @@ test-mr-py:
   script:
     - uv run pytest -n auto --cov=src/nv_config_manager --cov-report=xml:coverage.xml --cov-report=term
     - cd components/nautobot
-    - uv run pytest tests/ -n auto --cov=nv_config_manager_auth --cov=nv_config_manager_jobs --cov-report=xml:coverage.xml --cov-report=term
+    - uv run pytest tests/ -n auto --cov=nv_config_manager_auth --cov=nv_config_manager_jobs --cov-report=term
+    - uv run coverage xml --include='nv_config_manager_auth/*,nv_config_manager_jobs/*' -o coverage.xml
   artifacts:
     when: always
     paths:
@@ -431,7 +432,8 @@ test-main-py:
   script:
     - uv run pytest -n auto --cov=src/nv_config_manager --cov-report=xml:coverage.xml --cov-report=term
     - cd components/nautobot
-    - uv run pytest tests/ -n auto --cov=nv_config_manager_auth --cov=nv_config_manager_jobs --cov-report=xml:coverage.xml --cov-report=term
+    - uv run pytest tests/ -n auto --cov=nv_config_manager_auth --cov=nv_config_manager_jobs --cov-report=term
+    - uv run coverage xml --include='nv_config_manager_auth/*,nv_config_manager_jobs/*' -o coverage.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -3,6 +3,12 @@
   - pyproject.toml
   - uv.lock
 
+.nautobot-coverage-script: &nautobot-coverage-script |
+  set -e
+  cd components/nautobot
+  uv run pytest tests/ -n auto --cov=nv_config_manager_auth --cov=nv_config_manager_jobs --cov-report=term
+  uv run coverage xml --include='nv_config_manager_auth/*,nv_config_manager_jobs/*' -o coverage.xml
+
 test-mr-py:
   stage: test
   tags:
@@ -38,9 +44,7 @@ test-mr-py:
     - uv sync --frozen
   script:
     - uv run pytest -n auto --cov=src/nv_config_manager --cov-report=xml:coverage.xml --cov-report=term
-    - cd components/nautobot
-    - uv run pytest tests/ -n auto --cov=nv_config_manager_auth --cov=nv_config_manager_jobs --cov-report=term
-    - uv run coverage xml --include='nv_config_manager_auth/*,nv_config_manager_jobs/*' -o coverage.xml
+    - *nautobot-coverage-script
   artifacts:
     when: always
     paths:
@@ -432,9 +436,7 @@ test-main-py:
     - uv sync --frozen
   script:
     - uv run pytest -n auto --cov=src/nv_config_manager --cov-report=xml:coverage.xml --cov-report=term
-    - cd components/nautobot
-    - uv run pytest tests/ -n auto --cov=nv_config_manager_auth --cov=nv_config_manager_jobs --cov-report=term
-    - uv run coverage xml --include='nv_config_manager_auth/*,nv_config_manager_jobs/*' -o coverage.xml
+    - *nautobot-coverage-script
   artifacts:
     when: always
     paths:

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -304,7 +304,8 @@ integration-test:
       echo "Docker is ready"
 
       # Login to the configured image target to pull base images during docker builds
-      eval "$(bash .gitlab/ci/scripts/image_target_env.sh)"
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
+      eval "$image_target_exports"
       image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
       test -n "$image_token" || (echo "Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset" && exit 1)
       printf '%s' "$image_token" | docker login -u "$NVCM_IMAGE_USERNAME" --password-stdin "$NVCM_IMAGE_REGISTRY"

--- a/build/kea-admin/entrypoint.sh
+++ b/build/kea-admin/entrypoint.sh
@@ -4,11 +4,11 @@
 # Reference: https://kea.readthedocs.io/en/kea-2.6.2/arm/admin.html
 set -e
 
-if [ -z "$INI_FILE" ]; then
+if [[ -z "$INI_FILE" ]]; then
   INI_FILE=/etc/vault/nv-config-manager.ini
 fi
 
-if [ ! -f "$INI_FILE" ]; then
+if [[ ! -f "$INI_FILE" ]]; then
   echo "Error: $INI_FILE does not exist"
   exit 1
 fi
@@ -27,7 +27,7 @@ echo "  User: $DB_USER"
 echo "  Database: $DB_NAME"
 
 # Validate required variables
-if [ -z "$DB_HOST" ] || [ -z "$DB_PORT" ] || [ -z "$DB_USER" ] || [ -z "$DB_PASSWORD" ] || [ -z "$DB_NAME" ]; then
+if [[ -z "$DB_HOST" || -z "$DB_PORT" || -z "$DB_USER" || -z "$DB_PASSWORD" || -z "$DB_NAME" ]]; then
     echo "Error: Required database configuration not found in $INI_FILE"
     echo "Please ensure [dhcp.lease_db] section has host, port, user, password, and database"
     exit 1
@@ -67,4 +67,3 @@ PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U "$DB_USER" -d "$DB_NAME"
 }
 
 echo "Kea database schema initialized successfully!"
-

--- a/build/setup.stork.deb.sh
+++ b/build/setup.stork.deb.sh
@@ -21,7 +21,7 @@ apt-get install -y --no-install-recommends \
 
 # Map Ubuntu Noble (24.04) to Jammy (22.04) since Stork may not have Noble packages yet
 STORK_CODENAME="${VERSION_CODENAME}"
-if [ "${VERSION_CODENAME}" = "noble" ]; then
+if [[ "${VERSION_CODENAME}" = "noble" ]]; then
     echo "Ubuntu Noble detected, using Jammy repository (compatible packages)..."
     STORK_CODENAME="jammy"
 fi

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/templates/nautobot_app_overlays/vxlan_retrieve.html
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/templates/nautobot_app_overlays/vxlan_retrieve.html
@@ -84,11 +84,11 @@
     </div>
     <table class="table table-hover panel-body attr-table">
         <tr>
-            <td>Route distinguisher</td>
+            <th scope="row">Route distinguisher</th>
             <td>{{ object.vrf.rd|placeholder }}</td>
         </tr>
         <tr>
-            <td>Import route targets (VRF)</td>
+            <th scope="row">Import route targets (VRF)</th>
             <td>
                 {% if object.vrf.import_targets.exists %}
                     {% for rt in object.vrf.import_targets.all %}
@@ -100,7 +100,7 @@
             </td>
         </tr>
         <tr>
-            <td>Export route targets (VRF)</td>
+            <th scope="row">Export route targets (VRF)</th>
             <td>
                 {% if object.vrf.export_targets.exists %}
                     {% for rt in object.vrf.export_targets.all %}

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/templates/nautobot_app_overlays/vxlan_retrieve.html
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/templates/nautobot_app_overlays/vxlan_retrieve.html
@@ -83,6 +83,10 @@
         <strong>Linked VRF (L3)</strong>
     </div>
     <table class="table table-hover panel-body attr-table">
+        <colgroup>
+            <col style="width: 25%;">
+            <col>
+        </colgroup>
         <tr>
             <th scope="row">Route distinguisher</th>
             <td>{{ object.vrf.rd|placeholder }}</td>

--- a/deploy/airgapped/create-airgapped.sh
+++ b/deploy/airgapped/create-airgapped.sh
@@ -195,7 +195,7 @@ load_operator_versions() {
 }
 
 detect_container_runtime() {
-    if [ "$CONTAINER_RUNTIME" != "auto" ]; then
+    if [[ "$CONTAINER_RUNTIME" != "auto" ]]; then
         log_info "Using specified container runtime: $CONTAINER_RUNTIME"
         return 0
     fi
@@ -231,36 +231,36 @@ check_prerequisites() {
         fi
     done
     
-    if [ ${#missing_tools[@]} -gt 0 ]; then
+    if [[ ${#missing_tools[@]} -gt 0 ]]; then
         log_error "Missing required tools: ${missing_tools[*]}"
         log_error "Please install them and try again."
         exit 1
     fi
     
     # Check that the chart exists
-    if [ ! -f "$CHART_DIR/Chart.yaml" ]; then
+    if [[ ! -f "$CHART_DIR/Chart.yaml" ]]; then
         log_error "Chart.yaml not found in $CHART_DIR"
         log_error "This script should be run from the bootstrap/ directory of nv-config-manager-chart"
         exit 1
     fi
     
     # Only require NGC_API_KEY if we're pulling images
-    if [ "$SKIP_IMAGES" != "true" ] && [ -z "$NGC_API_KEY" ]; then
+    if [[ "$SKIP_IMAGES" != "true" && -z "$NGC_API_KEY" ]]; then
         log_warn "NGC_REGISTRY_TOKEN/NGC_API_KEY not set"
         log_warn "Images from NVCR may fail to pull without authentication"
         log_info "Set NGC_REGISTRY_TOKEN or NGC_API_KEY environment variable, or use --ngc-api-key"
     fi
     
     # Detect and verify container runtime
-    if [ "$SKIP_IMAGES" != "true" ]; then
+    if [[ "$SKIP_IMAGES" != "true" ]]; then
         detect_container_runtime
         
-        if [ "$CONTAINER_RUNTIME" = "docker" ]; then
+        if [[ "$CONTAINER_RUNTIME" = "docker" ]]; then
             if ! docker info &> /dev/null; then
                 log_error "Docker is not running. Please start Docker and try again."
                 exit 1
             fi
-        elif [ "$CONTAINER_RUNTIME" = "containerd" ]; then
+        elif [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
             if ! ctr version &> /dev/null; then
                 log_error "containerd is not running or not accessible."
                 exit 1
@@ -274,7 +274,7 @@ check_prerequisites() {
 setup_ngc_authentication() {
     log_info "Setting up NGC authentication..."
     
-    if [ -z "$NGC_API_KEY" ]; then
+    if [[ -z "$NGC_API_KEY" ]]; then
         log_warn "NGC_REGISTRY_TOKEN/NGC_API_KEY not set"
         log_info "Attempting to pull images without NVCR authentication..."
         return 0
@@ -283,7 +283,7 @@ setup_ngc_authentication() {
     # Login to NVCR with NGC API key
     log_info "Logging in to NVCR (nvcr.io)..."
     
-    if [ "$CONTAINER_RUNTIME" = "docker" ]; then
+    if [[ "$CONTAINER_RUNTIME" = "docker" ]]; then
         if echo "$NGC_API_KEY" | docker login nvcr.io --username '$oauthtoken' --password-stdin &> /dev/null; then
             log_success "Successfully authenticated with NVCR"
             return 0
@@ -292,7 +292,7 @@ setup_ngc_authentication() {
             log_error "Please check your NGC_API_KEY and try again"
             exit 1
         fi
-    elif [ "$CONTAINER_RUNTIME" = "containerd" ]; then
+    elif [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
         # For containerd, we'll pass credentials directly to ctr image pull
         log_success "NGC API key is set - will pass credentials directly to ctr image pull"
         return 0
@@ -322,10 +322,10 @@ setup_build_dir() {
 }
 
 get_version() {
-    if [ -z "$VERSION" ]; then
+    if [[ -z "$VERSION" ]]; then
         # Extract version from Chart.yaml
         VERSION=$(grep '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}' | tr -d '"' | tr -d "'")
-        if [ -z "$VERSION" ]; then
+        if [[ -z "$VERSION" ]]; then
             VERSION="0.0.0-dev"
         fi
     fi
@@ -371,7 +371,7 @@ PY
 }
 
 package_helm_chart() {
-    if [ "$SKIP_CHART" = true ]; then
+    if [[ "$SKIP_CHART" = true ]]; then
         log_warn "Skipping Helm chart packaging"
         return
     fi
@@ -396,7 +396,7 @@ package_helm_chart() {
     helm package "$helm_dir" --destination "$helm_dir"
     
     local chart_tgz=$(ls "$helm_dir"/*.tgz 2>/dev/null | head -1)
-    if [ -n "$chart_tgz" ]; then
+    if [[ -n "$chart_tgz" ]]; then
         log_success "Helm chart ready: $helm_dir/ (packaged: $(basename "$chart_tgz"))"
     else
         log_success "Helm chart ready: $helm_dir/"
@@ -417,21 +417,21 @@ load_external_charts() {
     # Load any additional charts from charts.config.
     local charts_config="$SCRIPT_DIR/charts.config"
     
-    if [ ! -f "$charts_config" ]; then
+    if [[ ! -f "$charts_config" ]]; then
         return
     fi
     
-    while IFS= read -r line || [ -n "$line" ]; do
+    while IFS= read -r line || [[ -n "$line" ]]; do
         # Skip empty lines and comments
         [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
         # Remove leading/trailing whitespace
         line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        [ -n "$line" ] && echo "$line"
+        [[ -n "$line" ]] && echo "$line"
     done < "$charts_config"
 }
 
 package_external_charts() {
-    if [ "$SKIP_CHART" = true ]; then
+    if [[ "$SKIP_CHART" = true ]]; then
         log_warn "Skipping external chart packaging"
         return
     fi
@@ -442,10 +442,10 @@ package_external_charts() {
     # Load operator charts from the shared manifest plus any extra charts from config.
     local external_charts=()
     while IFS= read -r line; do
-        [ -n "$line" ] && external_charts+=("$line")
+        [[ -n "$line" ]] && external_charts+=("$line")
     done < <(load_external_charts)
     
-    if [ ${#external_charts[@]} -eq 0 ]; then
+    if [[ ${#external_charts[@]} -eq 0 ]]; then
         log_info "No external charts configured"
         return
     fi
@@ -476,7 +476,7 @@ package_external_charts() {
             local chart_name="${chart_spec%%:*}"       # Extract chart name
             local chart_version="${chart_spec#*:}"     # Extract version
             
-            if [ -z "$repo_url" ] || [ -z "$chart_name" ] || [ -z "$chart_version" ]; then
+            if [[ -z "$repo_url" || -z "$chart_name" || -z "$chart_version" ]]; then
                 log_warn "Invalid helm entry: $chart_entry (expected helm://repo-url|chart-name:version)"
                 continue
             fi
@@ -502,7 +502,7 @@ package_external_charts() {
             local chart_name="${chart_entry%%:*}"
             local chart_version="${chart_entry#*:}"
             
-            if [ -z "$chart_name" ] || [ -z "$chart_version" ]; then
+            if [[ -z "$chart_name" || -z "$chart_version" ]]; then
                 log_warn "Invalid chart entry: $chart_entry (expected chart-name:version or oci://...)"
                 continue
             fi
@@ -516,7 +516,7 @@ package_external_charts() {
             local temp_pull_dir=$(mktemp -d)
             pushd "$temp_pull_dir" &> /dev/null
             
-            if [ -n "$NGC_API_KEY" ]; then
+            if [[ -n "$NGC_API_KEY" ]]; then
                 if helm fetch "$chart_url" --username='$oauthtoken' --password="$NGC_API_KEY" 2>/dev/null; then
                     pull_success=true
                 fi
@@ -527,7 +527,7 @@ package_external_charts() {
                 fi
             fi
             
-            if [ "$pull_success" = true ] && ls *.tgz 2>/dev/null | head -1 | grep -q .; then
+            if [[ "$pull_success" = true ]] && ls *.tgz 2>/dev/null | head -1 | grep -q .; then
                 mv *.tgz "$charts_dir/"
                 log_success "Packaged: $chart_tgz"
             else
@@ -544,7 +544,7 @@ package_external_charts() {
 # These are required for airgapped deployment
 # Note: Envoy Gateway is installed via the chart generated from operator-versions.env.
 package_dependency_manifests() {
-    if [ "$SKIP_CHART" = true ]; then
+    if [[ "$SKIP_CHART" = true ]]; then
         log_warn "Skipping dependency manifest packaging"
         return
     fi
@@ -584,7 +584,7 @@ extract_images_from_external_charts() {
     
     # Find all external chart tarballs (excluding nv-config-manager)
     for chart_tgz in "$charts_dir"/*.tgz; do
-        [ -f "$chart_tgz" ] || continue
+        [[ -f "$chart_tgz" ]] || continue
         
         local chart_basename=$(basename "$chart_tgz" .tgz)
         # Skip the main nv-config-manager chart
@@ -596,16 +596,16 @@ extract_images_from_external_charts() {
         
         # Find the chart directory inside
         local chart_dir=$(find "$temp_extract" -maxdepth 1 -type d ! -path "$temp_extract" | head -1)
-        [ -d "$chart_dir" ] || { rm -rf "$temp_extract"; continue; }
+        [[ -d "$chart_dir" ]] || { rm -rf "$temp_extract"; continue; }
         
         # Use helm template to extract images
         local templated_output
         templated_output=$(helm template test "$chart_dir" 2>/dev/null) || true
         
-        if [ -n "$templated_output" ]; then
+        if [[ -n "$templated_output" ]]; then
             # Extract image references
             while IFS= read -r img; do
-                [ -n "$img" ] && images+=("$img")
+                [[ -n "$img" ]] && images+=("$img")
             done < <(echo "$templated_output" | grep -E 'image:|repository:' | \
                      sed -E 's/.*image:[[:space:]]*["'"'"']?([^"'"'"'[:space:]]+)["'"'"']?.*/\1/' | \
                      grep -E '^[a-zA-Z0-9]' | sort -u)
@@ -621,16 +621,16 @@ load_extra_images() {
     # Load additional images from extraimages.config
     local extra_images_file="$SCRIPT_DIR/extraimages.config"
     
-    if [ ! -f "$extra_images_file" ]; then
+    if [[ ! -f "$extra_images_file" ]]; then
         return
     fi
     
-    while IFS= read -r line || [ -n "$line" ]; do
+    while IFS= read -r line || [[ -n "$line" ]]; do
         # Skip empty lines and comments
         [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
         # Remove leading/trailing whitespace
         line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        [ -n "$line" ] && echo "$line"
+        [[ -n "$line" ]] && echo "$line"
     done < "$extra_images_file"
 }
 
@@ -639,13 +639,13 @@ extract_images_from_manifests() {
     local manifests_dir="$1"
     local images=()
     
-    if [ ! -d "$manifests_dir" ]; then
+    if [[ ! -d "$manifests_dir" ]]; then
         return
     fi
     
     # Find all YAML files in manifests directory
     for manifest_file in "$manifests_dir"/*.yaml "$manifests_dir"/*.yml; do
-        [ -f "$manifest_file" ] || continue
+        [[ -f "$manifest_file" ]] || continue
         
         # Extract image references from the manifest
         # Look for "image:" fields in Kubernetes manifests
@@ -654,7 +654,7 @@ extract_images_from_manifests() {
             local image_value=$(echo "$image_line" | sed -E 's/^[[:space:]]*image:[[:space:]]*//' | sed -E 's/^["'\''"]|["'\''"]$//g')
             
             # Skip empty, null, or invalid values
-            if [ -z "$image_value" ] || [ "$image_value" = "null" ] || [ "$image_value" = "~" ]; then
+            if [[ -z "$image_value" || "$image_value" = "null" || "$image_value" = "~" ]]; then
                 continue
             fi
             
@@ -676,7 +676,7 @@ extract_images_from_manifests() {
             # Normalize image reference - add docker.io registry if no registry specified
             local first_segment=$(echo "$image_value" | cut -d'/' -f1 | cut -d':' -f1)
             if ! echo "$first_segment" | grep -q '\.'; then
-                if [ "$first_segment" != "docker.io" ] && [ "$first_segment" != "nvcr.io" ] && [ "$first_segment" != "ghcr.io" ] && [ "$first_segment" != "quay.io" ] && [ "$first_segment" != "gcr.io" ] && [ "$first_segment" != "registry.k8s.io" ]; then
+                if [[ "$first_segment" != "docker.io" && "$first_segment" != "nvcr.io" && "$first_segment" != "ghcr.io" && "$first_segment" != "quay.io" && "$first_segment" != "gcr.io" && "$first_segment" != "registry.k8s.io" ]]; then
                     if echo "$image_value" | grep -q '/'; then
                         image_value="docker.io/${image_value}"
                     else
@@ -708,7 +708,7 @@ extract_images_from_chart() {
     
     # Find the extracted chart directory
     local chart_dir=$(find "$charts_dir" -maxdepth 1 -type d -name "nv-config-manager*" | head -1)
-    if [ -z "$chart_dir" ] || [ ! -f "$chart_dir/Chart.yaml" ]; then
+    if [[ -z "$chart_dir" || ! -f "$chart_dir/Chart.yaml" ]]; then
         # Try the packaged tgz
         chart_dir="$charts_dir"
     fi
@@ -719,14 +719,14 @@ extract_images_from_chart() {
     local templated_output
     local helm_err=""
     
-    if [ -f "$values_file" ]; then
+    if [[ -f "$values_file" ]]; then
         helm_err=$(helm template test "$chart_dir" -f "$values_file" 2>&1)
     else
         helm_err=$(helm template test "$chart_dir" 2>&1)
     fi
     local helm_exit=$?
     
-    if [ $helm_exit -eq 0 ]; then
+    if [[ $helm_exit -eq 0 ]]; then
         templated_output="$helm_err"
     else
         # Write error to stderr so it doesn't mix with image output
@@ -734,14 +734,14 @@ extract_images_from_chart() {
         templated_output=""
     fi
     
-    if [ -n "$templated_output" ]; then
+    if [[ -n "$templated_output" ]]; then
         # Extract image references from the templated output
         while IFS= read -r image_line; do
             # Remove leading whitespace and "image:" prefix
             local image_value=$(echo "$image_line" | sed -E 's/^[[:space:]]*image:[[:space:]]*//' | sed -E 's/^["'\''"]|["'\''"]$//g')
             
             # Skip empty, null, or invalid values
-            if [ -z "$image_value" ] || [ "$image_value" = "null" ] || [ "$image_value" = "~" ]; then
+            if [[ -z "$image_value" || "$image_value" = "null" || "$image_value" = "~" ]]; then
                 continue
             fi
             
@@ -763,7 +763,7 @@ extract_images_from_chart() {
             # Normalize image reference - add docker.io registry if no registry specified
             local first_segment=$(echo "$image_value" | cut -d'/' -f1 | cut -d':' -f1)
             if ! echo "$first_segment" | grep -q '\.'; then
-                if [ "$first_segment" != "docker.io" ] && [ "$first_segment" != "nvcr.io" ] && [ "$first_segment" != "ghcr.io" ] && [ "$first_segment" != "quay.io" ] && [ "$first_segment" != "gcr.io" ] && [ "$first_segment" != "registry.k8s.io" ]; then
+                if [[ "$first_segment" != "docker.io" && "$first_segment" != "nvcr.io" && "$first_segment" != "ghcr.io" && "$first_segment" != "quay.io" && "$first_segment" != "gcr.io" && "$first_segment" != "registry.k8s.io" ]]; then
                     if echo "$image_value" | grep -q '/'; then
                         image_value="docker.io/${image_value}"
                     else
@@ -830,13 +830,13 @@ save_image_archive() {
 pull_docker_images() {
     local arch="${1:-amd64}"
     
-    if [ "$SKIP_IMAGES" = true ]; then
+    if [[ "$SKIP_IMAGES" = true ]]; then
         log_warn "Skipping Docker image pulling"
         return
     fi
     
     # Setup NGC authentication before pulling images (only on first call)
-    if [ "$arch" = "amd64" ] || [ "$TARGET_ARCH" = "arm64" ]; then
+    if [[ "$arch" = "amd64" || "$TARGET_ARCH" = "arm64" ]]; then
         setup_ngc_authentication
     fi
     
@@ -850,19 +850,19 @@ pull_docker_images() {
     log_info "Extracting image references from chart..."
     local images=()
     local temp_err=$(mktemp)
-    if [ -d "$helm_dir" ]; then
+    if [[ -d "$helm_dir" ]]; then
         local extracted_output
         extracted_output=$(extract_images_from_chart "$helm_dir" 2>"$temp_err")
         while IFS= read -r line; do
-            [ -n "$line" ] && images+=("$line")
+            [[ -n "$line" ]] && images+=("$line")
         done <<< "$extracted_output"
     fi
     
     # Log any helm template errors
-    if [ -s "$temp_err" ]; then
+    if [[ -s "$temp_err" ]]; then
         log_warn "Helm template errors encountered:"
         while IFS= read -r err_line; do
-            [ -n "$err_line" ] && log_info "  $err_line"
+            [[ -n "$err_line" ]] && log_info "  $err_line"
         done < "$temp_err"
     fi
     rm -f "$temp_err"
@@ -871,10 +871,10 @@ pull_docker_images() {
     log_info "Loading extra images from extraimages.config..."
     local extra_images=()
     while IFS= read -r line; do
-        [ -n "$line" ] && extra_images+=("$line")
+        [[ -n "$line" ]] && extra_images+=("$line")
     done < <(load_extra_images)
     
-    if [ ${#extra_images[@]} -gt 0 ]; then
+    if [[ ${#extra_images[@]} -gt 0 ]]; then
         log_info "Found ${#extra_images[@]} extra image(s) in extraimages.config"
         images+=("${extra_images[@]}")
     fi
@@ -884,10 +884,10 @@ pull_docker_images() {
     log_info "Extracting images from external charts..."
     local external_chart_images=()
     while IFS= read -r line; do
-        [ -n "$line" ] && external_chart_images+=("$line")
+        [[ -n "$line" ]] && external_chart_images+=("$line")
     done < <(extract_images_from_external_charts "$charts_dir")
     
-    if [ ${#external_chart_images[@]} -gt 0 ]; then
+    if [[ ${#external_chart_images[@]} -gt 0 ]]; then
         log_info "Found ${#external_chart_images[@]} image(s) from external charts"
         images+=("${external_chart_images[@]}")
     fi
@@ -897,10 +897,10 @@ pull_docker_images() {
     log_info "Extracting images from dependency manifests..."
     local manifest_images=()
     while IFS= read -r line; do
-        [ -n "$line" ] && manifest_images+=("$line")
+        [[ -n "$line" ]] && manifest_images+=("$line")
     done < <(extract_images_from_manifests "$manifests_dir")
     
-    if [ ${#manifest_images[@]} -gt 0 ]; then
+    if [[ ${#manifest_images[@]} -gt 0 ]]; then
         log_info "Found ${#manifest_images[@]} image(s) from dependency manifests (Envoy Gateway, etc.)"
         images+=("${manifest_images[@]}")
     fi
@@ -908,11 +908,11 @@ pull_docker_images() {
     # Remove duplicates
     local unique_images=()
     while IFS= read -r img; do
-        [ -n "$img" ] && unique_images+=("$img")
+        [[ -n "$img" ]] && unique_images+=("$img")
     done < <(printf '%s\n' "${images[@]}" | sort -u)
     images=("${unique_images[@]}")
     
-    if [ ${#images[@]} -eq 0 ]; then
+    if [[ ${#images[@]} -eq 0 ]]; then
         log_warn "No images found"
         return 0
     fi
@@ -930,24 +930,24 @@ pull_docker_images() {
         
         local pull_success=false
         
-        if [ "$CONTAINER_RUNTIME" = "docker" ]; then
+        if [[ "$CONTAINER_RUNTIME" = "docker" ]]; then
             set +e
             local pull_err=""
             pull_err=$(docker pull --platform linux/$arch "$image" 2>&1)
             local pull_exit=$?
             set -e
             
-            if [ $pull_exit -eq 0 ]; then
+            if [[ $pull_exit -eq 0 ]]; then
                 log_success "  Pulled $image"
                 log_info "  Saving $image to $filename..."
                 save_image_archive "$image" "$images_dir/$filename" "$arch"
                 pull_success=true
             else
                 log_warn "  Failed to pull $image for $arch"
-                if [ -n "$pull_err" ]; then
+                if [[ -n "$pull_err" ]]; then
                     log_info "  Error: $(echo "$pull_err" | grep -v "^$" | head -3 | tr '\n' ' ')"
                 fi
-                if [ "$LOCAL_IMAGE_FALLBACK" = true ] && docker image inspect "$image" &>/dev/null; then
+                if [[ "$LOCAL_IMAGE_FALLBACK" = true ]] && docker image inspect "$image" &>/dev/null; then
                     log_warn "  Using local image for $image because remote pull failed"
                     log_info "  Saving $image to $filename..."
                     if save_image_archive "$image" "$images_dir/$filename" "$arch"; then
@@ -958,7 +958,7 @@ pull_docker_images() {
                     fi
                 fi
             fi
-        elif [ "$CONTAINER_RUNTIME" = "containerd" ]; then
+        elif [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
             # Use ctr for pulling and exporting with containerd
             # Pass credentials directly for NVCR images
             local pull_exit=1
@@ -966,14 +966,14 @@ pull_docker_images() {
             
             # Pull with specified platform for all images (multi-arch manifests)
             set +e  # Temporarily disable exit on error
-            if [[ "$image" == nvcr.io/* ]] && [ -n "$NGC_API_KEY" ]; then
+            if [[ "$image" == nvcr.io/* && -n "$NGC_API_KEY" ]]; then
                 # NVCR images - pull with specified platform
                 # Retry up to 3 times for large images
                 local pull_output=""
                 local retry_count=0
                 pull_exit=1
-                while [ $retry_count -lt 3 ] && [ $pull_exit -ne 0 ]; do
-                    if [ $retry_count -gt 0 ]; then
+                while [[ $retry_count -lt 3 && $pull_exit -ne 0 ]]; do
+                    if [[ $retry_count -gt 0 ]]; then
                         log_info "  Retrying pull (attempt $((retry_count + 1))/3)..."
                         sleep 2
                     fi
@@ -989,7 +989,7 @@ pull_docker_images() {
                 done
                 
                 # Log error if pull failed
-                if [ $pull_exit -ne 0 ]; then
+                if [[ $pull_exit -ne 0 ]]; then
                     log_info "  Pull error: $(echo "$pull_output" | grep -v "^$" | head -5 | tr '\n' ' ')"
                 fi
             else
@@ -999,25 +999,25 @@ pull_docker_images() {
                 pull_output=$(ctr image pull --snapshotter=native --platform linux/$arch "$image" 2>&1)
                 pull_exit=$?
                 # If native snapshotter fails, try default overlayfs
-                if [ $pull_exit -ne 0 ]; then
+                if [[ $pull_exit -ne 0 ]]; then
                     pull_output=$(ctr image pull --platform linux/$arch "$image" 2>&1)
                     pull_exit=$?
                 fi
                 # Log error if pull failed
-                if [ $pull_exit -ne 0 ]; then
+                if [[ $pull_exit -ne 0 ]]; then
                     log_warn "  Pull failed for $arch architecture (image may not have $arch variant)"
                 fi
             fi
             set -e  # Re-enable exit on error
             
             # Verify architecture matches what we requested
-            if [ $pull_exit -eq 0 ]; then
+            if [[ $pull_exit -eq 0 ]]; then
                 # Check actual platforms of pulled image
                 local list_output=$(ctr image list "name==$image" 2>&1)
                 # PLATFORMS is the 6th field
                 local platforms=$(echo "$list_output" | awk 'NR==2 {print $6}')
                 
-                if [ -n "$platforms" ] && [ "$platforms" != "-" ]; then
+                if [[ -n "$platforms" && "$platforms" != "-" ]]; then
                     # Check if our requested architecture is in the platforms list
                     if echo "$platforms" | grep -q "linux/$arch"; then
                         log_info "  Verified architecture: linux/$arch"
@@ -1032,7 +1032,7 @@ pull_docker_images() {
                 fi
             fi
             
-            if [ $pull_exit -eq 0 ]; then
+            if [[ $pull_exit -eq 0 ]]; then
                 log_success "  Pulled $image"
                 log_info "  Exporting $image to $filename..."
                 set +e  # Temporarily disable exit on error
@@ -1043,13 +1043,13 @@ pull_docker_images() {
                 export_exit=$?
                 
                 # If export failed, try re-pulling
-                if [ $export_exit -ne 0 ]; then
+                if [[ $export_exit -ne 0 ]]; then
                     if echo "$export_err" | grep -q "content digest.*not found\|not found"; then
                         log_info "  Export failed, re-pulling image..."
                         # Remove the image first to ensure clean state
                         ctr image rm "$image" &> /dev/null || true
                         # Re-pull (use native snapshotter to avoid whiteout issues)
-                        if [[ "$image" == nvcr.io/* ]] && [ -n "$NGC_API_KEY" ]; then
+                        if [[ "$image" == nvcr.io/* && -n "$NGC_API_KEY" ]]; then
                             ctr image pull --snapshotter=native --platform linux/$arch -u '$oauthtoken:'"$NGC_API_KEY" "$image" &> /dev/null || true
                         else
                             ctr image pull --snapshotter=native --platform linux/$arch "$image" &> /dev/null || true
@@ -1065,23 +1065,23 @@ pull_docker_images() {
                 set -e  # Re-enable exit on error
                 
                 # Check if export succeeded and file exists with non-zero size
-                if [ $export_exit -eq 0 ] && [ -f "$images_dir/$filename" ]; then
+                if [[ $export_exit -eq 0 && -f "$images_dir/$filename" ]]; then
                     local file_size=$(stat -f%z "$images_dir/$filename" 2>/dev/null || stat -c%s "$images_dir/$filename" 2>/dev/null || echo "0")
-                    if [ "$file_size" -gt 0 ]; then
+                    if [[ "$file_size" -gt 0 ]]; then
                         pull_success=true
                         log_success "  Exported $image (${file_size} bytes)"
                     else
                         log_warn "  Export created empty file for $image (removing)"
                         rm -f "$images_dir/$filename"
-                        if [ -n "$export_err" ]; then
+                        if [[ -n "$export_err" ]]; then
                             log_info "  Export error: $export_err"
                         fi
                     fi
                 else
                     log_warn "  Failed to export $image (pull succeeded but export failed)"
                     # Remove empty file if it was created
-                    [ -f "$images_dir/$filename" ] && [ ! -s "$images_dir/$filename" ] && rm -f "$images_dir/$filename"
-                    if [ -n "$export_err" ]; then
+                    [[ -f "$images_dir/$filename" && ! -s "$images_dir/$filename" ]] && rm -f "$images_dir/$filename"
+                    if [[ -n "$export_err" ]]; then
                         log_info "  Export error: $export_err"
                     fi
                 fi
@@ -1090,7 +1090,7 @@ pull_docker_images() {
             fi
         fi
         
-        if [ "$pull_success" = true ]; then
+        if [[ "$pull_success" = true ]]; then
             log_success "  Saved $image"
             echo "$image" >> "$image_list_file"
         else
@@ -1098,12 +1098,12 @@ pull_docker_images() {
         fi
     done
 
-    if [ ${#failed_images[@]} -gt 0 ]; then
+    if [[ ${#failed_images[@]} -gt 0 ]]; then
         log_error "Failed to pull or save ${#failed_images[@]} image(s) for $arch:"
         for failed_image in "${failed_images[@]}"; do
             log_error "  $failed_image"
         done
-        if [ "$ALLOW_MISSING_IMAGES" = true ]; then
+        if [[ "$ALLOW_MISSING_IMAGES" = true ]]; then
             log_warn "Continuing because --allow-missing-images was set; bundle may not install offline"
         else
             log_error "Bundle image set is incomplete. Set --allow-missing-images only for best-effort diagnostics."
@@ -1115,7 +1115,7 @@ pull_docker_images() {
 }
 
 create_documentation() {
-    if [ "$SKIP_DOCS" = true ]; then
+    if [[ "$SKIP_DOCS" = true ]]; then
         log_warn "Skipping documentation copy"
         return
     fi
@@ -1131,7 +1131,7 @@ create_documentation() {
 }
 
 copy_skopeo_tool() {
-    if [ "$INCLUDE_SKOPEO" != true ]; then
+    if [[ "$INCLUDE_SKOPEO" != true ]]; then
         return
     fi
 
@@ -1532,10 +1532,10 @@ print_summary() {
     echo "  Version: $VERSION"
     echo ""
 
-    if [ "$TARGET_ARCH" = "both" ] || [ "$TARGET_ARCH" = "amd64" ]; then
+    if [[ "$TARGET_ARCH" = "both" || "$TARGET_ARCH" = "amd64" ]]; then
         echo "  AMD64 Package: $abs_output_dir/nv-config-manager-airgapped-${VERSION}-amd64.tar.gz"
     fi
-    if [ "$TARGET_ARCH" = "both" ] || [ "$TARGET_ARCH" = "arm64" ]; then
+    if [[ "$TARGET_ARCH" = "both" || "$TARGET_ARCH" = "arm64" ]]; then
         echo "  ARM64 Package: $abs_output_dir/nv-config-manager-airgapped-${VERSION}-arm64.tar.gz"
     fi
     echo ""
@@ -1583,7 +1583,7 @@ main() {
     
     # Build architectures
     local archs=()
-    if [ "$TARGET_ARCH" = "both" ]; then
+    if [[ "$TARGET_ARCH" = "both" ]]; then
         archs=("amd64" "arm64")
     else
         archs=("$TARGET_ARCH")

--- a/deploy/airgapped/create-airgapped.sh
+++ b/deploy/airgapped/create-airgapped.sh
@@ -718,13 +718,21 @@ extract_images_from_chart() {
     local values_file="$SCRIPT_DIR/values-airgapped-extract.yaml"
     local templated_output
     local helm_err=""
+    local helm_exit
     
     if [[ -f "$values_file" ]]; then
-        helm_err=$(helm template test "$chart_dir" -f "$values_file" 2>&1)
+        if helm_err=$(helm template test "$chart_dir" -f "$values_file" 2>&1); then
+            helm_exit=0
+        else
+            helm_exit=$?
+        fi
     else
-        helm_err=$(helm template test "$chart_dir" 2>&1)
+        if helm_err=$(helm template test "$chart_dir" 2>&1); then
+            helm_exit=0
+        else
+            helm_exit=$?
+        fi
     fi
-    local helm_exit=$?
     
     if [[ $helm_exit -eq 0 ]]; then
         templated_output="$helm_err"
@@ -977,7 +985,7 @@ pull_docker_images() {
                         log_info "  Retrying pull (attempt $((retry_count + 1))/3)..."
                         sleep 2
                     fi
-                    pull_output=$(timeout 300 ctr image pull --snapshotter=native --platform linux/$arch -u '$oauthtoken:'"$NGC_API_KEY" "$image" 2>&1 || true)
+                    pull_output=$(timeout 300 ctr image pull --snapshotter=native --platform linux/$arch -u '$oauthtoken:'"$NGC_API_KEY" "$image" 2>&1)
                     pull_exit=$?
                     
                     # Check if timeout occurred

--- a/development/ufm_mock/manifest.yaml
+++ b/development/ufm_mock/manifest.yaml
@@ -31,6 +31,7 @@ spec:
         app.kubernetes.io/name: ufm-mock
         app.kubernetes.io/component: dev-mock
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -112,6 +113,7 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+              ephemeral-storage: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/development/ufm_mock/manifest.yaml
+++ b/development/ufm_mock/manifest.yaml
@@ -110,6 +110,7 @@ spec:
             requests:
               cpu: 50m
               memory: 128Mi
+              ephemeral-storage: 128Mi
             limits:
               cpu: 500m
               memory: 256Mi


### PR DESCRIPTION
## Description

Address high/med sonar findings and address issue preventing the sonar pipeline.

- Scope GitHub Actions permissions to the jobs that require them and pass the RC source ref through the step environment instead of interpolating it into shell code.
- Make shell function returns explicit and replace legacy single-bracket Bash conditionals with `[[ ... ]]`.
- Propagate image-target resolution failures through every CI caller and preserve Helm/CTR failures in the air-gapped bundle paths.
- Normalize multi-package Nautobot coverage XML to one source root with package-qualified filenames so Sonar can resolve every file unambiguously.
- Share the Nautobot coverage commands between merge-request and main jobs through one fail-fast YAML anchor.
- Normalize a trailing slash in `SONAR_HOST_URL` before calling the SAST export API so the job receives JSON instead of the Sonar HTML application.
- Disable the unused UFM mock service-account token, reserve `128Mi` of ephemeral storage, and cap it at `512Mi`.
- Mark the Linked VRF attribute labels as semantic table row headers while preserving Nautobot's 25% label-column width.

## Validation

- Parsed every GitHub Actions workflow as YAML and verified affected checkout jobs have explicit `contents` permissions with no workflow-level grants remaining.
- Ran `bash -n` on every modified shell script, exercised the air-gapped creator's `--help` path, and confirmed the affected Bash scripts contain no single-bracket conditionals.
- Exercised `image_target_env.sh` with a representative image-target record and verified its exact exports.
- Verified a missing image target exits the caller with status 1, a synthetic Helm exit 42 reaches the fallback under `set -e`, and a synthetic NVCR exit 7 is retried three times.
- Ran all 124 Nautobot tests with coverage, regenerated the normalized XML, and verified it contains one source root with package-qualified paths while preserving 66% coverage.
- Parsed the shared Nautobot coverage anchor, verified both jobs resolve to the same block, and checked its shell syntax.
- Reproduced the SAST export failure against the double-slash API URL and verified the normalized URL returns a valid GitLab SAST JSON document.
- Parsed the UFM mock manifest and asserted token automounting is disabled and both storage request and limit are present.
- Verified the Linked VRF table contains three scoped row headers.
- Built the Nautobot overlay plugin sdist and wheel with `uv build`.
- Ran `git diff --check`.

- [x] Standard CI passes.
- [x] Kind integration was not run because these changes are static-analysis remediations to CI permissions, build utilities, a development-only mock manifest, and template semantics; no application workflow behavior changed.

Passing Kind Integration run: https://github.com/NVIDIA/nv-config-manager/actions/runs/28533963918

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] Existing static checks and targeted validation cover these changes; no new application tests are needed.
- [x] No documentation update is needed because there is no user-facing behavior change.
- [x] Generated artifacts are not affected; generated Go bindings were intentionally left unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation, guard checks, and exit-code handling across air-gapped bundle creation, image packaging, and target-selection logic.
  * Hardened the Kea admin entrypoint to fail fast on missing/invalid config and streamline database validation.
* **Style**
  * Updated the VXLAN retrieve UI table markup for clearer, more accessible label semantics.
* **Chores**
  * Tightened CI token permissions to job scope and improved CI shell execution safety when sourcing image-target environment exports.
  * Refined coverage generation and SonarQube URL handling; updated the UFM mock deployment’s token and storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->