### PR TITLE
Disable EKS cloudwatch auto-instrumentation that breaks Temporal

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -502,6 +502,23 @@ checksum/auth-ini: {{ include "nv-config-manager.authIniSections" . | sha256sum 
 {{- end -}}
 
 {{/*
+Opt out of AWS CloudWatch Application Signals / OTel auto-instrumentation on
+Temporal server pods. The Go Temporal server only supports OTLP over gRPC; EKS
+Application Signals injects http/protobuf env vars that prevent startup.
+Usage: {{ include "nv-config-manager.temporalServerOtelOptOutAnnotations" . | nindent 8 }}
+*/}}
+{{- define "nv-config-manager.temporalServerOtelOptOutAnnotations" -}}
+instrumentation.opentelemetry.io/inject-java: "false"
+instrumentation.opentelemetry.io/inject-python: "false"
+instrumentation.opentelemetry.io/inject-dotnet: "false"
+instrumentation.opentelemetry.io/inject-nodejs: "false"
+cloudwatch.aws.amazon.com/auto-annotate-java: "false"
+cloudwatch.aws.amazon.com/auto-annotate-python: "false"
+cloudwatch.aws.amazon.com/auto-annotate-dotnet: "false"
+cloudwatch.aws.amazon.com/auto-annotate-nodejs: "false"
+{{- end -}}
+
+{{/*
 Generate a JSON array of JWT provider configs for the Nautobot
 nv_config_manager_auth.jwt_authentication module.  Includes:
   - OIDC provider (user_provider: true) for browser users

--- a/deploy/helm/templates/temporal.yaml
+++ b/deploy/helm/templates/temporal.yaml
@@ -62,6 +62,7 @@ spec:
         {{- include "nv-config-manager.customPodLabels" $ | nindent 8 }}
       annotations:
         {{- include "nv-config-manager.authIniChecksum" $ | nindent 8 }}
+        {{- include "nv-config-manager.temporalServerOtelOptOutAnnotations" $ | nindent 8 }}
         checksum/temporal-config: {{ include "nv-config-manager.configmap.temporal-config" $ | sha256sum }}
         checksum/temporal-dynamic-config: {{ include "nv-config-manager.configmap.temporal-dynamic-config" $ | sha256sum }}
         {{- if include "nv-config-manager.spiffe.enabled" $ }}
@@ -156,6 +157,9 @@ spec:
               fieldPath: status.podIP
         - name: SERVICES
           value: {{ $service }}
+        # Temporal server only supports OTLP/gRPC; disable injected http/protobuf tracing.
+        - name: OTEL_TRACES_EXPORTER
+          value: "none"
         # Temporal database credentials
         - name: POSTGRES_HOST
           value: {{ tpl $.Values.externalServices.postgres.temporal.host $ | quote }}


### PR DESCRIPTION
## Description

- Opt Temporal server pods out of EKS CloudWatch Application Signals / ADOT auto-instrumentation, which injects `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf` and prevents the Go `temporalio/server` from starting.
- Add explicit `OTEL_TRACES_EXPORTER=none` on Temporal server containers as a belt-and-suspenders guard against injected OTLP trace exporters.

## Problem

On EKS environments the CloudWatch Application Signals mutating webhook auto-instruments pods with certain labels.  The NVCM chart adds that label to Temporal server pod templates.

When Temporal pods are recreated (e.g. YTL migration rollout), the webhook injects OTEL env vars such as:

- `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf`
- `OTEL_TRACES_EXPORTER=otlp`
- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces`

Temporal server only supports OTLP over gRPC, so frontend/history/matching/worker crash on startup with:
```unsupported OTEL exporter protocol: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf```

The Go Temporal server only supports OTLP over gRPC, so startup fails immediately.

### What the webhook added
Pod annotations (added by the mutating webhook, not the chart):
```
cloudwatch.aws.amazon.com/auto-annotate-java: "true"
cloudwatch.aws.amazon.com/auto-annotate-python: "true"
cloudwatch.aws.amazon.com/auto-annotate-dotnet: "true"
cloudwatch.aws.amazon.com/auto-annotate-nodejs: "true"
instrumentation.opentelemetry.io/inject-java: "true"
instrumentation.opentelemetry.io/inject-python: "true"
instrumentation.opentelemetry.io/inject-dotnet: "true"
instrumentation.opentelemetry.io/inject-nodejs: "true"
```
So it was trying to instrument the pod for Java, Python, .NET, and Node.js — even though temporal-frontend is a Go temporalio/server container.

## Solution

1. Add `nv-config-manager.temporalServerOtelOptOutAnnotations` helper that sets:
   - `instrumentation.opentelemetry.io/inject-{java,python,dotnet,nodejs}: "false"`
   - `cloudwatch.aws.amazon.com/auto-annotate-{java,python,dotnet,nodejs}: "false"`
2. Apply those annotations to Temporal server pod templates.
3. Set `OTEL_TRACES_EXPORTER=none` on Temporal server containers.

Python NVCM services (i.e. everything except Temporal) are unaffected and can continue to receive Application Signals instrumentation where desired.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pod annotations for Temporal server pods to opt out of automatic observability injection.
  * Updated the Temporal server runtime configuration to disable outbound trace exporting.

* **Bug Fixes**
  * Prevents unwanted OpenTelemetry and AWS CloudWatch Application Signals auto-annotations from being applied to Temporal server pods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->