### PR TITLE
fix parameter mapping in tool registration

### DIFF
--- a/bindings/go/config-store/model_batch_config_item.go
+++ b/bindings/go/config-store/model_batch_config_item.go
@@ -27,7 +27,8 @@ type BatchConfigItem struct {
 	// Commit message
 	CommitMessage string `json:"commit_message"`
 	// Configuration file content
-	Content   string       `json:"content"`
+	Content string `json:"content"`
+	// Optional timestamp for the version (defaults to current time)
 	CreatedAt NullableTime `json:"created_at,omitempty"`
 	// Config file type (intended or backup)
 	FileType *FileType `json:"file_type,omitempty"`

--- a/bindings/go/config-store/model_cache_status_response.go
+++ b/bindings/go/config-store/model_cache_status_response.go
@@ -21,12 +21,16 @@ var _ MappedNullable = &CacheStatusResponse{}
 
 // CacheStatusResponse Cache service status response.
 type CacheStatusResponse struct {
+	// Cache TTL in seconds
 	CacheTtl NullableInt32 `json:"cache_ttl,omitempty"`
 	// Whether cache service is enabled
-	Enabled           bool           `json:"enabled"`
-	Message           NullableString `json:"message,omitempty"`
-	NautobotConnected NullableBool   `json:"nautobot_connected,omitempty"`
-	RedisConnected    NullableBool   `json:"redis_connected,omitempty"`
+	Enabled bool `json:"enabled"`
+	// Status message if disabled
+	Message NullableString `json:"message,omitempty"`
+	// Whether Nautobot client is available
+	NautobotConnected NullableBool `json:"nautobot_connected,omitempty"`
+	// Whether Redis is connected
+	RedisConnected NullableBool `json:"redis_connected,omitempty"`
 }
 
 type _CacheStatusResponse CacheStatusResponse

--- a/bindings/go/config-store/model_cache_test_found_response.go
+++ b/bindings/go/config-store/model_cache_test_found_response.go
@@ -26,7 +26,8 @@ type CacheTestFoundResponse struct {
 	// Device UUID
 	DeviceUuid string `json:"device_uuid"`
 	// Whether device was found
-	Found    *bool          `json:"found,omitempty"`
+	Found *bool `json:"found,omitempty"`
+	// Platform name
 	Platform NullableString `json:"platform"`
 	// Site name
 	Site string `json:"site"`

--- a/bindings/go/config-store/model_config_create_request.go
+++ b/bindings/go/config-store/model_config_create_request.go
@@ -27,7 +27,8 @@ type ConfigCreateRequest struct {
 	// Commit message describing the change
 	CommitMessage string `json:"commit_message"`
 	// Configuration file content
-	Content   string       `json:"content"`
+	Content string `json:"content"`
+	// Optional timestamp for the version (defaults to current time)
 	CreatedAt NullableTime `json:"created_at,omitempty"`
 	// Config file type (intended or backup)
 	FileType *FileType `json:"file_type,omitempty"`

--- a/bindings/go/config-store/model_config_response.go
+++ b/bindings/go/config-store/model_config_response.go
@@ -31,8 +31,9 @@ type ConfigResponse struct {
 	// SHA256 hash of content
 	ContentHash string `json:"content_hash"`
 	// Timestamp when version was created
-	CreatedAt time.Time              `json:"created_at"`
-	Device    NullableDeviceMetadata `json:"device,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	// Device metadata from Nautobot
+	Device NullableDeviceMetadata `json:"device,omitempty"`
 	// Device UUID
 	DeviceUuid string `json:"device_uuid"`
 	// Config file type (intended or backup)

--- a/bindings/go/config-store/model_config_versions_response.go
+++ b/bindings/go/config-store/model_config_versions_response.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &ConfigVersionsResponse{}
 
 // ConfigVersionsResponse Response with list of versions.
 type ConfigVersionsResponse struct {
+	// Device metadata from Nautobot
 	Device NullableDeviceMetadata `json:"device,omitempty"`
 	// Device UUID
 	DeviceUuid string `json:"device_uuid"`

--- a/bindings/go/config-store/model_device_metadata.go
+++ b/bindings/go/config-store/model_device_metadata.go
@@ -22,14 +22,20 @@ var _ MappedNullable = &DeviceMetadata{}
 
 // DeviceMetadata Device metadata from Nautobot.
 type DeviceMetadata struct {
+	// When metadata was last refreshed
 	LastUpdated NullableTime `json:"last_updated,omitempty"`
 	// Device name
-	Name        string         `json:"name"`
+	Name string `json:"name"`
+	// Link to device in Nautobot
 	NautobotUrl NullableString `json:"nautobot_url,omitempty"`
-	Platform    NullableString `json:"platform,omitempty"`
-	PrimaryIp4  NullableString `json:"primary_ip4,omitempty"`
-	Rack        NullableString `json:"rack,omitempty"`
-	Role        NullableString `json:"role,omitempty"`
+	// Platform/OS name
+	Platform NullableString `json:"platform,omitempty"`
+	// Primary IPv4 address
+	PrimaryIp4 NullableString `json:"primary_ip4,omitempty"`
+	// Rack name
+	Rack NullableString `json:"rack,omitempty"`
+	// Device role
+	Role NullableString `json:"role,omitempty"`
 	// Site name
 	Site string `json:"site"`
 }

--- a/bindings/go/config-store/model_diff_response.go
+++ b/bindings/go/config-store/model_diff_response.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &DiffResponse{}
 
 // DiffResponse Response with diff between two versions.
 type DiffResponse struct {
+	// Device metadata from Nautobot
 	Device NullableDeviceMetadata `json:"device,omitempty"`
 	// Device UUID
 	DeviceUuid string `json:"device_uuid"`

--- a/bindings/go/internal/clienttest/generated_models_test.go
+++ b/bindings/go/internal/clienttest/generated_models_test.go
@@ -24,26 +24,46 @@ import (
 )
 
 func TestGeneratedDeviceCableValidationInputDocumentsDevice(t *testing.T) {
-	filename := filepath.Join("..", "..", "temporal", "model_device_cable_validation_input.go")
-	file, err := parser.ParseFile(token.NewFileSet(), filename, nil, parser.ParseComments)
+	const expected = "Preloaded data for the target network device, if available."
+	comments := generatedStructFieldComments(t, "model_device_cable_validation_input.go")
+	if comments["Device"] != expected {
+		t.Fatalf("Device comment = %q, want %q", comments["Device"], expected)
+	}
+}
+
+func TestGeneratedBackupInputDocumentsOptionalMetadata(t *testing.T) {
+	expected := map[string]string{
+		"IntendedConfigCommitId": "Config Store commit containing the intended configuration.",
+		"User":                   "User that requested the backup.",
+		"UserDomain":             "Domain of the user requesting the backup.",
+		"WorkflowId":             "Identifier of the parent workflow, if any.",
+	}
+	comments := generatedStructFieldComments(t, "model_backup_input.go")
+	for field, expectedComment := range expected {
+		if comments[field] != expectedComment {
+			t.Errorf("%s comment = %q, want %q", field, comments[field], expectedComment)
+		}
+	}
+}
+
+func generatedStructFieldComments(t *testing.T, filename string) map[string]string {
+	t.Helper()
+	path := filepath.Join("..", "..", "temporal", filename)
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ParseComments)
 	if err != nil {
 		t.Fatalf("parse generated model: %v", err)
 	}
 
-	var deviceComment string
+	comments := make(map[string]string)
 	ast.Inspect(file, func(node ast.Node) bool {
 		field, ok := node.(*ast.Field)
-		if !ok || len(field.Names) != 1 || field.Names[0].Name != "Device" || field.Doc == nil {
+		if !ok || len(field.Names) != 1 || field.Doc == nil {
 			return true
 		}
-		deviceComment = strings.TrimSpace(field.Doc.Text())
-		return false
+		comments[field.Names[0].Name] = strings.TrimSpace(field.Doc.Text())
+		return true
 	})
-
-	const expected = "Preloaded data for the target network device, if available."
-	if deviceComment != expected {
-		t.Fatalf("Device comment = %q, want %q", deviceComment, expected)
-	}
+	return comments
 }
 
 func TestGeneratedModelsRejectNullForRequiredFields(t *testing.T) {

--- a/bindings/go/internal/clienttest/generated_models_test.go
+++ b/bindings/go/internal/clienttest/generated_models_test.go
@@ -6,10 +6,14 @@ package clienttest
 import (
 	"context"
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -18,6 +22,29 @@ import (
 	"github.com/nvidia/nv-config-manager/bindings/go/render"
 	"github.com/nvidia/nv-config-manager/bindings/go/ztp"
 )
+
+func TestGeneratedDeviceCableValidationInputDocumentsDevice(t *testing.T) {
+	filename := filepath.Join("..", "..", "temporal", "model_device_cable_validation_input.go")
+	file, err := parser.ParseFile(token.NewFileSet(), filename, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse generated model: %v", err)
+	}
+
+	var deviceComment string
+	ast.Inspect(file, func(node ast.Node) bool {
+		field, ok := node.(*ast.Field)
+		if !ok || len(field.Names) != 1 || field.Names[0].Name != "Device" || field.Doc == nil {
+			return true
+		}
+		deviceComment = strings.TrimSpace(field.Doc.Text())
+		return false
+	})
+
+	const expected = "Preloaded data for the target network device, if available."
+	if deviceComment != expected {
+		t.Fatalf("Device comment = %q, want %q", deviceComment, expected)
+	}
+}
 
 func TestGeneratedModelsRejectNullForRequiredFields(t *testing.T) {
 	testCases := []struct {

--- a/bindings/go/render/model_bulk_render_response.go
+++ b/bindings/go/render/model_bulk_render_response.go
@@ -21,10 +21,12 @@ var _ MappedNullable = &BulkRenderResponse{}
 
 // BulkRenderResponse Response from a bulk render operation (render-all or batch).
 type BulkRenderResponse struct {
-	FailedDevices  []FailedDevice `json:"failed_devices,omitempty"`
-	MaxConcurrency NullableInt32  `json:"max_concurrency,omitempty"`
-	Message        string         `json:"message"`
-	QueuedCount    int32          `json:"queued_count"`
+	// Devices that failed to queue
+	FailedDevices []FailedDevice `json:"failed_devices,omitempty"`
+	// Maximum concurrent renders (batch only)
+	MaxConcurrency NullableInt32 `json:"max_concurrency,omitempty"`
+	Message        string        `json:"message"`
+	QueuedCount    int32         `json:"queued_count"`
 	// Total number of devices targeted
 	TotalDevices *int32 `json:"total_devices,omitempty"`
 }

--- a/bindings/go/temporal/model_backup_input.go
+++ b/bindings/go/temporal/model_backup_input.go
@@ -23,12 +23,12 @@ var _ MappedNullable = &BackupInput{}
 type BackupInput struct {
 	// Identifier of the network device to back up.
 	DeviceId               string         `json:"device_id"`
-	IntendedConfigCommitId NullableString `json:"intended_config_commit_id"`
+	IntendedConfigCommitId NullableString `json:"intended_config_commit_id,omitempty"`
 	// Reason the backup workflow was started.
 	Trigger    TriggerEnum    `json:"trigger"`
-	User       NullableString `json:"user"`
-	UserDomain NullableString `json:"user_domain"`
-	WorkflowId NullableString `json:"workflow_id"`
+	User       NullableString `json:"user,omitempty"`
+	UserDomain NullableString `json:"user_domain,omitempty"`
+	WorkflowId NullableString `json:"workflow_id,omitempty"`
 }
 
 type _BackupInput BackupInput
@@ -37,14 +37,10 @@ type _BackupInput BackupInput
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBackupInput(deviceId string, intendedConfigCommitId NullableString, trigger TriggerEnum, user NullableString, userDomain NullableString, workflowId NullableString) *BackupInput {
+func NewBackupInput(deviceId string, trigger TriggerEnum) *BackupInput {
 	this := BackupInput{}
 	this.DeviceId = deviceId
-	this.IntendedConfigCommitId = intendedConfigCommitId
 	this.Trigger = trigger
-	this.User = user
-	this.UserDomain = userDomain
-	this.WorkflowId = workflowId
 	return &this
 }
 
@@ -80,20 +76,20 @@ func (o *BackupInput) SetDeviceId(v string) {
 	o.DeviceId = v
 }
 
-// GetIntendedConfigCommitId returns the IntendedConfigCommitId field value
-// If the value is explicit nil, the zero value for string will be returned
+// GetIntendedConfigCommitId returns the IntendedConfigCommitId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BackupInput) GetIntendedConfigCommitId() string {
-	if o == nil || o.IntendedConfigCommitId.Get() == nil {
+	if o == nil || IsNil(o.IntendedConfigCommitId.Get()) {
 		var ret string
 		return ret
 	}
-
 	return *o.IntendedConfigCommitId.Get()
 }
 
-// GetIntendedConfigCommitIdOk returns a tuple with the IntendedConfigCommitId field value
+// GetIntendedConfigCommitIdOk returns a tuple with the IntendedConfigCommitId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
+
 func (o *BackupInput) GetIntendedConfigCommitIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -101,9 +97,28 @@ func (o *BackupInput) GetIntendedConfigCommitIdOk() (*string, bool) {
 	return o.IntendedConfigCommitId.Get(), o.IntendedConfigCommitId.IsSet()
 }
 
-// SetIntendedConfigCommitId sets field value
+// HasIntendedConfigCommitId returns a boolean if a field has been set.
+func (o *BackupInput) HasIntendedConfigCommitId() bool {
+	if o != nil && o.IntendedConfigCommitId.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetIntendedConfigCommitId gets a reference to the given NullableString and assigns it to the IntendedConfigCommitId field.
 func (o *BackupInput) SetIntendedConfigCommitId(v string) {
 	o.IntendedConfigCommitId.Set(&v)
+}
+
+// SetIntendedConfigCommitIdNil sets the value for IntendedConfigCommitId to be an explicit nil
+func (o *BackupInput) SetIntendedConfigCommitIdNil() {
+	o.IntendedConfigCommitId.Set(nil)
+}
+
+// UnsetIntendedConfigCommitId ensures that no value is present for IntendedConfigCommitId, not even an explicit nil
+func (o *BackupInput) UnsetIntendedConfigCommitId() {
+	o.IntendedConfigCommitId.Unset()
 }
 
 // GetTrigger returns the Trigger field value
@@ -130,20 +145,20 @@ func (o *BackupInput) SetTrigger(v TriggerEnum) {
 	o.Trigger = v
 }
 
-// GetUser returns the User field value
-// If the value is explicit nil, the zero value for string will be returned
+// GetUser returns the User field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BackupInput) GetUser() string {
-	if o == nil || o.User.Get() == nil {
+	if o == nil || IsNil(o.User.Get()) {
 		var ret string
 		return ret
 	}
-
 	return *o.User.Get()
 }
 
-// GetUserOk returns a tuple with the User field value
+// GetUserOk returns a tuple with the User field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
+
 func (o *BackupInput) GetUserOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -151,25 +166,44 @@ func (o *BackupInput) GetUserOk() (*string, bool) {
 	return o.User.Get(), o.User.IsSet()
 }
 
-// SetUser sets field value
+// HasUser returns a boolean if a field has been set.
+func (o *BackupInput) HasUser() bool {
+	if o != nil && o.User.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetUser gets a reference to the given NullableString and assigns it to the User field.
 func (o *BackupInput) SetUser(v string) {
 	o.User.Set(&v)
 }
 
-// GetUserDomain returns the UserDomain field value
-// If the value is explicit nil, the zero value for string will be returned
+// SetUserNil sets the value for User to be an explicit nil
+func (o *BackupInput) SetUserNil() {
+	o.User.Set(nil)
+}
+
+// UnsetUser ensures that no value is present for User, not even an explicit nil
+func (o *BackupInput) UnsetUser() {
+	o.User.Unset()
+}
+
+// GetUserDomain returns the UserDomain field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BackupInput) GetUserDomain() string {
-	if o == nil || o.UserDomain.Get() == nil {
+	if o == nil || IsNil(o.UserDomain.Get()) {
 		var ret string
 		return ret
 	}
-
 	return *o.UserDomain.Get()
 }
 
-// GetUserDomainOk returns a tuple with the UserDomain field value
+// GetUserDomainOk returns a tuple with the UserDomain field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
+
 func (o *BackupInput) GetUserDomainOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -177,25 +211,44 @@ func (o *BackupInput) GetUserDomainOk() (*string, bool) {
 	return o.UserDomain.Get(), o.UserDomain.IsSet()
 }
 
-// SetUserDomain sets field value
+// HasUserDomain returns a boolean if a field has been set.
+func (o *BackupInput) HasUserDomain() bool {
+	if o != nil && o.UserDomain.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetUserDomain gets a reference to the given NullableString and assigns it to the UserDomain field.
 func (o *BackupInput) SetUserDomain(v string) {
 	o.UserDomain.Set(&v)
 }
 
-// GetWorkflowId returns the WorkflowId field value
-// If the value is explicit nil, the zero value for string will be returned
+// SetUserDomainNil sets the value for UserDomain to be an explicit nil
+func (o *BackupInput) SetUserDomainNil() {
+	o.UserDomain.Set(nil)
+}
+
+// UnsetUserDomain ensures that no value is present for UserDomain, not even an explicit nil
+func (o *BackupInput) UnsetUserDomain() {
+	o.UserDomain.Unset()
+}
+
+// GetWorkflowId returns the WorkflowId field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BackupInput) GetWorkflowId() string {
-	if o == nil || o.WorkflowId.Get() == nil {
+	if o == nil || IsNil(o.WorkflowId.Get()) {
 		var ret string
 		return ret
 	}
-
 	return *o.WorkflowId.Get()
 }
 
-// GetWorkflowIdOk returns a tuple with the WorkflowId field value
+// GetWorkflowIdOk returns a tuple with the WorkflowId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
+
 func (o *BackupInput) GetWorkflowIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -203,9 +256,28 @@ func (o *BackupInput) GetWorkflowIdOk() (*string, bool) {
 	return o.WorkflowId.Get(), o.WorkflowId.IsSet()
 }
 
-// SetWorkflowId sets field value
+// HasWorkflowId returns a boolean if a field has been set.
+func (o *BackupInput) HasWorkflowId() bool {
+	if o != nil && o.WorkflowId.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetWorkflowId gets a reference to the given NullableString and assigns it to the WorkflowId field.
 func (o *BackupInput) SetWorkflowId(v string) {
 	o.WorkflowId.Set(&v)
+}
+
+// SetWorkflowIdNil sets the value for WorkflowId to be an explicit nil
+func (o *BackupInput) SetWorkflowIdNil() {
+	o.WorkflowId.Set(nil)
+}
+
+// UnsetWorkflowId ensures that no value is present for WorkflowId, not even an explicit nil
+func (o *BackupInput) UnsetWorkflowId() {
+	o.WorkflowId.Unset()
 }
 
 func (o BackupInput) MarshalJSON() ([]byte, error) {
@@ -219,11 +291,19 @@ func (o BackupInput) MarshalJSON() ([]byte, error) {
 func (o BackupInput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["device_id"] = o.DeviceId
-	toSerialize["intended_config_commit_id"] = o.IntendedConfigCommitId.Get()
+	if o.IntendedConfigCommitId.IsSet() {
+		toSerialize["intended_config_commit_id"] = o.IntendedConfigCommitId.Get()
+	}
 	toSerialize["trigger"] = o.Trigger
-	toSerialize["user"] = o.User.Get()
-	toSerialize["user_domain"] = o.UserDomain.Get()
-	toSerialize["workflow_id"] = o.WorkflowId.Get()
+	if o.User.IsSet() {
+		toSerialize["user"] = o.User.Get()
+	}
+	if o.UserDomain.IsSet() {
+		toSerialize["user_domain"] = o.UserDomain.Get()
+	}
+	if o.WorkflowId.IsSet() {
+		toSerialize["workflow_id"] = o.WorkflowId.Get()
+	}
 	return toSerialize, nil
 }
 
@@ -232,12 +312,8 @@ func (o *BackupInput) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := map[string]bool{
-		"device_id":                 false,
-		"intended_config_commit_id": true,
-		"trigger":                   false,
-		"user":                      true,
-		"user_domain":               true,
-		"workflow_id":               true,
+		"device_id": false,
+		"trigger":   false,
 	}
 
 	allProperties := make(map[string]interface{})

--- a/bindings/go/temporal/model_backup_input.go
+++ b/bindings/go/temporal/model_backup_input.go
@@ -21,12 +21,14 @@ var _ MappedNullable = &BackupInput{}
 
 // BackupInput Backup Workflow Input Definiton.
 type BackupInput struct {
+	// Identifier of the network device to back up.
 	DeviceId               string         `json:"device_id"`
 	IntendedConfigCommitId NullableString `json:"intended_config_commit_id"`
-	Trigger                TriggerEnum    `json:"trigger"`
-	User                   NullableString `json:"user"`
-	UserDomain             NullableString `json:"user_domain"`
-	WorkflowId             NullableString `json:"workflow_id"`
+	// Reason the backup workflow was started.
+	Trigger    TriggerEnum    `json:"trigger"`
+	User       NullableString `json:"user"`
+	UserDomain NullableString `json:"user_domain"`
+	WorkflowId NullableString `json:"workflow_id"`
 }
 
 type _BackupInput BackupInput

--- a/bindings/go/temporal/model_backup_input.go
+++ b/bindings/go/temporal/model_backup_input.go
@@ -22,12 +22,16 @@ var _ MappedNullable = &BackupInput{}
 // BackupInput Backup Workflow Input Definiton.
 type BackupInput struct {
 	// Identifier of the network device to back up.
-	DeviceId               string         `json:"device_id"`
+	DeviceId string `json:"device_id"`
+	// Config Store commit containing the intended configuration.
 	IntendedConfigCommitId NullableString `json:"intended_config_commit_id,omitempty"`
 	// Reason the backup workflow was started.
-	Trigger    TriggerEnum    `json:"trigger"`
-	User       NullableString `json:"user,omitempty"`
+	Trigger TriggerEnum `json:"trigger"`
+	// User that requested the backup.
+	User NullableString `json:"user,omitempty"`
+	// Domain of the user requesting the backup.
 	UserDomain NullableString `json:"user_domain,omitempty"`
+	// Identifier of the parent workflow, if any.
 	WorkflowId NullableString `json:"workflow_id,omitempty"`
 }
 

--- a/bindings/go/temporal/model_batch_deploy_input.go
+++ b/bindings/go/temporal/model_batch_deploy_input.go
@@ -21,11 +21,15 @@ var _ MappedNullable = &BatchDeployInput{}
 
 // BatchDeployInput Input for batch deploy child workflow.
 type BatchDeployInput struct {
-	BatchDevices     []DeviceDiffData `json:"batch_devices"`
-	BatchNumber      NullableInt32    `json:"batch_number,omitempty"`
-	CommitConfirm    *bool            `json:"commit_confirm,omitempty"`
-	DiffGroup        DiffGroup        `json:"diff_group"`
-	ParentWorkflowId string           `json:"parent_workflow_id"`
+	// Devices whose configurations will be deployed in this batch.
+	BatchDevices []DeviceDiffData `json:"batch_devices"`
+	BatchNumber  NullableInt32    `json:"batch_number,omitempty"`
+	// Whether to use commit-confirmed mode when the platform supports it.
+	CommitConfirm *bool `json:"commit_confirm,omitempty"`
+	// Shared configuration diff for the device batch.
+	DiffGroup DiffGroup `json:"diff_group"`
+	// Identifier of the parent multi-deploy workflow.
+	ParentWorkflowId string `json:"parent_workflow_id"`
 }
 
 type _BatchDeployInput BatchDeployInput

--- a/bindings/go/temporal/model_batch_deploy_input.go
+++ b/bindings/go/temporal/model_batch_deploy_input.go
@@ -23,7 +23,8 @@ var _ MappedNullable = &BatchDeployInput{}
 type BatchDeployInput struct {
 	// Devices whose configurations will be deployed in this batch.
 	BatchDevices []DeviceDiffData `json:"batch_devices"`
-	BatchNumber  NullableInt32    `json:"batch_number,omitempty"`
+	// Sequence number of this batch within the parent workflow.
+	BatchNumber NullableInt32 `json:"batch_number,omitempty"`
 	// Whether to use commit-confirmed mode when the platform supports it.
 	CommitConfirm *bool `json:"commit_confirm,omitempty"`
 	// Shared configuration diff for the device batch.

--- a/bindings/go/temporal/model_connected_host_workflow_input.go
+++ b/bindings/go/temporal/model_connected_host_workflow_input.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &ConnectedHostWorkflowInput{}
 
 // ConnectedHostWorkflowInput Connected Host Workflow Input.
 type ConnectedHostWorkflowInput struct {
+	// Identifier of the network device to analyze.
 	DeviceId string `json:"device_id"`
 }
 

--- a/bindings/go/temporal/model_deploy_input.go
+++ b/bindings/go/temporal/model_deploy_input.go
@@ -21,8 +21,10 @@ var _ MappedNullable = &DeployInput{}
 
 // DeployInput Config Deployment Workflow Input Definiton.
 type DeployInput struct {
-	CommitConfirm *bool  `json:"commit_confirm,omitempty"`
-	DeviceId      string `json:"device_id"`
+	// Whether to use commit-confirmed mode when the platform supports it.
+	CommitConfirm *bool `json:"commit_confirm,omitempty"`
+	// Identifier of the network device to configure.
+	DeviceId string `json:"device_id"`
 }
 
 type _DeployInput DeployInput

--- a/bindings/go/temporal/model_device_1.go
+++ b/bindings/go/temporal/model_device_1.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 )
 
-// Device1 struct for Device1
+// Device1 Identifier or preloaded data for the target network device.
 type Device1 struct {
 	NetworkDeviceData *NetworkDeviceData
 	String            *string

--- a/bindings/go/temporal/model_device_cable_validation_input.go
+++ b/bindings/go/temporal/model_device_cable_validation_input.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &DeviceCableValidationInput{}
 
 // DeviceCableValidationInput Input for Device Cable Validation Workflow.
 type DeviceCableValidationInput struct {
+	// Preloaded data for the target network device, if available.
 	Device NullableNetworkDeviceData `json:"device,omitempty"`
 	// Identifier of the network device to validate.
 	DeviceId string `json:"device_id"`

--- a/bindings/go/temporal/model_device_cable_validation_input.go
+++ b/bindings/go/temporal/model_device_cable_validation_input.go
@@ -21,9 +21,11 @@ var _ MappedNullable = &DeviceCableValidationInput{}
 
 // DeviceCableValidationInput Input for Device Cable Validation Workflow.
 type DeviceCableValidationInput struct {
-	Device           NullableNetworkDeviceData `json:"device,omitempty"`
-	DeviceId         string                    `json:"device_id"`
-	IgnoreNoNeighbor *bool                     `json:"ignore_no_neighbor,omitempty"`
+	Device NullableNetworkDeviceData `json:"device,omitempty"`
+	// Identifier of the network device to validate.
+	DeviceId string `json:"device_id"`
+	// Whether interfaces without discovered neighbors should be ignored.
+	IgnoreNoNeighbor *bool `json:"ignore_no_neighbor,omitempty"`
 }
 
 type _DeviceCableValidationInput DeviceCableValidationInput

--- a/bindings/go/temporal/model_device_password_rotation_input.go
+++ b/bindings/go/temporal/model_device_password_rotation_input.go
@@ -21,7 +21,9 @@ var _ MappedNullable = &DevicePasswordRotationInput{}
 
 // DevicePasswordRotationInput Device Password Rotation Workflow Input Definition.
 type DevicePasswordRotationInput struct {
-	DeviceId       string `json:"device_id"`
+	// Identifier of the network device to update.
+	DeviceId string `json:"device_id"`
+	// Name of the managed secret containing the replacement password.
 	SelectedSecret string `json:"selected_secret"`
 }
 

--- a/bindings/go/temporal/model_diagnostics_workflow_input.go
+++ b/bindings/go/temporal/model_diagnostics_workflow_input.go
@@ -21,12 +21,18 @@ var _ MappedNullable = &DiagnosticsWorkflowInput{}
 
 // DiagnosticsWorkflowInput struct for DiagnosticsWorkflowInput
 type DiagnosticsWorkflowInput struct {
-	Commands           []string `json:"commands"`
-	DeviceIds          []string `json:"device_ids"`
-	IncludeTechSupport *bool    `json:"include_tech_support,omitempty"`
-	IssueKey           *string  `json:"issue_key,omitempty"`
-	TicketingPlatform  *string  `json:"ticketing_platform,omitempty"`
-	User               *string  `json:"user,omitempty"`
+	// Diagnostic command catalog names to run on each device.
+	Commands []string `json:"commands"`
+	// Nautobot identifiers of the devices to diagnose.
+	DeviceIds []string `json:"device_ids"`
+	// Whether to collect a technical-support bundle from each device.
+	IncludeTechSupport *bool `json:"include_tech_support,omitempty"`
+	// Issue key to update; empty enables ticketless mode.
+	IssueKey *string `json:"issue_key,omitempty"`
+	// Ticketing platform to update; empty enables ticketless mode.
+	TicketingPlatform *string `json:"ticketing_platform,omitempty"`
+	// Engineer username or email, populated from request authentication when omitted.
+	User *string `json:"user,omitempty"`
 }
 
 type _DiagnosticsWorkflowInput DiagnosticsWorkflowInput

--- a/bindings/go/temporal/model_hello_world_input.go
+++ b/bindings/go/temporal/model_hello_world_input.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &HelloWorldInput{}
 
 // HelloWorldInput Hello World Input Definition.
 type HelloWorldInput struct {
+	// Name to include in the workflow greeting.
 	Name string `json:"name"`
 }
 

--- a/bindings/go/temporal/model_ib_port_guid_discovery_input.go
+++ b/bindings/go/temporal/model_ib_port_guid_discovery_input.go
@@ -21,9 +21,12 @@ var _ MappedNullable = &IBPortGuidDiscoveryInput{}
 
 // IBPortGuidDiscoveryInput Input for the IB Port GUID Discovery workflow.
 type IBPortGuidDiscoveryInput struct {
-	DryRun          *bool    `json:"dry_run,omitempty"`
+	// Whether to report changes without updating Nautobot.
+	DryRun *bool `json:"dry_run,omitempty"`
+	// Identifiers of the InfiniBand switches whose interfaces will be synchronized.
 	SwitchDeviceIds []string `json:"switch_device_ids"`
-	UfmDeviceId     string   `json:"ufm_device_id"`
+	// Identifier of the UFM device used to discover port GUIDs.
+	UfmDeviceId string `json:"ufm_device_id"`
 }
 
 type _IBPortGuidDiscoveryInput IBPortGuidDiscoveryInput

--- a/bindings/go/temporal/model_ibp_key_creation_input.go
+++ b/bindings/go/temporal/model_ibp_key_creation_input.go
@@ -24,13 +24,15 @@ type IBPKeyCreationInput struct {
 	// Hostname of the UFM server managing the InfiniBand fabric.
 	Host string `json:"host"`
 	// Whether IP over InfiniBand is enabled for the partition.
-	IpOverIb *bool          `json:"ip_over_ib,omitempty"`
-	Pkey     NullableString `json:"pkey,omitempty"`
+	IpOverIb *bool `json:"ip_over_ib,omitempty"`
+	// Partition key to create; automatically allocated when omitted.
+	Pkey NullableString `json:"pkey,omitempty"`
 	// Highest partition key eligible for automatic allocation.
 	PkeyMax *int32 `json:"pkey_max,omitempty"`
 	// Lowest partition key eligible for automatic allocation.
-	PkeyMin *int32         `json:"pkey_min,omitempty"`
-	Site    NullableString `json:"site,omitempty"`
+	PkeyMin *int32 `json:"pkey_min,omitempty"`
+	// Site used for UFM credential lookup; resolved from the host when omitted.
+	Site NullableString `json:"site,omitempty"`
 }
 
 type _IBPKeyCreationInput IBPKeyCreationInput

--- a/bindings/go/temporal/model_ibp_key_creation_input.go
+++ b/bindings/go/temporal/model_ibp_key_creation_input.go
@@ -21,12 +21,16 @@ var _ MappedNullable = &IBPKeyCreationInput{}
 
 // IBPKeyCreationInput InfiniBand PKey Creation Workflow Input.  By default, auto-assigns the next available PKey. Pass an explicit “pkey“ value only when a specific partition key is required.  “site“ is optional. When omitted, the workflow resolves the device's Site-typed Nautobot location from “host“ and uses that as the UFM credential lookup key. Pass “site“ explicitly to override the auto-resolved value (e.g. for API callers that want to skip the Nautobot round-trip).
 type IBPKeyCreationInput struct {
-	Host     string         `json:"host"`
+	// Hostname of the UFM server managing the InfiniBand fabric.
+	Host string `json:"host"`
+	// Whether IP over InfiniBand is enabled for the partition.
 	IpOverIb *bool          `json:"ip_over_ib,omitempty"`
 	Pkey     NullableString `json:"pkey,omitempty"`
-	PkeyMax  *int32         `json:"pkey_max,omitempty"`
-	PkeyMin  *int32         `json:"pkey_min,omitempty"`
-	Site     NullableString `json:"site,omitempty"`
+	// Highest partition key eligible for automatic allocation.
+	PkeyMax *int32 `json:"pkey_max,omitempty"`
+	// Lowest partition key eligible for automatic allocation.
+	PkeyMin *int32         `json:"pkey_min,omitempty"`
+	Site    NullableString `json:"site,omitempty"`
 }
 
 type _IBPKeyCreationInput IBPKeyCreationInput

--- a/bindings/go/temporal/model_ibp_key_member_add_input.go
+++ b/bindings/go/temporal/model_ibp_key_member_add_input.go
@@ -21,13 +21,20 @@ var _ MappedNullable = &IBPKeyMemberAddInput{}
 
 // IBPKeyMemberAddInput InfiniBand PKey Member Add Workflow Input.  Site and Overlay are resolved server-side from “host“ and “pkey“.
 type IBPKeyMemberAddInput struct {
-	GuidMemberships []string       `json:"guid_memberships,omitempty"`
-	Guids           []string       `json:"guids,omitempty"`
-	Host            string         `json:"host"`
-	Interfaces      []InterfaceRef `json:"interfaces,omitempty"`
-	IpOverIb        *bool          `json:"ip_over_ib,omitempty"`
-	MembershipType  *string        `json:"membership_type,omitempty"`
-	Pkey            string         `json:"pkey"`
+	// Per-GUID membership types corresponding to the supplied GUIDs.
+	GuidMemberships []string `json:"guid_memberships,omitempty"`
+	// InfiniBand port GUIDs to add directly to the partition.
+	Guids []string `json:"guids,omitempty"`
+	// Hostname of the UFM server managing the InfiniBand fabric.
+	Host string `json:"host"`
+	// Nautobot interfaces to resolve to InfiniBand port GUIDs.
+	Interfaces []InterfaceRef `json:"interfaces,omitempty"`
+	// Whether IP over InfiniBand is enabled for the partition.
+	IpOverIb *bool `json:"ip_over_ib,omitempty"`
+	// Default partition membership type for added members.
+	MembershipType *string `json:"membership_type,omitempty"`
+	// Partition key whose membership will be expanded.
+	Pkey string `json:"pkey"`
 }
 
 type _IBPKeyMemberAddInput IBPKeyMemberAddInput

--- a/bindings/go/temporal/model_ibp_key_member_delete_input.go
+++ b/bindings/go/temporal/model_ibp_key_member_delete_input.go
@@ -21,10 +21,14 @@ var _ MappedNullable = &IBPKeyMemberDeleteInput{}
 
 // IBPKeyMemberDeleteInput InfiniBand PKey Member Delete Workflow Input.  Provide either “interfaces“ (resolved to GUIDs via Nautobot) or “guids“ directly, but not both. Site and Overlay are resolved server-side from “host“ and “pkey“.
 type IBPKeyMemberDeleteInput struct {
-	Guids      []string       `json:"guids,omitempty"`
-	Host       string         `json:"host"`
+	// InfiniBand port GUIDs to remove directly from the partition.
+	Guids []string `json:"guids,omitempty"`
+	// Hostname of the UFM server managing the InfiniBand fabric.
+	Host string `json:"host"`
+	// Nautobot interfaces to resolve to InfiniBand port GUIDs.
 	Interfaces []InterfaceRef `json:"interfaces,omitempty"`
-	Pkey       string         `json:"pkey"`
+	// Partition key whose members will be removed.
+	Pkey string `json:"pkey"`
 }
 
 type _IBPKeyMemberDeleteInput IBPKeyMemberDeleteInput

--- a/bindings/go/temporal/model_ibp_key_member_update_input.go
+++ b/bindings/go/temporal/model_ibp_key_member_update_input.go
@@ -21,13 +21,20 @@ var _ MappedNullable = &IBPKeyMemberUpdateInput{}
 
 // IBPKeyMemberUpdateInput InfiniBand PKey Member Update Workflow Input.  Site and Overlay are resolved server-side from “host“ and “pkey“.
 type IBPKeyMemberUpdateInput struct {
-	GuidMemberships []string       `json:"guid_memberships,omitempty"`
-	Guids           []string       `json:"guids,omitempty"`
-	Host            string         `json:"host"`
-	Interfaces      []InterfaceRef `json:"interfaces,omitempty"`
-	IpOverIb        *bool          `json:"ip_over_ib,omitempty"`
-	MembershipType  *string        `json:"membership_type,omitempty"`
-	Pkey            string         `json:"pkey"`
+	// Per-GUID membership types corresponding to the supplied GUIDs.
+	GuidMemberships []string `json:"guid_memberships,omitempty"`
+	// InfiniBand port GUIDs that should belong to the partition.
+	Guids []string `json:"guids,omitempty"`
+	// Hostname of the UFM server managing the InfiniBand fabric.
+	Host string `json:"host"`
+	// Nautobot interfaces to resolve to InfiniBand port GUIDs.
+	Interfaces []InterfaceRef `json:"interfaces,omitempty"`
+	// IP over InfiniBand setting used when the partition does not already exist.
+	IpOverIb *bool `json:"ip_over_ib,omitempty"`
+	// Default partition membership type for updated members.
+	MembershipType *string `json:"membership_type,omitempty"`
+	// Partition key whose membership will be replaced.
+	Pkey string `json:"pkey"`
 }
 
 type _IBPKeyMemberUpdateInput IBPKeyMemberUpdateInput

--- a/bindings/go/temporal/model_infiniband_cable_validation_input.go
+++ b/bindings/go/temporal/model_infiniband_cable_validation_input.go
@@ -21,8 +21,10 @@ var _ MappedNullable = &InfinibandCableValidationInput{}
 
 // InfinibandCableValidationInput IB Cable Validation Workflow Input Definition.
 type InfinibandCableValidationInput struct {
+	// Identifiers of the InfiniBand switches to validate.
 	SwitchDeviceIds []string `json:"switch_device_ids"`
-	UfmDeviceId     string   `json:"ufm_device_id"`
+	// Identifier of the UFM device used to inspect the InfiniBand fabric.
+	UfmDeviceId string `json:"ufm_device_id"`
 }
 
 type _InfinibandCableValidationInput InfinibandCableValidationInput

--- a/bindings/go/temporal/model_infiniband_get_unhealthy_ports_input.go
+++ b/bindings/go/temporal/model_infiniband_get_unhealthy_ports_input.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &InfinibandGetUnhealthyPortsInput{}
 
 // InfinibandGetUnhealthyPortsInput Unhealthy Ports Validation Workflow Input Definition.
 type InfinibandGetUnhealthyPortsInput struct {
+	// Identifier of the UFM device to inspect.
 	DeviceId string `json:"device_id"`
 }
 

--- a/bindings/go/temporal/model_infiniband_mlnx_os_upgrade_input.go
+++ b/bindings/go/temporal/model_infiniband_mlnx_os_upgrade_input.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &InfinibandMlnxOSUpgradeInput{}
 
 // InfinibandMlnxOSUpgradeInput Infiniband Mellanox OS Upgrade Workflow Input Definition.
 type InfinibandMlnxOSUpgradeInput struct {
+	// Identifier of the InfiniBand switch to upgrade.
 	DeviceId string `json:"device_id"`
 }
 

--- a/bindings/go/temporal/model_multi_deploy_input.go
+++ b/bindings/go/temporal/model_multi_deploy_input.go
@@ -22,13 +22,16 @@ var _ MappedNullable = &MultiDeployInput{}
 // MultiDeployInput Multi-Deploy Workflow Input Definition.
 type MultiDeployInput struct {
 	// Whether to use commit-confirmed mode when the platform supports it.
-	CommitConfirm *bool          `json:"commit_confirm,omitempty"`
-	Location      NullableString `json:"location,omitempty"`
+	CommitConfirm *bool `json:"commit_confirm,omitempty"`
+	// Location used to filter the selected network devices.
+	Location NullableString `json:"location,omitempty"`
 	// Maximum number of devices included in each deployment batch.
 	MaxBatchSize *int32 `json:"max_batch_size,omitempty"`
 	// Device role used to select network devices for deployment.
-	Role   string         `json:"role"`
-	Status []string       `json:"status,omitempty"`
+	Role string `json:"role"`
+	// Device statuses used to filter the selected network devices.
+	Status []string `json:"status,omitempty"`
+	// Tenant used to filter the selected network devices.
 	Tenant NullableString `json:"tenant,omitempty"`
 }
 

--- a/bindings/go/temporal/model_multi_deploy_input.go
+++ b/bindings/go/temporal/model_multi_deploy_input.go
@@ -21,12 +21,15 @@ var _ MappedNullable = &MultiDeployInput{}
 
 // MultiDeployInput Multi-Deploy Workflow Input Definition.
 type MultiDeployInput struct {
+	// Whether to use commit-confirmed mode when the platform supports it.
 	CommitConfirm *bool          `json:"commit_confirm,omitempty"`
 	Location      NullableString `json:"location,omitempty"`
-	MaxBatchSize  *int32         `json:"max_batch_size,omitempty"`
-	Role          string         `json:"role"`
-	Status        []string       `json:"status,omitempty"`
-	Tenant        NullableString `json:"tenant,omitempty"`
+	// Maximum number of devices included in each deployment batch.
+	MaxBatchSize *int32 `json:"max_batch_size,omitempty"`
+	// Device role used to select network devices for deployment.
+	Role   string         `json:"role"`
+	Status []string       `json:"status,omitempty"`
+	Tenant NullableString `json:"tenant,omitempty"`
 }
 
 type _MultiDeployInput MultiDeployInput

--- a/bindings/go/temporal/model_nv_link_switch_firmware_upgrade_input.go
+++ b/bindings/go/temporal/model_nv_link_switch_firmware_upgrade_input.go
@@ -21,8 +21,10 @@ var _ MappedNullable = &NVLinkSwitchFirmwareUpgradeInput{}
 
 // NVLinkSwitchFirmwareUpgradeInput NVLinkSwitch Firmware Upgrade Workflow Input Definition.
 type NVLinkSwitchFirmwareUpgradeInput struct {
+	// Target NVLink firmware bundle version.
 	BundleVersion string `json:"bundle_version"`
-	DeviceId      string `json:"device_id"`
+	// Identifier of the NVLink switch to upgrade.
+	DeviceId string `json:"device_id"`
 }
 
 type _NVLinkSwitchFirmwareUpgradeInput NVLinkSwitchFirmwareUpgradeInput

--- a/bindings/go/temporal/model_port_lldp_info_input.go
+++ b/bindings/go/temporal/model_port_lldp_info_input.go
@@ -19,8 +19,11 @@ var _ MappedNullable = &PortLLDPInfoInput{}
 
 // PortLLDPInfoInput Input for Port LLDP Info Workflow.
 type PortLLDPInfoInput struct {
-	DeviceId         NullableString `json:"device_id,omitempty"`
-	Interface        NullableString `json:"interface,omitempty"`
+	// Identifier of the network device to inspect.
+	DeviceId NullableString `json:"device_id,omitempty"`
+	// Name of the local interface.
+	Interface NullableString `json:"interface,omitempty"`
+	// MAC address of the remote device to locate.
 	RemoteMacAddress NullableString `json:"remote_mac_address,omitempty"`
 }
 

--- a/bindings/go/temporal/model_redfish_provisioning_input.go
+++ b/bindings/go/temporal/model_redfish_provisioning_input.go
@@ -21,13 +21,20 @@ var _ MappedNullable = &RedfishProvisioningInput{}
 
 // RedfishProvisioningInput Input for Redfish provisioning workflow.
 type RedfishProvisioningInput struct {
-	BmcSwitchRoles   []string `json:"bmc_switch_roles"`
+	// Switch roles used to discover BMC-connected network interfaces.
+	BmcSwitchRoles []string `json:"bmc_switch_roles"`
+	// DPU manufacturer names eligible for Redfish provisioning.
 	DpuManufacturers []string `json:"dpu_manufacturers,omitempty"`
-	HttpTimeoutS     *int32   `json:"http_timeout_s,omitempty"`
-	IpRangeEnd       string   `json:"ip_range_end"`
-	IpRangeStart     string   `json:"ip_range_start"`
-	Port             *int32   `json:"port,omitempty"`
-	Site             string   `json:"site"`
+	// Timeout in seconds for Redfish HTTP requests.
+	HttpTimeoutS *int32 `json:"http_timeout_s,omitempty"`
+	// Last BMC IP address to scan.
+	IpRangeEnd string `json:"ip_range_end"`
+	// First BMC IP address to scan.
+	IpRangeStart string `json:"ip_range_start"`
+	// HTTPS port used to contact Redfish services.
+	Port *int32 `json:"port,omitempty"`
+	// Site containing the BMC network to provision.
+	Site string `json:"site"`
 }
 
 type _RedfishProvisioningInput RedfishProvisioningInput

--- a/bindings/go/temporal/model_reprovision_input.go
+++ b/bindings/go/temporal/model_reprovision_input.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &ReprovisionInput{}
 
 // ReprovisionInput Reprovision Workflow Input Definition.
 type ReprovisionInput struct {
+	// Identifier of the network device to reprovision.
 	DeviceId string `json:"device_id"`
 }
 

--- a/bindings/go/temporal/model_site_cable_validation_input.go
+++ b/bindings/go/temporal/model_site_cable_validation_input.go
@@ -21,12 +21,18 @@ var _ MappedNullable = &SiteCableValidationInput{}
 
 // SiteCableValidationInput Input for Site Cable Validation Workflow.
 type SiteCableValidationInput struct {
-	DeviceTypeIds   []string `json:"device_type_ids,omitempty"`
-	RaiseForInvalid *bool    `json:"raise_for_invalid,omitempty"`
-	Roles           []string `json:"roles,omitempty"`
-	Site            string   `json:"site"`
-	Status          []string `json:"status,omitempty"`
-	Tenant          *string  `json:"tenant,omitempty"`
+	// Device type identifiers used to filter network devices.
+	DeviceTypeIds []string `json:"device_type_ids,omitempty"`
+	// Whether invalid cabling should fail the workflow.
+	RaiseForInvalid *bool `json:"raise_for_invalid,omitempty"`
+	// Device roles used to filter the selected network devices.
+	Roles []string `json:"roles,omitempty"`
+	// Site containing the network devices to validate.
+	Site string `json:"site"`
+	// Device statuses used to filter the selected network devices.
+	Status []string `json:"status,omitempty"`
+	// Tenant used to filter the selected network devices.
+	Tenant *string `json:"tenant,omitempty"`
 }
 
 type _SiteCableValidationInput SiteCableValidationInput

--- a/bindings/go/temporal/model_site_password_rotation_input.go
+++ b/bindings/go/temporal/model_site_password_rotation_input.go
@@ -21,11 +21,16 @@ var _ MappedNullable = &SitePasswordRotationInput{}
 
 // SitePasswordRotationInput Site Password Rotation Workflow Input Definition.
 type SitePasswordRotationInput struct {
-	Location       string   `json:"location"`
-	Roles          []string `json:"roles,omitempty"`
-	SelectedSecret string   `json:"selected_secret"`
-	Status         []string `json:"status,omitempty"`
-	Tenant         *string  `json:"tenant,omitempty"`
+	// Location containing the devices to update.
+	Location string `json:"location"`
+	// Device roles used to filter the selected network devices.
+	Roles []string `json:"roles,omitempty"`
+	// Name of the managed secret containing the replacement password.
+	SelectedSecret string `json:"selected_secret"`
+	// Device statuses used to filter the selected network devices.
+	Status []string `json:"status,omitempty"`
+	// Tenant used to filter the selected network devices.
+	Tenant *string `json:"tenant,omitempty"`
 }
 
 type _SitePasswordRotationInput SitePasswordRotationInput

--- a/bindings/go/temporal/model_sp_x_overlay_assignment_input.go
+++ b/bindings/go/temporal/model_sp_x_overlay_assignment_input.go
@@ -21,12 +21,15 @@ var _ MappedNullable = &SpXOverlayAssignmentInput{}
 
 // SpXOverlayAssignmentInput SpX Overlay Assignment Workflow Input Definition.
 type SpXOverlayAssignmentInput struct {
-	Device       Device1 `json:"device"`
+	Device Device1 `json:"device"`
+	// Tag identifying the namespace used for allocation.
 	NamespaceTag *string `json:"namespace_tag,omitempty"`
 	// Identifier of the SpX overlay whose VRF will be assigned to the device and ports.
-	OverlayId string   `json:"overlay_id"`
+	OverlayId string `json:"overlay_id"`
+	// Names of the device interfaces to assign to the overlay.
 	PortNames []string `json:"port_names"`
-	Site      string   `json:"site"`
+	// Site containing the target network device.
+	Site string `json:"site"`
 }
 
 type _SpXOverlayAssignmentInput SpXOverlayAssignmentInput

--- a/bindings/go/temporal/model_sp_x_overlay_creation_input.go
+++ b/bindings/go/temporal/model_sp_x_overlay_creation_input.go
@@ -21,14 +21,17 @@ var _ MappedNullable = &SpXOverlayCreationInput{}
 
 // SpXOverlayCreationInput SpX Overlay Creation Workflow Input Definition.
 type SpXOverlayCreationInput struct {
+	// Tag identifying the namespace used for allocation.
 	NamespaceTag *string `json:"namespace_tag,omitempty"`
 	// Unique identifier for the SpX overlay. Used as an idempotency key — re-running with the same ID returns existing VRFs without creating new ones.
 	OverlayId string `json:"overlay_id"`
 	// Upper bound of the route-distinguisher allocation range (0–65535). Must be greater than rd_min.
 	RdMax *int32 `json:"rd_max,omitempty"`
 	// Lower bound of the route-distinguisher allocation range (0–65535). The first available RD in [rd_min, rd_max] is allocated.
-	RdMin  *int32 `json:"rd_min,omitempty"`
-	Site   string `json:"site"`
+	RdMin *int32 `json:"rd_min,omitempty"`
+	// Site where the SpX overlay will be created.
+	Site string `json:"site"`
+	// Tenant that will own the SpX overlay.
 	Tenant string `json:"tenant"`
 }
 

--- a/bindings/go/temporal/model_sp_x_overlay_deletion_input.go
+++ b/bindings/go/temporal/model_sp_x_overlay_deletion_input.go
@@ -21,10 +21,12 @@ var _ MappedNullable = &SpXOverlayDeletionInput{}
 
 // SpXOverlayDeletionInput SpX Overlay Deletion Workflow Input Definition.
 type SpXOverlayDeletionInput struct {
+	// Tag identifying the namespace used for allocation.
 	NamespaceTag *string `json:"namespace_tag,omitempty"`
 	// Identifier of the SpX overlay to delete.
 	OverlayId string `json:"overlay_id"`
-	Site      string `json:"site"`
+	// Site containing the SpX overlay to delete.
+	Site string `json:"site"`
 }
 
 type _SpXOverlayDeletionInput SpXOverlayDeletionInput

--- a/bindings/go/temporal/model_sp_x_overlay_tenant_change_input.go
+++ b/bindings/go/temporal/model_sp_x_overlay_tenant_change_input.go
@@ -21,12 +21,16 @@ var _ MappedNullable = &SpXOverlayTenantChangeInput{}
 
 // SpXOverlayTenantChangeInput SpX Overlay Tenant Change Workflow Input Definition.
 type SpXOverlayTenantChangeInput struct {
-	DeviceId     string  `json:"device_id"`
+	// Identifier of the target network device.
+	DeviceId string `json:"device_id"`
+	// Tag identifying the namespace used for allocation.
 	NamespaceTag *string `json:"namespace_tag,omitempty"`
 	// Identifier of the SpX overlay to assign and deploy tenant configuration for.
-	OverlayId string   `json:"overlay_id"`
+	OverlayId string `json:"overlay_id"`
+	// Names of the device interfaces to assign to the overlay.
 	PortNames []string `json:"port_names"`
-	Site      string   `json:"site"`
+	// Site containing the target network device.
+	Site string `json:"site"`
 }
 
 type _SpXOverlayTenantChangeInput SpXOverlayTenantChangeInput

--- a/bindings/go/temporal/model_stage.go
+++ b/bindings/go/temporal/model_stage.go
@@ -21,22 +21,23 @@ var _ MappedNullable = &Stage{}
 
 // Stage Workflow Stage Model.
 type Stage struct {
-	ApprovalThreshold *int32          `json:"approval_threshold,omitempty"`
-	Approvers         []Review        `json:"approvers,omitempty"`
-	ChildWorkflows    []string        `json:"child_workflows,omitempty"`
-	DependsOn         []string        `json:"depends_on"`
-	Description       string          `json:"description"`
-	ExecutionTime     NullableFloat32 `json:"execution_time"`
-	Input             interface{}     `json:"input,omitempty"`
-	Name              string          `json:"name"`
-	Output            interface{}     `json:"output,omitempty"`
-	Rejecters         []Review        `json:"rejecters,omitempty"`
-	RequiresApproval  bool            `json:"requires_approval"`
-	RetryCount        *int32          `json:"retry_count,omitempty"`
-	Retryable         bool            `json:"retryable"`
-	State             StateEnum       `json:"state"`
-	StateHistory      []HistoryEntry  `json:"state_history,omitempty"`
-	Traceback         NullableString  `json:"traceback"`
+	ApprovalThreshold *int32   `json:"approval_threshold,omitempty"`
+	Approvers         []Review `json:"approvers,omitempty"`
+	ChildWorkflows    []string `json:"child_workflows,omitempty"`
+	DependsOn         []string `json:"depends_on"`
+	Description       string   `json:"description"`
+	// Calculate the time spent executing the stage.
+	ExecutionTime    NullableFloat32 `json:"execution_time"`
+	Input            interface{}     `json:"input,omitempty"`
+	Name             string          `json:"name"`
+	Output           interface{}     `json:"output,omitempty"`
+	Rejecters        []Review        `json:"rejecters,omitempty"`
+	RequiresApproval bool            `json:"requires_approval"`
+	RetryCount       *int32          `json:"retry_count,omitempty"`
+	Retryable        bool            `json:"retryable"`
+	State            StateEnum       `json:"state"`
+	StateHistory     []HistoryEntry  `json:"state_history,omitempty"`
+	Traceback        NullableString  `json:"traceback"`
 }
 
 type _Stage Stage

--- a/bindings/go/temporal/model_switch_os_upgrade_input.go
+++ b/bindings/go/temporal/model_switch_os_upgrade_input.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &SwitchOSUpgradeInput{}
 
 // SwitchOSUpgradeInput Firmware Upgrade Workflow Input Definition.
 type SwitchOSUpgradeInput struct {
+	// Identifier of the network switch to upgrade.
 	DeviceId string `json:"device_id"`
 }
 

--- a/bindings/go/temporal/model_validate_hardware_input.go
+++ b/bindings/go/temporal/model_validate_hardware_input.go
@@ -21,12 +21,18 @@ var _ MappedNullable = &ValidateHardwareInput{}
 
 // ValidateHardwareInput Validate Hardware Workflow Input.
 type ValidateHardwareInput struct {
-	DeviceTypeIds   []string `json:"device_type_ids,omitempty"`
-	RaiseForInvalid *bool    `json:"raise_for_invalid,omitempty"`
-	Roles           []string `json:"roles,omitempty"`
-	Site            string   `json:"site"`
-	Status          []string `json:"status,omitempty"`
-	Tenant          string   `json:"tenant"`
+	// Device type identifiers used to filter network devices.
+	DeviceTypeIds []string `json:"device_type_ids,omitempty"`
+	// Whether invalid hardware should fail the workflow.
+	RaiseForInvalid *bool `json:"raise_for_invalid,omitempty"`
+	// Device roles used to filter the selected network devices.
+	Roles []string `json:"roles,omitempty"`
+	// Site used to select network devices for validation.
+	Site string `json:"site"`
+	// Device statuses used to filter the selected network devices.
+	Status []string `json:"status,omitempty"`
+	// Tenant used to filter the selected network devices.
+	Tenant string `json:"tenant"`
 }
 
 type _ValidateHardwareInput ValidateHardwareInput

--- a/bindings/go/ztp/model_object_info.go
+++ b/bindings/go/ztp/model_object_info.go
@@ -21,13 +21,16 @@ var _ MappedNullable = &ObjectInfo{}
 
 // ObjectInfo Metadata for an object in the storage backend.
 type ObjectInfo struct {
+	// ETag hash
 	Etag NullableString `json:"etag,omitempty"`
 	// Object key/path
-	Key          string            `json:"key"`
-	LastModified LastModified      `json:"last_modified"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
+	Key          string       `json:"key"`
+	LastModified LastModified `json:"last_modified"`
+	// Object metadata
+	Metadata map[string]string `json:"metadata,omitempty"`
 	// Object size in bytes
-	Size int32             `json:"size"`
+	Size int32 `json:"size"`
+	// Object tags
 	Tags map[string]string `json:"tags,omitempty"`
 }
 

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -5,6 +5,7 @@
         "description": "Backup Workflow Input Definiton.",
         "properties": {
           "device_id": {
+            "description": "Identifier of the network device to back up.",
             "title": "Device Id",
             "type": "string"
           },
@@ -17,10 +18,12 @@
                 "type": "null"
               }
             ],
+            "description": "Config Store commit containing the intended configuration.",
             "title": "Intended Config Commit Id"
           },
           "trigger": {
-            "$ref": "#/components/schemas/TriggerEnum"
+            "$ref": "#/components/schemas/TriggerEnum",
+            "description": "Reason the backup workflow was started."
           },
           "user": {
             "anyOf": [
@@ -31,6 +34,7 @@
                 "type": "null"
               }
             ],
+            "description": "User that requested the backup.",
             "title": "User"
           },
           "user_domain": {
@@ -42,6 +46,7 @@
                 "type": "null"
               }
             ],
+            "description": "Domain of the user requesting the backup.",
             "title": "User Domain"
           },
           "workflow_id": {
@@ -53,6 +58,7 @@
                 "type": "null"
               }
             ],
+            "description": "Identifier of the parent workflow, if any.",
             "title": "Workflow Id"
           }
         },
@@ -71,6 +77,7 @@
         "description": "Input for batch deploy child workflow.",
         "properties": {
           "batch_devices": {
+            "description": "Devices whose configurations will be deployed in this batch.",
             "items": {
               "$ref": "#/components/schemas/DeviceDiffData"
             },
@@ -86,17 +93,21 @@
                 "type": "null"
               }
             ],
+            "description": "Sequence number of this batch within the parent workflow.",
             "title": "Batch Number"
           },
           "commit_confirm": {
             "default": true,
+            "description": "Whether to use commit-confirmed mode when the platform supports it.",
             "title": "Commit Confirm",
             "type": "boolean"
           },
           "diff_group": {
-            "$ref": "#/components/schemas/DiffGroup"
+            "$ref": "#/components/schemas/DiffGroup",
+            "description": "Shared configuration diff for the device batch."
           },
           "parent_workflow_id": {
+            "description": "Identifier of the parent multi-deploy workflow.",
             "title": "Parent Workflow Id",
             "type": "string"
           }
@@ -132,6 +143,7 @@
         "description": "Connected Host Workflow Input.",
         "properties": {
           "device_id": {
+            "description": "Identifier of the network device to analyze.",
             "title": "Device Id",
             "type": "string"
           }
@@ -147,10 +159,12 @@
         "properties": {
           "commit_confirm": {
             "default": true,
+            "description": "Whether to use commit-confirmed mode when the platform supports it.",
             "title": "Commit Confirm",
             "type": "boolean"
           },
           "device_id": {
+            "description": "Identifier of the network device to configure.",
             "title": "Device Id",
             "type": "string"
           }
@@ -202,14 +216,17 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Preloaded data for the target network device, if available."
           },
           "device_id": {
+            "description": "Identifier of the network device to validate.",
             "title": "Device Id",
             "type": "string"
           },
           "ignore_no_neighbor": {
             "default": false,
+            "description": "Whether interfaces without discovered neighbors should be ignored.",
             "title": "Ignore No Neighbor",
             "type": "boolean"
           }
@@ -281,10 +298,12 @@
         "description": "Device Password Rotation Workflow Input Definition.",
         "properties": {
           "device_id": {
+            "description": "Identifier of the network device to update.",
             "title": "Device Id",
             "type": "string"
           },
           "selected_secret": {
+            "description": "Name of the managed secret containing the replacement password.",
             "title": "Selected Secret",
             "type": "string"
           }
@@ -299,6 +318,7 @@
       "DiagnosticsWorkflowInput": {
         "properties": {
           "commands": {
+            "description": "Diagnostic command catalog names to run on each device.",
             "items": {
               "type": "string"
             },
@@ -306,6 +326,7 @@
             "type": "array"
           },
           "device_ids": {
+            "description": "Nautobot identifiers of the devices to diagnose.",
             "items": {
               "type": "string"
             },
@@ -314,21 +335,25 @@
           },
           "include_tech_support": {
             "default": false,
+            "description": "Whether to collect a technical-support bundle from each device.",
             "title": "Include Tech Support",
             "type": "boolean"
           },
           "issue_key": {
             "default": "",
+            "description": "Issue key to update; empty enables ticketless mode.",
             "title": "Issue Key",
             "type": "string"
           },
           "ticketing_platform": {
             "default": "",
+            "description": "Ticketing platform to update; empty enables ticketless mode.",
             "title": "Ticketing Platform",
             "type": "string"
           },
           "user": {
             "default": "",
+            "description": "Engineer username or email, populated from request authentication when omitted.",
             "title": "User",
             "type": "string"
           }
@@ -384,6 +409,7 @@
         "description": "Hello World Input Definition.",
         "properties": {
           "name": {
+            "description": "Name to include in the workflow greeting.",
             "title": "Name",
             "type": "string"
           }
@@ -416,11 +442,13 @@
         "description": "InfiniBand PKey Creation Workflow Input.\n\nBy default, auto-assigns the next available PKey. Pass an explicit\n``pkey`` value only when a specific partition key is required.\n\n``site`` is optional. When omitted, the workflow resolves the device's\nSite-typed Nautobot location from ``host`` and uses that as the UFM\ncredential lookup key. Pass ``site`` explicitly to override the\nauto-resolved value (e.g. for API callers that want to skip the\nNautobot round-trip).",
         "properties": {
           "host": {
+            "description": "Hostname of the UFM server managing the InfiniBand fabric.",
             "title": "Host",
             "type": "string"
           },
           "ip_over_ib": {
             "default": true,
+            "description": "Whether IP over InfiniBand is enabled for the partition.",
             "title": "Ip Over Ib",
             "type": "boolean"
           },
@@ -433,15 +461,18 @@
                 "type": "null"
               }
             ],
+            "description": "Partition key to create; automatically allocated when omitted.",
             "title": "Pkey"
           },
           "pkey_max": {
             "default": 32766,
+            "description": "Highest partition key eligible for automatic allocation.",
             "title": "Pkey Max",
             "type": "integer"
           },
           "pkey_min": {
             "default": 1,
+            "description": "Lowest partition key eligible for automatic allocation.",
             "title": "Pkey Min",
             "type": "integer"
           },
@@ -454,6 +485,7 @@
                 "type": "null"
               }
             ],
+            "description": "Site used for UFM credential lookup; resolved from the host when omitted.",
             "title": "Site"
           }
         },
@@ -468,6 +500,7 @@
         "properties": {
           "guid_memberships": {
             "default": [],
+            "description": "Per-GUID membership types corresponding to the supplied GUIDs.",
             "items": {
               "type": "string"
             },
@@ -476,6 +509,7 @@
           },
           "guids": {
             "default": [],
+            "description": "InfiniBand port GUIDs to add directly to the partition.",
             "items": {
               "type": "string"
             },
@@ -483,11 +517,13 @@
             "type": "array"
           },
           "host": {
+            "description": "Hostname of the UFM server managing the InfiniBand fabric.",
             "title": "Host",
             "type": "string"
           },
           "interfaces": {
             "default": [],
+            "description": "Nautobot interfaces to resolve to InfiniBand port GUIDs.",
             "items": {
               "$ref": "#/components/schemas/InterfaceRef"
             },
@@ -496,15 +532,18 @@
           },
           "ip_over_ib": {
             "default": true,
+            "description": "Whether IP over InfiniBand is enabled for the partition.",
             "title": "Ip Over Ib",
             "type": "boolean"
           },
           "membership_type": {
             "default": "full",
+            "description": "Default partition membership type for added members.",
             "title": "Membership Type",
             "type": "string"
           },
           "pkey": {
+            "description": "Partition key whose membership will be expanded.",
             "title": "Pkey",
             "type": "string"
           }
@@ -521,6 +560,7 @@
         "properties": {
           "guids": {
             "default": [],
+            "description": "InfiniBand port GUIDs to remove directly from the partition.",
             "items": {
               "type": "string"
             },
@@ -528,11 +568,13 @@
             "type": "array"
           },
           "host": {
+            "description": "Hostname of the UFM server managing the InfiniBand fabric.",
             "title": "Host",
             "type": "string"
           },
           "interfaces": {
             "default": [],
+            "description": "Nautobot interfaces to resolve to InfiniBand port GUIDs.",
             "items": {
               "$ref": "#/components/schemas/InterfaceRef"
             },
@@ -540,6 +582,7 @@
             "type": "array"
           },
           "pkey": {
+            "description": "Partition key whose members will be removed.",
             "title": "Pkey",
             "type": "string"
           }
@@ -556,6 +599,7 @@
         "properties": {
           "guid_memberships": {
             "default": [],
+            "description": "Per-GUID membership types corresponding to the supplied GUIDs.",
             "items": {
               "type": "string"
             },
@@ -564,6 +608,7 @@
           },
           "guids": {
             "default": [],
+            "description": "InfiniBand port GUIDs that should belong to the partition.",
             "items": {
               "type": "string"
             },
@@ -571,11 +616,13 @@
             "type": "array"
           },
           "host": {
+            "description": "Hostname of the UFM server managing the InfiniBand fabric.",
             "title": "Host",
             "type": "string"
           },
           "interfaces": {
             "default": [],
+            "description": "Nautobot interfaces to resolve to InfiniBand port GUIDs.",
             "items": {
               "$ref": "#/components/schemas/InterfaceRef"
             },
@@ -584,15 +631,18 @@
           },
           "ip_over_ib": {
             "default": true,
+            "description": "IP over InfiniBand setting used when the partition does not already exist.",
             "title": "Ip Over Ib",
             "type": "boolean"
           },
           "membership_type": {
             "default": "full",
+            "description": "Default partition membership type for updated members.",
             "title": "Membership Type",
             "type": "string"
           },
           "pkey": {
+            "description": "Partition key whose membership will be replaced.",
             "title": "Pkey",
             "type": "string"
           }
@@ -609,10 +659,12 @@
         "properties": {
           "dry_run": {
             "default": true,
+            "description": "Whether to report changes without updating Nautobot.",
             "title": "Dry Run",
             "type": "boolean"
           },
           "switch_device_ids": {
+            "description": "Identifiers of the InfiniBand switches whose interfaces will be synchronized.",
             "items": {
               "type": "string"
             },
@@ -620,6 +672,7 @@
             "type": "array"
           },
           "ufm_device_id": {
+            "description": "Identifier of the UFM device used to discover port GUIDs.",
             "title": "Ufm Device Id",
             "type": "string"
           }
@@ -635,6 +688,7 @@
         "description": "IB Cable Validation Workflow Input Definition.",
         "properties": {
           "switch_device_ids": {
+            "description": "Identifiers of the InfiniBand switches to validate.",
             "items": {
               "type": "string"
             },
@@ -642,6 +696,7 @@
             "type": "array"
           },
           "ufm_device_id": {
+            "description": "Identifier of the UFM device used to inspect the InfiniBand fabric.",
             "title": "Ufm Device Id",
             "type": "string"
           }
@@ -657,6 +712,7 @@
         "description": "Unhealthy Ports Validation Workflow Input Definition.",
         "properties": {
           "device_id": {
+            "description": "Identifier of the UFM device to inspect.",
             "title": "Device Id",
             "type": "string"
           }
@@ -671,6 +727,7 @@
         "description": "Infiniband Mellanox OS Upgrade Workflow Input Definition.",
         "properties": {
           "device_id": {
+            "description": "Identifier of the InfiniBand switch to upgrade.",
             "title": "Device Id",
             "type": "string"
           }
@@ -735,6 +792,7 @@
         "properties": {
           "commit_confirm": {
             "default": true,
+            "description": "Whether to use commit-confirmed mode when the platform supports it.",
             "title": "Commit Confirm",
             "type": "boolean"
           },
@@ -747,14 +805,17 @@
                 "type": "null"
               }
             ],
+            "description": "Location used to filter the selected network devices.",
             "title": "Location"
           },
           "max_batch_size": {
             "default": 10,
+            "description": "Maximum number of devices included in each deployment batch.",
             "title": "Max Batch Size",
             "type": "integer"
           },
           "role": {
+            "description": "Device role used to select network devices for deployment.",
             "title": "Role",
             "type": "string"
           },
@@ -770,6 +831,7 @@
                 "type": "null"
               }
             ],
+            "description": "Device statuses used to filter the selected network devices.",
             "title": "Status"
           },
           "tenant": {
@@ -781,6 +843,7 @@
                 "type": "null"
               }
             ],
+            "description": "Tenant used to filter the selected network devices.",
             "title": "Tenant"
           }
         },
@@ -794,10 +857,12 @@
         "description": "NVLinkSwitch Firmware Upgrade Workflow Input Definition.",
         "properties": {
           "bundle_version": {
+            "description": "Target NVLink firmware bundle version.",
             "title": "Bundle Version",
             "type": "string"
           },
           "device_id": {
+            "description": "Identifier of the NVLink switch to upgrade.",
             "title": "Device Id",
             "type": "string"
           }
@@ -949,6 +1014,7 @@
                 "type": "null"
               }
             ],
+            "description": "Identifier of the network device to inspect.",
             "title": "Device Id"
           },
           "interface": {
@@ -960,6 +1026,7 @@
                 "type": "null"
               }
             ],
+            "description": "Name of the local interface.",
             "title": "Interface"
           },
           "remote_mac_address": {
@@ -971,6 +1038,7 @@
                 "type": "null"
               }
             ],
+            "description": "MAC address of the remote device to locate.",
             "title": "Remote Mac Address"
           }
         },
@@ -1040,6 +1108,7 @@
         "description": "Input for Redfish provisioning workflow.",
         "properties": {
           "bmc_switch_roles": {
+            "description": "Switch roles used to discover BMC-connected network interfaces.",
             "items": {
               "type": "string"
             },
@@ -1051,6 +1120,7 @@
               "Mellanox Technologies",
               "MLNX"
             ],
+            "description": "DPU manufacturer names eligible for Redfish provisioning.",
             "items": {
               "type": "string"
             },
@@ -1059,23 +1129,28 @@
           },
           "http_timeout_s": {
             "default": 5,
+            "description": "Timeout in seconds for Redfish HTTP requests.",
             "title": "Http Timeout S",
             "type": "integer"
           },
           "ip_range_end": {
+            "description": "Last BMC IP address to scan.",
             "title": "Ip Range End",
             "type": "string"
           },
           "ip_range_start": {
+            "description": "First BMC IP address to scan.",
             "title": "Ip Range Start",
             "type": "string"
           },
           "port": {
             "default": 443,
+            "description": "HTTPS port used to contact Redfish services.",
             "title": "Port",
             "type": "integer"
           },
           "site": {
+            "description": "Site containing the BMC network to provision.",
             "title": "Site",
             "type": "string"
           }
@@ -1093,6 +1168,7 @@
         "description": "Reprovision Workflow Input Definition.",
         "properties": {
           "device_id": {
+            "description": "Identifier of the network device to reprovision.",
             "title": "Device Id",
             "type": "string"
           }
@@ -1171,6 +1247,7 @@
         "properties": {
           "device_type_ids": {
             "default": [],
+            "description": "Device type identifiers used to filter network devices.",
             "items": {
               "type": "string"
             },
@@ -1179,6 +1256,7 @@
           },
           "raise_for_invalid": {
             "default": false,
+            "description": "Whether invalid cabling should fail the workflow.",
             "title": "Raise For Invalid",
             "type": "boolean"
           },
@@ -1196,6 +1274,7 @@
               "smn-leaf",
               "smn-aggleaf"
             ],
+            "description": "Device roles used to filter the selected network devices.",
             "items": {
               "type": "string"
             },
@@ -1203,6 +1282,7 @@
             "type": "array"
           },
           "site": {
+            "description": "Site containing the network devices to validate.",
             "title": "Site",
             "type": "string"
           },
@@ -1211,6 +1291,7 @@
               "active",
               "provisioning"
             ],
+            "description": "Device statuses used to filter the selected network devices.",
             "items": {
               "type": "string"
             },
@@ -1219,6 +1300,7 @@
           },
           "tenant": {
             "default": "nsv",
+            "description": "Tenant used to filter the selected network devices.",
             "title": "Tenant",
             "type": "string"
           }
@@ -1233,6 +1315,7 @@
         "description": "Site Password Rotation Workflow Input Definition.",
         "properties": {
           "location": {
+            "description": "Location containing the devices to update.",
             "title": "Location",
             "type": "string"
           },
@@ -1246,6 +1329,7 @@
               "SMN-Leaf",
               "SMN-Aggleaf"
             ],
+            "description": "Device roles used to filter the selected network devices.",
             "items": {
               "type": "string"
             },
@@ -1253,6 +1337,7 @@
             "type": "array"
           },
           "selected_secret": {
+            "description": "Name of the managed secret containing the replacement password.",
             "title": "Selected Secret",
             "type": "string"
           },
@@ -1261,6 +1346,7 @@
               "Active",
               "Provisioned"
             ],
+            "description": "Device statuses used to filter the selected network devices.",
             "items": {
               "type": "string"
             },
@@ -1269,6 +1355,7 @@
           },
           "tenant": {
             "default": "NGC",
+            "description": "Tenant used to filter the selected network devices.",
             "title": "Tenant",
             "type": "string"
           }
@@ -1292,10 +1379,12 @@
                 "$ref": "#/components/schemas/NetworkDeviceData"
               }
             ],
+            "description": "Identifier or preloaded data for the target network device.",
             "title": "Device"
           },
           "namespace_tag": {
             "default": "spectrumx",
+            "description": "Tag identifying the namespace used for allocation.",
             "title": "Namespace Tag",
             "type": "string"
           },
@@ -1305,6 +1394,7 @@
             "type": "string"
           },
           "port_names": {
+            "description": "Names of the device interfaces to assign to the overlay.",
             "items": {
               "type": "string"
             },
@@ -1312,6 +1402,7 @@
             "type": "array"
           },
           "site": {
+            "description": "Site containing the target network device.",
             "title": "Site",
             "type": "string"
           }
@@ -1330,6 +1421,7 @@
         "properties": {
           "namespace_tag": {
             "default": "spectrumx",
+            "description": "Tag identifying the namespace used for allocation.",
             "title": "Namespace Tag",
             "type": "string"
           },
@@ -1351,10 +1443,12 @@
             "type": "integer"
           },
           "site": {
+            "description": "Site where the SpX overlay will be created.",
             "title": "Site",
             "type": "string"
           },
           "tenant": {
+            "description": "Tenant that will own the SpX overlay.",
             "title": "Tenant",
             "type": "string"
           }
@@ -1372,6 +1466,7 @@
         "properties": {
           "namespace_tag": {
             "default": "spectrumx",
+            "description": "Tag identifying the namespace used for allocation.",
             "title": "Namespace Tag",
             "type": "string"
           },
@@ -1381,6 +1476,7 @@
             "type": "string"
           },
           "site": {
+            "description": "Site containing the SpX overlay to delete.",
             "title": "Site",
             "type": "string"
           }
@@ -1396,11 +1492,13 @@
         "description": "SpX Overlay Tenant Change Workflow Input Definition.",
         "properties": {
           "device_id": {
+            "description": "Identifier of the target network device.",
             "title": "Device ID",
             "type": "string"
           },
           "namespace_tag": {
             "default": "spectrumx",
+            "description": "Tag identifying the namespace used for allocation.",
             "title": "Namespace Tag",
             "type": "string"
           },
@@ -1410,6 +1508,7 @@
             "type": "string"
           },
           "port_names": {
+            "description": "Names of the device interfaces to assign to the overlay.",
             "items": {
               "type": "string"
             },
@@ -1417,6 +1516,7 @@
             "type": "array"
           },
           "site": {
+            "description": "Site containing the target network device.",
             "title": "Site",
             "type": "string"
           }
@@ -1583,6 +1683,7 @@
         "description": "Firmware Upgrade Workflow Input Definition.",
         "properties": {
           "device_id": {
+            "description": "Identifier of the network switch to upgrade.",
             "title": "Device Id",
             "type": "string"
           }
@@ -1679,6 +1780,7 @@
                 "$ref": "#/components/schemas/NetworkDeviceData"
               }
             ],
+            "description": "Identifier or preloaded data for the network device to configure.",
             "title": "Device"
           },
           "intended_config_commit_id": {
@@ -1730,6 +1832,7 @@
         "properties": {
           "device_type_ids": {
             "default": [],
+            "description": "Device type identifiers used to filter network devices.",
             "items": {
               "type": "string"
             },
@@ -1738,11 +1841,13 @@
           },
           "raise_for_invalid": {
             "default": false,
+            "description": "Whether invalid hardware should fail the workflow.",
             "title": "Raise For Invalid",
             "type": "boolean"
           },
           "roles": {
             "default": [],
+            "description": "Device roles used to filter the selected network devices.",
             "items": {
               "type": "string"
             },
@@ -1750,11 +1855,13 @@
             "type": "array"
           },
           "site": {
+            "description": "Site used to select network devices for validation.",
             "title": "Site",
             "type": "string"
           },
           "status": {
             "default": [],
+            "description": "Device statuses used to filter the selected network devices.",
             "items": {
               "type": "string"
             },
@@ -1762,6 +1869,7 @@
             "type": "array"
           },
           "tenant": {
+            "description": "Tenant used to filter the selected network devices.",
             "title": "Tenant",
             "type": "string"
           }

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -64,11 +64,7 @@
         },
         "required": [
           "device_id",
-          "trigger",
-          "user",
-          "user_domain",
-          "workflow_id",
-          "intended_config_commit_id"
+          "trigger"
         ],
         "title": "BackupInput",
         "type": "object"
@@ -211,7 +207,8 @@
           "device": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/NetworkDeviceData"
+                "$ref": "#/components/schemas/NetworkDeviceData",
+                "description": "Preloaded data for the target network device, if available."
               },
               {
                 "type": "null"

--- a/scripts/generate_go_bindings.sh
+++ b/scripts/generate_go_bindings.sh
@@ -40,13 +40,35 @@ services=(config-store dhcp render temporal ztp)
 for service in "${services[@]}"; do
     repo_id="nv-config-manager/bindings/go/${service}"
     package_name="${service//-/}"
+    generator_spec="$staging_root/${service}.openapi.json"
+
+    # OpenAPI Generator drops property descriptions while simplifying nullable
+    # OpenAPI 3.1 anyOf schemas. Copy the description to each non-null branch so
+    # generated Go struct fields retain the schema documentation.
+    jq '
+        walk(
+            if type == "object"
+                and (.description? | type == "string")
+                and (.anyOf? | type == "array")
+            then
+                .description as $description
+                | .anyOf |= map(
+                    if .type? != "null" and .description? == null
+                    then . + {description: $description}
+                    else .
+                    end
+                )
+            else .
+            end
+        )
+    ' "$repo_root/docs/api-specs/${service}.openapi.json" > "$generator_spec"
 
     docker run --rm \
         --user "$(id -u):$(id -g)" \
         --volume "$repo_root:/repo:ro" \
         --volume "$staging_root:/out" \
         "$GENERATOR_IMAGE" generate \
-        --input-spec "/repo/docs/api-specs/${service}.openapi.json" \
+        --input-spec "/out/${service}.openapi.json" \
         --generator-name go \
         --template-dir /out/templates \
         --output "/out/${service}" \

--- a/src/nv_config_manager/mcp/tools.py
+++ b/src/nv_config_manager/mcp/tools.py
@@ -16,7 +16,8 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+import inspect
+from typing import Annotated, Any, cast
 
 from mcp.server.fastmcp import FastMCP
 
@@ -37,6 +38,7 @@ from nv_config_manager.mcp.clients import (
 from nv_config_manager.mcp.settings import MCPSettings
 from nv_config_manager.mcp.workflows import (
     MCPWorkflow,
+    allows_none,
     discover_mcp_workflows,
     normalize_workflow_parameters,
 )
@@ -307,7 +309,7 @@ def register_tools(server: FastMCP, settings: MCPSettings) -> None:
 def _register_workflow_starter(
     server: FastMCP, settings: MCPSettings, workflow: MCPWorkflow
 ) -> None:
-    async def run_workflow(parameters: dict[str, Any] | None = None) -> dict[str, Any]:
+    async def run_workflow(**parameters: Any) -> dict[str, Any]:
         """Start a safe diagnostic workflow."""
         normalized = normalize_workflow_parameters(workflow, parameters)
         result = await start_workflow(settings, workflow.endpoint, normalized)
@@ -326,13 +328,38 @@ def _register_workflow_starter(
         }
 
     run_workflow.__name__ = workflow.tool_name
+    cast(Any, run_workflow).__signature__ = _workflow_tool_signature(workflow)
     run_workflow.__doc__ = (
         f"{workflow.description}\n\n"
-        "Pass workflow input fields as the `parameters` object. "
+        "Pass the workflow input fields shown in this tool's input schema. "
         "Use `workflow_ui_href` as the end-user Config Manager workflow link. "
         "The response includes the workflow input schema for reference."
     )
     server.tool(name=workflow.tool_name, description=workflow.description)(run_workflow)
+
+
+def _workflow_tool_signature(workflow: MCPWorkflow) -> inspect.Signature:
+    """Build the workflow-specific signature FastMCP uses for its input schema."""
+    parameters: list[inspect.Parameter] = []
+    for field_name, field_info in workflow.input_class.model_fields.items():
+        default: Any = inspect.Parameter.empty
+        if field_name == "trigger":
+            default = "API"
+        elif allows_none(field_info.annotation):
+            default = None
+        elif not field_info.is_required():
+            default = field_info
+
+        parameters.append(
+            inspect.Parameter(
+                field_name,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=Annotated[field_info.annotation, field_info],
+            )
+        )
+
+    return inspect.Signature(parameters, return_annotation=dict[str, Any])
 
 
 def _drop_none(values: dict[str, Any]) -> dict[str, Any]:

--- a/src/nv_config_manager/mcp/workflows.py
+++ b/src/nv_config_manager/mcp/workflows.py
@@ -40,8 +40,25 @@ class MCPWorkflow:
 
     @property
     def input_schema(self) -> dict[str, Any]:
-        """Return the Pydantic JSON schema for the workflow input model."""
-        return self.input_class.model_json_schema()
+        """Return the normalized JSON schema accepted by the MCP workflow tool."""
+        schema = self.input_class.model_json_schema()
+        required = schema.get("required", [])
+        for field_name, field_info in self.input_class.model_fields.items():
+            property_schema = schema.get("properties", {}).get(field_name)
+            if field_name == "trigger":
+                required = [name for name in required if name != field_name]
+                if isinstance(property_schema, dict):
+                    property_schema["default"] = "API"
+            elif allows_none(field_info.annotation):
+                required = [name for name in required if name != field_name]
+                if isinstance(property_schema, dict):
+                    property_schema["default"] = None
+
+        if required:
+            schema["required"] = required
+        else:
+            schema.pop("required", None)
+        return schema
 
 
 def discover_mcp_workflows() -> list[MCPWorkflow]:
@@ -87,7 +104,7 @@ def normalize_workflow_parameters(
     for field_name, field_info in fields.items():
         if field_name in normalized:
             continue
-        if _allows_none(field_info.annotation):
+        if allows_none(field_info.annotation):
             normalized[field_name] = None
 
     return normalized
@@ -98,7 +115,7 @@ def _tool_name_from_endpoint(endpoint: str) -> str:
     return f"run_{slug.replace('-', '_')}"
 
 
-def _allows_none(annotation: Any) -> bool:
+def allows_none(annotation: Any) -> bool:
     if annotation is None or annotation is type(None):
         return True
     return type(None) in get_args(annotation)

--- a/src/nv_config_manager/temporal/hello_world/workflows/hello_world_workflow.py
+++ b/src/nv_config_manager/temporal/hello_world/workflows/hello_world_workflow.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -47,7 +47,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=1)
 class HelloWorldInput(BaseModel):
     """Hello World Input Definition."""
 
-    name: str
+    name: str = Field(description="Name to include in the workflow greeting.")
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/backup.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/backup.py
@@ -74,11 +74,15 @@ class BackupInput(BaseModel):
 
     device_id: str = Field(description="Identifier of the network device to back up.")
     trigger: TriggerEnum = Field(description="Reason the backup workflow was started.")
-    user: str | None = Field(description="User that requested the backup.")
-    user_domain: str | None = Field(description="Domain of the user requesting the backup.")
-    workflow_id: str | None = Field(description="Identifier of the parent workflow, if any.")
+    user: str | None = Field(default=None, description="User that requested the backup.")
+    user_domain: str | None = Field(
+        default=None, description="Domain of the user requesting the backup."
+    )
+    workflow_id: str | None = Field(
+        default=None, description="Identifier of the parent workflow, if any."
+    )
     intended_config_commit_id: str | None = Field(
-        description="Config Store commit containing the intended configuration."
+        default=None, description="Config Store commit containing the intended configuration."
     )
 
 

--- a/src/nv_config_manager/temporal/ngc/workflows/backup.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/backup.py
@@ -18,7 +18,7 @@ import asyncio
 from datetime import timedelta
 from enum import StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
@@ -72,12 +72,14 @@ class TriggerEnum(StrEnum):
 class BackupInput(BaseModel):
     """Backup Workflow Input Definiton."""
 
-    device_id: str
-    trigger: TriggerEnum
-    user: str | None
-    user_domain: str | None
-    workflow_id: str | None
-    intended_config_commit_id: str | None
+    device_id: str = Field(description="Identifier of the network device to back up.")
+    trigger: TriggerEnum = Field(description="Reason the backup workflow was started.")
+    user: str | None = Field(description="User that requested the backup.")
+    user_domain: str | None = Field(description="Domain of the user requesting the backup.")
+    workflow_id: str | None = Field(description="Identifier of the parent workflow, if any.")
+    intended_config_commit_id: str | None = Field(
+        description="Config Store commit containing the intended configuration."
+    )
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/bmc.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/bmc.py
@@ -21,7 +21,7 @@ import copy
 import logging
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -81,13 +81,20 @@ NIC_MANUFACTURER_MELLANOX = ["Mellanox Technologies", "MLNX"]
 class RedfishProvisioningInput(BaseModel):
     """Input for Redfish provisioning workflow."""
 
-    site: str
-    bmc_switch_roles: list[str]
-    ip_range_start: str
-    ip_range_end: str
-    port: int = 443
-    http_timeout_s: int = 5
-    dpu_manufacturers: list[str] = NIC_MANUFACTURER_MELLANOX
+    site: str = Field(description="Site containing the BMC network to provision.")
+    bmc_switch_roles: list[str] = Field(
+        description="Switch roles used to discover BMC-connected network interfaces."
+    )
+    ip_range_start: str = Field(description="First BMC IP address to scan.")
+    ip_range_end: str = Field(description="Last BMC IP address to scan.")
+    port: int = Field(default=443, description="HTTPS port used to contact Redfish services.")
+    http_timeout_s: int = Field(
+        default=5, description="Timeout in seconds for Redfish HTTP requests."
+    )
+    dpu_manufacturers: list[str] = Field(
+        default=NIC_MANUFACTURER_MELLANOX,
+        description="DPU manufacturer names eligible for Redfish provisioning.",
+    )
 
 
 class RedfishProvisioningResult(BaseModel):

--- a/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
@@ -20,7 +20,7 @@ import asyncio
 from datetime import timedelta
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ChildWorkflowError
@@ -113,20 +113,38 @@ SUPPORTED_PLATFORMS = [Platform.CUMULUS_LINUX, Platform.ARISTA_EOS, Platform.NV_
 class SiteCableValidationInput(BaseModel):
     """Input for Site Cable Validation Workflow."""
 
-    site: str
-    roles: list[str] = DEFAULT_CONFIG_MANAGER_ROLES
-    status: list[str] = DEFAULT_CONFIG_MANAGER_STATUS
-    tenant: str = DEFAULT_CONFIG_MANAGER_TENANT
-    device_type_ids: list[str] = []
-    raise_for_invalid: bool = False
+    site: str = Field(description="Site containing the network devices to validate.")
+    roles: list[str] = Field(
+        default=DEFAULT_CONFIG_MANAGER_ROLES,
+        description="Device roles used to filter the selected network devices.",
+    )
+    status: list[str] = Field(
+        default=DEFAULT_CONFIG_MANAGER_STATUS,
+        description="Device statuses used to filter the selected network devices.",
+    )
+    tenant: str = Field(
+        default=DEFAULT_CONFIG_MANAGER_TENANT,
+        description="Tenant used to filter the selected network devices.",
+    )
+    device_type_ids: list[str] = Field(
+        default=[], description="Device type identifiers used to filter network devices."
+    )
+    raise_for_invalid: bool = Field(
+        default=False, description="Whether invalid cabling should fail the workflow."
+    )
 
 
 class DeviceCableValidationInput(BaseModel):
     """Input for Device Cable Validation Workflow."""
 
-    device_id: str
-    device: NetworkDeviceData | None = None
-    ignore_no_neighbor: bool = False
+    device_id: str = Field(description="Identifier of the network device to validate.")
+    device: NetworkDeviceData | None = Field(
+        default=None, description="Preloaded data for the target network device, if available."
+    )
+    ignore_no_neighbor: bool = Field(
+        default=False,
+        description="Whether interfaces without discovered neighbors should be ignored.",
+    )
 
 
 class DeviceCableValidationResult(BaseModel, validate_assignment=True):

--- a/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 from temporalio import workflow
@@ -108,6 +108,9 @@ CLONE_SEARCH_ATTRS = [
 ]
 
 SUPPORTED_PLATFORMS = [Platform.CUMULUS_LINUX, Platform.ARISTA_EOS, Platform.NV_OS]
+DEVICE_CABLE_VALIDATION_DEVICE_DESCRIPTION = (
+    "Preloaded data for the target network device, if available."
+)
 
 
 class SiteCableValidationInput(BaseModel):
@@ -138,8 +141,15 @@ class DeviceCableValidationInput(BaseModel):
     """Input for Device Cable Validation Workflow."""
 
     device_id: str = Field(description="Identifier of the network device to validate.")
-    device: NetworkDeviceData | None = Field(
-        default=None, description="Preloaded data for the target network device, if available."
+    device: (
+        Annotated[
+            NetworkDeviceData,
+            Field(description=DEVICE_CABLE_VALIDATION_DEVICE_DESCRIPTION),
+        ]
+        | None
+    ) = Field(
+        default=None,
+        description=DEVICE_CABLE_VALIDATION_DEVICE_DESCRIPTION,
     )
     ignore_no_neighbor: bool = Field(
         default=False,

--- a/src/nv_config_manager/temporal/ngc/workflows/connected_host.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/connected_host.py
@@ -21,7 +21,7 @@ from datetime import timedelta
 from typing import Any
 
 from py_markdown_table.markdown_table import markdown_table
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -99,7 +99,7 @@ def interface_sort_key(interface_name: str) -> tuple[str, list[int]]:
 class ConnectedHostWorkflowInput(BaseModel):
     """Connected Host Workflow Input."""
 
-    device_id: str
+    device_id: str = Field(description="Identifier of the network device to analyze.")
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/cumulus_hardware_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cumulus_hardware_validation.py
@@ -18,7 +18,7 @@ import asyncio
 from datetime import timedelta
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -194,12 +194,20 @@ def analyze_flagged_results(
 class ValidateHardwareInput(BaseModel):
     """Validate Hardware Workflow Input."""
 
-    site: str
-    roles: list[str] = []
-    status: list[str] = []
-    tenant: str
-    device_type_ids: list[str] = []
-    raise_for_invalid: bool = False
+    site: str = Field(description="Site used to select network devices for validation.")
+    roles: list[str] = Field(
+        default=[], description="Device roles used to filter the selected network devices."
+    )
+    status: list[str] = Field(
+        default=[], description="Device statuses used to filter the selected network devices."
+    )
+    tenant: str = Field(description="Tenant used to filter the selected network devices.")
+    device_type_ids: list[str] = Field(
+        default=[], description="Device type identifiers used to filter network devices."
+    )
+    raise_for_invalid: bool = Field(
+        default=False, description="Whether invalid hardware should fail the workflow."
+    )
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -89,8 +89,11 @@ INTENDED_CONFIG_COMMIT_ID_DESCRIPTION = (
 class DeployInput(BaseModel):
     """Config Deployment Workflow Input Definiton."""
 
-    device_id: str
-    commit_confirm: bool = True
+    device_id: str = Field(description="Identifier of the network device to configure.")
+    commit_confirm: bool = Field(
+        default=True,
+        description="Whether to use commit-confirmed mode when the platform supports it.",
+    )
 
 
 @workflow.defn
@@ -405,7 +408,9 @@ class TenantDeployInput(BaseModel):
         }
     )
 
-    device: str | NetworkDeviceData
+    device: str | NetworkDeviceData = Field(
+        description="Identifier or preloaded data for the network device to configure."
+    )
     tenant_config_commit_id: str | None = Field(
         default=None,
         pattern=r"^\d+$",

--- a/src/nv_config_manager/temporal/ngc/workflows/device_password_rotation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/device_password_rotation.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -70,8 +70,10 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class DevicePasswordRotationInput(BaseModel):
     """Device Password Rotation Workflow Input Definition."""
 
-    device_id: str
-    selected_secret: str
+    device_id: str = Field(description="Identifier of the network device to update.")
+    selected_secret: str = Field(
+        description="Name of the managed secret containing the replacement password."
+    )
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/diagnostics.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/diagnostics.py
@@ -17,7 +17,7 @@
 import asyncio
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError
@@ -88,13 +88,22 @@ _PREFLIGHT_RETRY = RetryPolicy(maximum_attempts=1)  # fail fast before touching 
 
 
 class DiagnosticsWorkflowInput(BaseModel):
-    device_ids: list[str]  # Nautobot device UUIDs
-    commands: list[str]  # catalog command names e.g. ["show_version", "show_bgp_summary"]
-    ticketing_platform: str = ""  # e.g. "jira"; empty string = ticketless mode
-    issue_key: str = ""  # e.g. "GNI-1234"; empty string = ticketless mode
-    include_tech_support: bool = False
-    user: str = (
-        ""  # engineer username / email; auto-populated from request auth by dynamic_endpoints
+    device_ids: list[str] = Field(description="Nautobot identifiers of the devices to diagnose.")
+    commands: list[str] = Field(
+        description="Diagnostic command catalog names to run on each device."
+    )
+    ticketing_platform: str = Field(
+        default="", description="Ticketing platform to update; empty enables ticketless mode."
+    )
+    issue_key: str = Field(
+        default="", description="Issue key to update; empty enables ticketless mode."
+    )
+    include_tech_support: bool = Field(
+        default=False, description="Whether to collect a technical-support bundle from each device."
+    )
+    user: str = Field(
+        default="",
+        description="Engineer username or email, populated from request authentication when omitted.",
     )
 
 

--- a/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_creation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_creation.py
@@ -17,7 +17,7 @@
 from datetime import timedelta
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -71,12 +71,23 @@ class IBPKeyCreationInput(BaseModel):
     Nautobot round-trip).
     """
 
-    host: str
-    site: str | None = None
-    pkey: str | None = None
-    ip_over_ib: bool = True
-    pkey_min: int = 0x0001
-    pkey_max: int = 0x7FFE
+    host: str = Field(description="Hostname of the UFM server managing the InfiniBand fabric.")
+    site: str | None = Field(
+        default=None,
+        description="Site used for UFM credential lookup; resolved from the host when omitted.",
+    )
+    pkey: str | None = Field(
+        default=None, description="Partition key to create; automatically allocated when omitted."
+    )
+    ip_over_ib: bool = Field(
+        default=True, description="Whether IP over InfiniBand is enabled for the partition."
+    )
+    pkey_min: int = Field(
+        default=0x0001, description="Lowest partition key eligible for automatic allocation."
+    )
+    pkey_max: int = Field(
+        default=0x7FFE, description="Highest partition key eligible for automatic allocation."
+    )
 
 
 class IBPKeyCreationWorkflowOutput(BaseModel):

--- a/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_add.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_add.py
@@ -64,13 +64,23 @@ class IBPKeyMemberAddInput(BaseModel):
     Site and Overlay are resolved server-side from ``host`` and ``pkey``.
     """
 
-    host: str
-    pkey: str
-    interfaces: list[InterfaceRef] = []
-    guids: list[str] = []
-    guid_memberships: list[str] = []
-    membership_type: str = "full"
-    ip_over_ib: bool = True
+    host: str = Field(description="Hostname of the UFM server managing the InfiniBand fabric.")
+    pkey: str = Field(description="Partition key whose membership will be expanded.")
+    interfaces: list[InterfaceRef] = Field(
+        default=[], description="Nautobot interfaces to resolve to InfiniBand port GUIDs."
+    )
+    guids: list[str] = Field(
+        default=[], description="InfiniBand port GUIDs to add directly to the partition."
+    )
+    guid_memberships: list[str] = Field(
+        default=[], description="Per-GUID membership types corresponding to the supplied GUIDs."
+    )
+    membership_type: str = Field(
+        default="full", description="Default partition membership type for added members."
+    )
+    ip_over_ib: bool = Field(
+        default=True, description="Whether IP over InfiniBand is enabled for the partition."
+    )
 
     @field_validator("pkey")
     @classmethod

--- a/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_delete.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_delete.py
@@ -65,10 +65,14 @@ class IBPKeyMemberDeleteInput(BaseModel):
     server-side from ``host`` and ``pkey``.
     """
 
-    host: str
-    pkey: str
-    interfaces: list[InterfaceRef] = []
-    guids: list[str] = []
+    host: str = Field(description="Hostname of the UFM server managing the InfiniBand fabric.")
+    pkey: str = Field(description="Partition key whose members will be removed.")
+    interfaces: list[InterfaceRef] = Field(
+        default=[], description="Nautobot interfaces to resolve to InfiniBand port GUIDs."
+    )
+    guids: list[str] = Field(
+        default=[], description="InfiniBand port GUIDs to remove directly from the partition."
+    )
 
     @field_validator("pkey")
     @classmethod

--- a/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_update.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/ib_pkey_member_update.py
@@ -126,13 +126,24 @@ class IBPKeyMemberUpdateInput(BaseModel):
     Site and Overlay are resolved server-side from ``host`` and ``pkey``.
     """
 
-    host: str
-    pkey: str
-    interfaces: list[InterfaceRef] = []
-    guids: list[str] = []
-    guid_memberships: list[str] = []
-    membership_type: str = "full"
-    ip_over_ib: bool = True
+    host: str = Field(description="Hostname of the UFM server managing the InfiniBand fabric.")
+    pkey: str = Field(description="Partition key whose membership will be replaced.")
+    interfaces: list[InterfaceRef] = Field(
+        default=[], description="Nautobot interfaces to resolve to InfiniBand port GUIDs."
+    )
+    guids: list[str] = Field(
+        default=[], description="InfiniBand port GUIDs that should belong to the partition."
+    )
+    guid_memberships: list[str] = Field(
+        default=[], description="Per-GUID membership types corresponding to the supplied GUIDs."
+    )
+    membership_type: str = Field(
+        default="full", description="Default partition membership type for updated members."
+    )
+    ip_over_ib: bool = Field(
+        default=True,
+        description="IP over InfiniBand setting used when the partition does not already exist.",
+    )
 
     @field_validator("pkey")
     @classmethod

--- a/src/nv_config_manager/temporal/ngc/workflows/ib_port_guid_discovery.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/ib_port_guid_discovery.py
@@ -22,7 +22,7 @@ compute-side interfaces rather than relying on UFM node descriptions
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -59,9 +59,15 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class IBPortGuidDiscoveryInput(BaseModel):
     """Input for the IB Port GUID Discovery workflow."""
 
-    ufm_device_id: str
-    switch_device_ids: list[str]
-    dry_run: bool = True
+    ufm_device_id: str = Field(
+        description="Identifier of the UFM device used to discover port GUIDs."
+    )
+    switch_device_ids: list[str] = Field(
+        description="Identifiers of the InfiniBand switches whose interfaces will be synchronized."
+    )
+    dry_run: bool = Field(
+        default=True, description="Whether to report changes without updating Nautobot."
+    )
 
 
 class IBPortGuidDiscoveryResult(BaseModel):

--- a/src/nv_config_manager/temporal/ngc/workflows/infiniband_cable_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/infiniband_cable_validation.py
@@ -18,7 +18,7 @@ from datetime import timedelta
 from typing import Any
 
 from py_markdown_table.markdown_table import markdown_table
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -59,8 +59,12 @@ DEFAULT_IB_SWITCH_ROLES = [
 class InfinibandCableValidationInput(BaseModel):
     """IB Cable Validation Workflow Input Definition."""
 
-    ufm_device_id: str
-    switch_device_ids: list[str]
+    ufm_device_id: str = Field(
+        description="Identifier of the UFM device used to inspect the InfiniBand fabric."
+    )
+    switch_device_ids: list[str] = Field(
+        description="Identifiers of the InfiniBand switches to validate."
+    )
 
 
 class InvalidCable(BaseModel):

--- a/src/nv_config_manager/temporal/ngc/workflows/infiniband_get_unhealthy_ports.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/infiniband_get_unhealthy_ports.py
@@ -18,7 +18,7 @@ import base64
 from datetime import timedelta
 
 from py_markdown_table.markdown_table import markdown_table
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -50,7 +50,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class InfinibandGetUnhealthyPortsInput(BaseModel):
     """Unhealthy Ports Validation Workflow Input Definition."""
 
-    device_id: str
+    device_id: str = Field(description="Identifier of the UFM device to inspect.")
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/infiniband_mlnx_os_upgrade.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/infiniband_mlnx_os_upgrade.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
@@ -60,7 +60,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class InfinibandMlnxOSUpgradeInput(BaseModel):
     """Infiniband Mellanox OS Upgrade Workflow Input Definition."""
 
-    device_id: str
+    device_id: str = Field(description="Identifier of the InfiniBand switch to upgrade.")
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/lldp.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/lldp.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
@@ -51,9 +51,13 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=3)
 class PortLLDPInfoInput(BaseModel):
     """Input for Port LLDP Info Workflow."""
 
-    device_id: str | None = None
-    interface: str | None = None
-    remote_mac_address: str | None = None
+    device_id: str | None = Field(
+        default=None, description="Identifier of the network device to inspect."
+    )
+    interface: str | None = Field(default=None, description="Name of the local interface.")
+    remote_mac_address: str | None = Field(
+        default=None, description="MAC address of the remote device to locate."
+    )
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
@@ -19,7 +19,7 @@ import hashlib
 from datetime import timedelta
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ChildWorkflowError
@@ -77,12 +77,23 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class MultiDeployInput(BaseModel):
     """Multi-Deploy Workflow Input Definition."""
 
-    role: str
-    max_batch_size: int = 10
-    location: str | None = None
-    status: list[str] | None = None
-    tenant: str | None = None
-    commit_confirm: bool = True
+    role: str = Field(description="Device role used to select network devices for deployment.")
+    max_batch_size: int = Field(
+        default=10, description="Maximum number of devices included in each deployment batch."
+    )
+    location: str | None = Field(
+        default=None, description="Location used to filter the selected network devices."
+    )
+    status: list[str] | None = Field(
+        default=None, description="Device statuses used to filter the selected network devices."
+    )
+    tenant: str | None = Field(
+        default=None, description="Tenant used to filter the selected network devices."
+    )
+    commit_confirm: bool = Field(
+        default=True,
+        description="Whether to use commit-confirmed mode when the platform supports it.",
+    )
 
 
 class DeviceDiffData(BaseModel):
@@ -110,11 +121,18 @@ class DiffGroup(BaseModel):
 class BatchDeployInput(BaseModel):
     """Input for batch deploy child workflow."""
 
-    diff_group: DiffGroup
-    batch_devices: list[DeviceDiffData]
-    parent_workflow_id: str
-    batch_number: int | None = None
-    commit_confirm: bool = True
+    diff_group: DiffGroup = Field(description="Shared configuration diff for the device batch.")
+    batch_devices: list[DeviceDiffData] = Field(
+        description="Devices whose configurations will be deployed in this batch."
+    )
+    parent_workflow_id: str = Field(description="Identifier of the parent multi-deploy workflow.")
+    batch_number: int | None = Field(
+        default=None, description="Sequence number of this batch within the parent workflow."
+    )
+    commit_confirm: bool = Field(
+        default=True,
+        description="Whether to use commit-confirmed mode when the platform supports it.",
+    )
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/nvlinkswitch_firmware_upgrade.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/nvlinkswitch_firmware_upgrade.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
@@ -106,8 +106,8 @@ def _format_firmware_differences(differences: dict[str, dict[str, str]]) -> str:
 class NVLinkSwitchFirmwareUpgradeInput(BaseModel):
     """NVLinkSwitch Firmware Upgrade Workflow Input Definition."""
 
-    device_id: str
-    bundle_version: str
+    device_id: str = Field(description="Identifier of the NVLink switch to upgrade.")
+    bundle_version: str = Field(description="Target NVLink firmware bundle version.")
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/os_upgrade.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/os_upgrade.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
@@ -74,7 +74,7 @@ SUPPORTED_PLATFORMS = [Platform.CUMULUS_LINUX]
 class SwitchOSUpgradeInput(BaseModel):
     """Firmware Upgrade Workflow Input Definition."""
 
-    device_id: str
+    device_id: str = Field(description="Identifier of the network switch to upgrade.")
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/reprovision.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/reprovision.py
@@ -16,7 +16,7 @@
 
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
@@ -58,7 +58,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class ReprovisionInput(BaseModel):
     """Reprovision Workflow Input Definition."""
 
-    device_id: str
+    device_id: str = Field(description="Identifier of the network device to reprovision.")
 
 
 @workflow.defn

--- a/src/nv_config_manager/temporal/ngc/workflows/site_password_rotation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/site_password_rotation.py
@@ -17,7 +17,7 @@
 import asyncio
 from datetime import timedelta
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ChildWorkflowError
@@ -85,11 +85,22 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class SitePasswordRotationInput(BaseModel):
     """Site Password Rotation Workflow Input Definition."""
 
-    location: str
-    selected_secret: str
-    roles: list[str] = DEFAULT_CONFIG_MANAGER_ROLES
-    status: list[str] = DEFAULT_CONFIG_MANAGER_STATUS
-    tenant: str = DEFAULT_CONFIG_MANAGER_TENANT
+    location: str = Field(description="Location containing the devices to update.")
+    selected_secret: str = Field(
+        description="Name of the managed secret containing the replacement password."
+    )
+    roles: list[str] = Field(
+        default=DEFAULT_CONFIG_MANAGER_ROLES,
+        description="Device roles used to filter the selected network devices.",
+    )
+    status: list[str] = Field(
+        default=DEFAULT_CONFIG_MANAGER_STATUS,
+        description="Device statuses used to filter the selected network devices.",
+    )
+    tenant: str = Field(
+        default=DEFAULT_CONFIG_MANAGER_TENANT,
+        description="Tenant used to filter the selected network devices.",
+    )
 
 
 class PasswordRotationResultData(BaseModel):

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -95,13 +95,15 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 class SpXOverlayCreationInput(BaseModel):
     """SpX Overlay Creation Workflow Input Definition."""
 
-    site: str
+    site: str = Field(description="Site where the SpX overlay will be created.")
     overlay_id: str = Field(
         title="Overlay ID",
         description="Unique identifier for the SpX overlay. Used as an idempotency key — re-running with the same ID returns existing VRFs without creating new ones.",
     )
-    tenant: str
-    namespace_tag: str = NAMESPACE_TAG
+    tenant: str = Field(description="Tenant that will own the SpX overlay.")
+    namespace_tag: str = Field(
+        default=NAMESPACE_TAG, description="Tag identifying the namespace used for allocation."
+    )
     rd_min: int = Field(
         default=RD_MIN,
         title="RD Min",
@@ -254,12 +256,14 @@ class SpXOverlayCreationWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
 class SpXOverlayDeletionInput(BaseModel):
     """SpX Overlay Deletion Workflow Input Definition."""
 
-    site: str
+    site: str = Field(description="Site containing the SpX overlay to delete.")
     overlay_id: str = Field(
         title="Overlay ID",
         description="Identifier of the SpX overlay to delete.",
     )
-    namespace_tag: str = NAMESPACE_TAG
+    namespace_tag: str = Field(
+        default=NAMESPACE_TAG, description="Tag identifying the namespace used for allocation."
+    )
 
 
 class SpXOverlayDeletionWorkflowOutput(BaseModel):
@@ -421,10 +425,16 @@ class SpXOverlayAssignmentInput(BaseModel):
         title="Overlay ID",
         description="Identifier of the SpX overlay whose VRF will be assigned to the device and ports.",
     )
-    device: str | NetworkDeviceData
-    port_names: list[str]
-    site: str
-    namespace_tag: str = NAMESPACE_TAG
+    device: str | NetworkDeviceData = Field(
+        description="Identifier or preloaded data for the target network device."
+    )
+    port_names: list[str] = Field(
+        description="Names of the device interfaces to assign to the overlay."
+    )
+    site: str = Field(description="Site containing the target network device.")
+    namespace_tag: str = Field(
+        default=NAMESPACE_TAG, description="Tag identifying the namespace used for allocation."
+    )
 
 
 class SpXOverlayAssignmentWorkflowOutput(BaseModel):
@@ -699,10 +709,16 @@ class SpXOverlayTenantChangeInput(BaseModel):
         title="Overlay ID",
         description="Identifier of the SpX overlay to assign and deploy tenant configuration for.",
     )
-    device_id: str = Field(title="Device ID")
-    port_names: list[str]
-    site: str
-    namespace_tag: str = NAMESPACE_TAG
+    device_id: str = Field(
+        title="Device ID", description="Identifier of the target network device."
+    )
+    port_names: list[str] = Field(
+        description="Names of the device interfaces to assign to the overlay."
+    )
+    site: str = Field(description="Site containing the target network device.")
+    namespace_tag: str = Field(
+        default=NAMESPACE_TAG, description="Tag identifying the namespace used for allocation."
+    )
 
 
 class SpXOverlayTenantChangeWorkflowOutput(BaseModel):

--- a/src/tests/mcp/test_tools.py
+++ b/src/tests/mcp/test_tools.py
@@ -18,7 +18,8 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, Field
 
 from nv_config_manager.mcp import tools
 from nv_config_manager.mcp.settings import MCPSettings
@@ -42,7 +43,8 @@ class FakeServer:
 
 
 class WorkflowInput(BaseModel):
-    device_id: str
+    device_id: str = Field(description="Device to back up.")
+    include_metadata: bool = Field(default=True, description="Include backup metadata.")
 
 
 @pytest.fixture
@@ -89,13 +91,43 @@ async def test_workflow_starter_promotes_config_manager_ui_href(
     )
 
     tools._register_workflow_starter(server, settings, workflow)
-    result = await server.tools["run_backup"]({"device_id": "device-1"})
+    result = await server.tools["run_backup"](device_id="device-1")
 
     assert result["workflow_id"] == "workflow-123"
     assert result["workflow_ui_href"] == (
         "https://config-manager.example.test/workflows/workflow-123"
     )
     assert "workflow_ui_href" in (server.tools["run_backup"].__doc__ or "")
+
+
+async def test_workflow_starter_exposes_workflow_specific_input_schema(
+    settings: MCPSettings,
+) -> None:
+    server = FastMCP("test")
+    workflow = MCPWorkflow(
+        tool_name="run_backup",
+        workflow_name="BackupWorkflow",
+        description="Run a backup.",
+        endpoint="/ngc/backup",
+        input_class=WorkflowInput,
+    )
+
+    tools._register_workflow_starter(server, settings, workflow)
+    registered_tool = next(tool for tool in await server.list_tools() if tool.name == "run_backup")
+
+    assert "parameters" not in registered_tool.inputSchema["properties"]
+    assert registered_tool.inputSchema["required"] == ["device_id"]
+    assert registered_tool.inputSchema["properties"]["device_id"] == {
+        "description": "Device to back up.",
+        "title": "Device Id",
+        "type": "string",
+    }
+    assert registered_tool.inputSchema["properties"]["include_metadata"] == {
+        "default": True,
+        "description": "Include backup metadata.",
+        "title": "Include Metadata",
+        "type": "boolean",
+    }
 
 
 async def test_related_mcp_servers_includes_public_docs(

--- a/src/tests/mcp/test_workflows.py
+++ b/src/tests/mcp/test_workflows.py
@@ -15,6 +15,11 @@
 from __future__ import annotations
 
 from nv_config_manager.mcp.workflows import discover_mcp_workflows, normalize_workflow_parameters
+from nv_config_manager.temporal.common.mixins.metadata import WorkflowMetadataMixin
+from nv_config_manager.temporal.hello_world.workflows import (
+    REGISTERED_WORKFLOWS as HELLO_WORLD_WORKFLOWS,
+)
+from nv_config_manager.temporal.ngc.workflows import REGISTERED_WORKFLOWS as NGC_WORKFLOWS
 
 
 def test_only_safe_diagnostic_workflows_are_mcp_enabled() -> None:
@@ -38,6 +43,23 @@ def test_only_safe_diagnostic_workflows_are_mcp_enabled() -> None:
     assert "run_vpc_creation" not in tool_names
 
 
+def test_registered_workflow_models_describe_every_input_field() -> None:
+    missing_descriptions: dict[str, list[str]] = {}
+    for workflow in NGC_WORKFLOWS + HELLO_WORLD_WORKFLOWS:
+        if not issubclass(workflow, WorkflowMetadataMixin):
+            continue
+        input_class = workflow.get_workflow_input_class()
+        if input_class is None:
+            continue
+        missing_descriptions[workflow.__name__] = [
+            field_name
+            for field_name, field_info in input_class.model_fields.items()
+            if not field_info.description
+        ]
+
+    assert not {tool: fields for tool, fields in missing_descriptions.items() if fields}
+
+
 def test_workflow_parameter_normalization_fills_existing_nullable_bookkeeping() -> None:
     workflow = next(item for item in discover_mcp_workflows() if item.tool_name == "run_backup")
 
@@ -49,3 +71,15 @@ def test_workflow_parameter_normalization_fills_existing_nullable_bookkeeping() 
     assert normalized["user_domain"] is None
     assert normalized["workflow_id"] is None
     assert normalized["intended_config_commit_id"] is None
+
+
+def test_workflow_input_schema_matches_normalized_mcp_parameters() -> None:
+    workflow = next(item for item in discover_mcp_workflows() if item.tool_name == "run_backup")
+
+    schema = workflow.input_schema
+
+    assert schema["required"] == ["device_id"]
+    assert schema["properties"]["trigger"]["default"] == "API"
+    assert schema["properties"]["trigger"]["description"]
+    assert schema["properties"]["user"]["default"] is None
+    assert schema["properties"]["device_id"]["description"]

--- a/src/tests/temporal/ngc/workflows/test_backup_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_backup_workflow.py
@@ -46,6 +46,16 @@ TEST_RETRY_POLICY = RetryPolicy(maximum_attempts=1)
 TEST_TIMEOUT = timedelta(seconds=10)
 
 
+def test_backup_input_optional_metadata_defaults_to_none() -> None:
+    workflow_input = BackupInput(device_id="device-id", trigger=TriggerEnum.API)
+
+    assert workflow_input.user is None
+    assert workflow_input.user_domain is None
+    assert workflow_input.workflow_id is None
+    assert workflow_input.intended_config_commit_id is None
+    assert BackupInput.model_json_schema()["required"] == ["device_id", "trigger"]
+
+
 @activity.defn(name="get_network_device")
 async def mock_get_network_device(
     activity_input: GetNetworkDeviceInput,


### PR DESCRIPTION
## Description

* fix parameter mapping in dynamic workflow tool generation
* add descriptions for fields for every workflow input class

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/28543283482

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow and MCP tool input schemas now surface richer, human-readable field descriptions for clearer guidance.
* **Bug Fixes**
  * Backup workflow input now treats only `device_id` and `trigger` as required; optional fields are omitted from JSON when unset and default to `None` when null/unprovided.
  * MCP workflow tool schemas now accurately reflect required vs optional fields (including `trigger` defaulting to `"API"`).
* **Tests**
  * Added/updated checks to verify schema normalization, description coverage, and the BackupInput optional-field defaults/serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->