### PR TITLE
Show route targets on Spectrum-X overlay details

### DIFF
--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tables.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tables.py
@@ -88,6 +88,29 @@ EXPORT_RT_TEMPLATE = """
 {% for rt in record.export_targets.all %}{{ rt|hyperlinked_object }}{% if not forloop.last %}, {% endif %}{% empty %}{{ None|placeholder }}{% endfor %}
 """
 
+VRF_RD_TEMPLATE = """
+{% load helpers %}
+{% if record.vrf %}{{ record.vrf.rd|placeholder }}{% else %}{{ None|placeholder }}{% endif %}
+"""
+
+VRF_IMPORT_RT_TEMPLATE = """
+{% load helpers %}
+{% if record.vrf %}
+    {% for rt in record.vrf.import_targets.all %}{{ rt|hyperlinked_object }}{% if not forloop.last %}, {% endif %}{% empty %}{{ None|placeholder }}{% endfor %}
+{% else %}
+    {{ None|placeholder }}
+{% endif %}
+"""
+
+VRF_EXPORT_RT_TEMPLATE = """
+{% load helpers %}
+{% if record.vrf %}
+    {% for rt in record.vrf.export_targets.all %}{{ rt|hyperlinked_object }}{% if not forloop.last %}, {% endif %}{% empty %}{{ None|placeholder }}{% endfor %}
+{% else %}
+    {{ None|placeholder }}
+{% endif %}
+"""
+
 VXLAN_VNI_TEMPLATE = """
 {% load helpers %}
 {% if record.assigned_object_type.model == 'vxlan' %}
@@ -435,6 +458,49 @@ class VXLANAssignmentInlineTable(BaseTable):
             "status",
             "actions",
         ]
+
+
+class SpectrumXVXLANInlineTable(BaseTable):
+    """L3 VXLAN and VRF routing details shown on a Spectrum-X overlay."""
+
+    pk = ToggleColumn()
+    name = tables.LinkColumn(verbose_name="VXLAN")
+    vnid = tables.Column(verbose_name="VNI")
+    vrf = tables.Column(linkify=True)
+    route_distinguisher = tables.TemplateColumn(
+        template_code=VRF_RD_TEMPLATE,
+        verbose_name="RD",
+        orderable=False,
+    )
+    import_targets = tables.TemplateColumn(
+        template_code=VRF_IMPORT_RT_TEMPLATE,
+        verbose_name="Import RTs (VRF)",
+        orderable=False,
+    )
+    export_targets = tables.TemplateColumn(
+        template_code=VRF_EXPORT_RT_TEMPLATE,
+        verbose_name="Export RTs (VRF)",
+        orderable=False,
+    )
+    status = tables.Column()
+    actions = ButtonsColumn(models.VXLAN)
+
+    class Meta(BaseTable.Meta):
+        """Meta class."""
+
+        model = models.VXLAN
+        fields = [
+            "pk",
+            "name",
+            "vnid",
+            "vrf",
+            "route_distinguisher",
+            "import_targets",
+            "export_targets",
+            "status",
+            "actions",
+        ]
+        default_columns = fields
 
 
 class VXLANTable(StatusTableMixin, BaseTable):

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/templates/nautobot_app_overlays/overlay_retrieve.html
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/templates/nautobot_app_overlays/overlay_retrieve.html
@@ -59,6 +59,18 @@
 </div>
 {% endif %}
 
+{# Spectrum-X L3 VXLANs and their linked VRF route targets #}
+{% if vxlans_table %}
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <strong>L3 VXLANs and Route Targets</strong>
+    </div>
+    <div class="panel-body">
+        {% render_table vxlans_table %}
+    </div>
+</div>
+{% endif %}
+
 {# InfiniBand PKeys panel #}
 {% if pkeys_table %}
 <div class="panel panel-default">

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tests/test_tables.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tests/test_tables.py
@@ -134,6 +134,13 @@ class VXLANTableTestCase(TestCase):
         RequestConfig(self.factory.get("/")).configure(table)
         self.assertEqual(len(table.rows), models.VXLAN.objects.count())
 
+    def test_spectrum_x_inline_table_includes_vrf_routing_columns(self):
+        """Spectrum-X VXLAN table exposes the linked VRF's RD and RTs."""
+        table = tables.SpectrumXVXLANInlineTable(models.VXLAN.objects.all())
+        self.assertIn("route_distinguisher", table.columns.names())
+        self.assertIn("import_targets", table.columns.names())
+        self.assertIn("export_targets", table.columns.names())
+
 
 class InfiniBandPKeyTableTestCase(TestCase):
     """Tests for InfiniBandPKeyTable."""

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tests/test_views.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tests/test_views.py
@@ -124,6 +124,15 @@ class OverlayViewTestCase(TestCase):
             tenant=self.tenant,
             status=self.vxlan_status,
         )
+        l2_vxlan = models.VXLAN.objects.create(
+            vnid=60002,
+            name="Spectrum-X L2 VXLAN",
+            vni_type=choices.VNITypeChoices.L2_VNI,
+            namespace=self.namespace,
+            overlay=overlay,
+            tenant=self.tenant,
+            status=self.vxlan_status,
+        )
 
         url = reverse(
             "plugins:nautobot_app_overlays:overlay",
@@ -137,6 +146,7 @@ class OverlayViewTestCase(TestCase):
         self.assertContains(response, vrf.rd)
         self.assertContains(response, import_rt.name)
         self.assertContains(response, export_rt.name)
+        self.assertNotContains(response, l2_vxlan.name)
 
     def test_overlay_add_view(self):
         """Test the Overlay add view."""

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tests/test_views.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/tests/test_views.py
@@ -23,8 +23,9 @@ from django.test import TestCase
 from django.urls import reverse
 from nautobot.dcim.models import Interface
 from nautobot.extras.models import CustomField, Status
+from nautobot.ipam.models import VRF, RouteTarget
 
-from nautobot_app_overlays import forms, models
+from nautobot_app_overlays import choices, forms, models
 from nautobot_app_overlays.tests.fixtures import (
     create_assignment_test_data,
     create_device_test_data,
@@ -93,6 +94,49 @@ class OverlayViewTestCase(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Overlay Assignments")
+
+    def test_spectrum_x_overlay_detail_shows_vrf_route_targets(self):
+        """Spectrum-X overlay detail lists linked L3 VXLAN VRF routing data."""
+        overlay = models.Overlay.objects.create(
+            name="Spectrum-X Overlay",
+            tenant=self.tenant,
+            location=self.location,
+            isolation_type=choices.IsolationTypeChoices.SPECTRUM_X_VRF,
+            status=self.overlay_status,
+        )
+        vrf = VRF.objects.create(
+            name="Spectrum-X VRF",
+            namespace=self.namespace,
+            rd="*:60001",
+            tenant=self.tenant,
+        )
+        import_rt = RouteTarget.objects.create(name="65000:60001", tenant=self.tenant)
+        export_rt = RouteTarget.objects.create(name="65001:60001", tenant=self.tenant)
+        vrf.import_targets.add(import_rt)
+        vrf.export_targets.add(export_rt)
+        vxlan = models.VXLAN.objects.create(
+            vnid=60001,
+            name="Spectrum-X L3 VXLAN",
+            vni_type=choices.VNITypeChoices.L3_VNI,
+            namespace=self.namespace,
+            overlay=overlay,
+            vrf=vrf,
+            tenant=self.tenant,
+            status=self.vxlan_status,
+        )
+
+        url = reverse(
+            "plugins:nautobot_app_overlays:overlay",
+            kwargs={"pk": overlay.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "L3 VXLANs and Route Targets")
+        self.assertContains(response, vxlan.name)
+        self.assertContains(response, vrf.rd)
+        self.assertContains(response, import_rt.name)
+        self.assertContains(response, export_rt.name)
 
     def test_overlay_add_view(self):
         """Test the Overlay add view."""

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/views.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/views.py
@@ -30,7 +30,7 @@ from nautobot.dcim.models import Device, Interface, Rack
 from nautobot.extras.models import Status
 
 from nautobot_app_overlays import filters, forms, models, tables
-from nautobot_app_overlays.choices import IsolationTypeChoices
+from nautobot_app_overlays.choices import IsolationTypeChoices, VNITypeChoices
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +74,13 @@ class OverlayUIViewSet(NautobotUIViewSet):
             context["vxlan_assignments_table"] = vxlan_assignments_table
 
         elif instance.isolation_type == IsolationTypeChoices.SPECTRUM_X_VRF:
-            vxlans = instance.vxlans.select_related("vrf", "status").prefetch_related(
-                "vrf__import_targets",
-                "vrf__export_targets",
+            vxlans = (
+                instance.vxlans.filter(vni_type=VNITypeChoices.L3_VNI)
+                .select_related("vrf", "status")
+                .prefetch_related(
+                    "vrf__import_targets",
+                    "vrf__export_targets",
+                )
             )
             vxlans_table = tables.SpectrumXVXLANInlineTable(vxlans, orderable=False)
             RequestConfig(request, paginate={"per_page": 25}).configure(vxlans_table)

--- a/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/views.py
+++ b/components/nautobot/nautobot-app-overlays/nautobot_app_overlays/views.py
@@ -73,6 +73,15 @@ class OverlayUIViewSet(NautobotUIViewSet):
             RequestConfig(request, paginate={"per_page": 25}).configure(vxlan_assignments_table)
             context["vxlan_assignments_table"] = vxlan_assignments_table
 
+        elif instance.isolation_type == IsolationTypeChoices.SPECTRUM_X_VRF:
+            vxlans = instance.vxlans.select_related("vrf", "status").prefetch_related(
+                "vrf__import_targets",
+                "vrf__export_targets",
+            )
+            vxlans_table = tables.SpectrumXVXLANInlineTable(vxlans, orderable=False)
+            RequestConfig(request, paginate={"per_page": 25}).configure(vxlans_table)
+            context["vxlans_table"] = vxlans_table
+
         elif instance.isolation_type == IsolationTypeChoices.IB_PKEY:
             pkeys = instance.pkeys.all().select_related("tenant")
             pkeys_table = tables.InfiniBandPKeyTable(pkeys, orderable=False)

--- a/src/nv_config_manager/temporal/ngc/activities/nautobot.py
+++ b/src/nv_config_manager/temporal/ngc/activities/nautobot.py
@@ -45,6 +45,26 @@ SPECTRUMX_ISOLATION_TYPE = "spectrum_x_vrf"
 VXLAN_L3_VNI_TYPE = "l3"
 DEFAULT_STATUS_NAME = "Active"
 OVERLAY_ASSIGNMENTS_PATH = f"{OVERLAYS_PLUGIN_BASE}/overlay-assignments/"
+ROUTE_TARGETS_PATH = "ipam/route-targets/"
+
+
+async def _get_site_asn(client: NautobotClient, location_id: str) -> str:
+    """Return the site ASN from the location's active config contexts."""
+    query = """
+query ($location: [String]!) {
+  config_contexts(location: $location, is_active: true) {
+    data
+    weight
+  }
+}
+"""
+    result = await client.graphql_query(query, {"location": [location_id]})
+    contexts = result["data"]["config_contexts"]
+    for context in sorted(contexts, key=lambda item: item["weight"], reverse=True):
+        site_asn = (context.get("data") or {}).get("site_asn")
+        if site_asn is not None:
+            return str(site_asn)
+    raise ApplicationError(f"No site_asn config context found for location {location_id}")
 
 
 def _vni_from_rd(route_distinguisher: str) -> int:
@@ -432,6 +452,7 @@ async def provision_vrf(
     vrfs_created: list[Any] = []
     vxlans_created: list[Any] = []
     assignments_created: list[Any] = []
+    route_target_created: dict[str, Any] | None = None
     async with client:
         status_id = await client.lookup_id_by_name("extras/statuses/", DEFAULT_STATUS_NAME)
         if not status_id:
@@ -440,6 +461,9 @@ async def provision_vrf(
         tenant_id = await client.lookup_id_by_name("tenancy/tenants/", activity_input.tenant)
         if not tenant_id:
             raise ApplicationError(f"Tenant '{activity_input.tenant}' not found in Nautobot")
+
+        site_asn = await _get_site_asn(client, location_id)
+        route_target_name = f"{site_asn}:{vni}"
 
         overlay = await client.find_overlay(overlay_name, location_id)
         if overlay:
@@ -465,6 +489,13 @@ async def provision_vrf(
             logger.info("Created overlay %s (%s)", overlay_name, overlay_id)
 
         try:
+            route_target_id = await client.lookup_id_by_name(ROUTE_TARGETS_PATH, route_target_name)
+            if not route_target_id:
+                route_target_created = await client.post(
+                    ROUTE_TARGETS_PATH,
+                    data={"name": route_target_name, "tenant": tenant_id},
+                )
+                route_target_id = route_target_created["id"]
             for namespace in activity_input.namespaces:
                 vrf = await client.create_vrf(
                     data={
@@ -472,6 +503,8 @@ async def provision_vrf(
                         "rd": activity_input.route_distinguisher,
                         "namespace": namespace,
                         "tenant": tenant_id,
+                        "import_targets": [route_target_id],
+                        "export_targets": [route_target_id],
                     }
                 )
                 vrfs_created.append(vrf)
@@ -515,6 +548,14 @@ async def provision_vrf(
                     await client.delete_vrf(vrf["id"])
                 except Exception:
                     logger.exception("Failed to delete vrf %s during rollback", vrf["id"])
+            if route_target_created:
+                try:
+                    await client.delete(ROUTE_TARGETS_PATH + route_target_created["id"] + "/")
+                except Exception:
+                    logger.exception(
+                        "Failed to delete route target %s during rollback",
+                        route_target_created["id"],
+                    )
             raise ApplicationError("Failed to provision VPC") from error
 
 

--- a/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/spx_overlay.py
@@ -129,9 +129,7 @@ class SpXOverlayCreationWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixin
 
     # Workflow metadata
     workflow_name = "SpX Overlay Creation"
-    workflow_description = (
-        "Create a SpX Overlay with route distinguisher assignment and VRF/VXLAN provisioning"
-    )
+    workflow_description = "Create a SpX Overlay with RD/RT assignment and VRF/VXLAN provisioning"
     workflow_input_class = SpXOverlayCreationInput
     workflow_api_endpoint = "/ngc/spx_overlay_creation"
     workflow_namespace = "ngc"

--- a/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
+++ b/src/tests/temporal/ngc/activities/test_spx_overlay_activities.py
@@ -48,6 +48,8 @@ VRF_ID = "eeee0000-0000-0000-0000-000000000001"
 VXLAN_ID = "ffff0000-0000-0000-0000-000000000001"
 ASSIGNMENT_ID = "99990000-0000-0000-0000-000000000001"
 NS_ID = "11110000-0000-0000-0000-000000000001"
+ROUTE_TARGET_ID = "12120000-0000-0000-0000-000000000001"
+SITE_ASN = "4266000000"
 
 
 def _r(url):
@@ -78,6 +80,11 @@ def _namespace_graphql_response(*rds, namespace_id=NS_ID, namespace_name="spectr
             ]
         }
     }
+
+
+def _site_asn_graphql_response(site_asn=SITE_ASN):
+    data = {"site_asn": site_asn} if site_asn is not None else {}
+    return {"data": {"config_contexts": [{"data": data, "weight": 1000}]}}
 
 
 # ---------------------------------------------------------------------------
@@ -410,8 +417,14 @@ async def test_provision_vrf_creates_overlay_vrf_assignment_and_vxlan():
     with aioresponses() as m:
         m.get(_r(f"{NAUTOBOT}/api/extras/statuses/"), payload=_lookup(STATUS_ID))
         m.get(_r(f"{NAUTOBOT}/api/tenancy/tenants/"), payload=_lookup(TENANT_ID))
+        m.post(f"{NAUTOBOT}/api/graphql/", payload=_site_asn_graphql_response())
         m.get(_r(f"{OVERLAYS_BASE}/overlays/"), payload={"results": []})
         m.post(f"{OVERLAYS_BASE}/overlays/", payload={"id": OVERLAY_ID})
+        m.get(_r(f"{NAUTOBOT}/api/ipam/route-targets/"), payload={"results": []})
+        m.post(
+            f"{NAUTOBOT}/api/ipam/route-targets/",
+            payload={"id": ROUTE_TARGET_ID},
+        )
         m.post(f"{NAUTOBOT}/api/ipam/vrfs/", payload={"id": VRF_ID})
         m.post(
             f"{OVERLAYS_BASE}/overlay-assignments/",
@@ -434,6 +447,12 @@ async def test_provision_vrf_creates_overlay_vrf_assignment_and_vxlan():
             "rd": "*:60004",
             "namespace": NS_ID,
             "tenant": TENANT_ID,
+            "import_targets": [ROUTE_TARGET_ID],
+            "export_targets": [ROUTE_TARGET_ID],
+        }
+        assert _request_json(m, "post", f"{NAUTOBOT}/api/ipam/route-targets/") == {
+            "name": f"{SITE_ASN}:60004",
+            "tenant": TENANT_ID,
         }
         assert _request_json(m, "post", f"{OVERLAYS_BASE}/overlay-assignments/") == {
             "overlay": OVERLAY_ID,
@@ -448,11 +467,16 @@ async def test_provision_vrf_reuses_existing_overlay():
     with aioresponses() as m:
         m.get(_r(f"{NAUTOBOT}/api/extras/statuses/"), payload=_lookup(STATUS_ID))
         m.get(_r(f"{NAUTOBOT}/api/tenancy/tenants/"), payload=_lookup(TENANT_ID))
+        m.post(f"{NAUTOBOT}/api/graphql/", payload=_site_asn_graphql_response())
         m.get(
             _r(f"{OVERLAYS_BASE}/overlays/"),
             payload={"results": [{"id": OVERLAY_ID, "tenant": {"id": TENANT_ID}}]},
         )
         # No create_overlay call — overlay already exists
+        m.get(
+            _r(f"{NAUTOBOT}/api/ipam/route-targets/"),
+            payload=_lookup(ROUTE_TARGET_ID),
+        )
         m.post(f"{NAUTOBOT}/api/ipam/vrfs/", payload={"id": VRF_ID})
         m.post(
             f"{OVERLAYS_BASE}/overlay-assignments/",
@@ -476,8 +500,14 @@ async def test_provision_vrf_rolls_back_on_vxlan_failure():
     with aioresponses() as m:
         m.get(_r(f"{NAUTOBOT}/api/extras/statuses/"), payload=_lookup(STATUS_ID))
         m.get(_r(f"{NAUTOBOT}/api/tenancy/tenants/"), payload=_lookup(TENANT_ID))
+        m.post(f"{NAUTOBOT}/api/graphql/", payload=_site_asn_graphql_response())
         m.get(_r(f"{OVERLAYS_BASE}/overlays/"), payload={"results": []})
         m.post(f"{OVERLAYS_BASE}/overlays/", payload={"id": OVERLAY_ID})
+        m.get(_r(f"{NAUTOBOT}/api/ipam/route-targets/"), payload={"results": []})
+        m.post(
+            f"{NAUTOBOT}/api/ipam/route-targets/",
+            payload={"id": ROUTE_TARGET_ID},
+        )
         m.post(f"{NAUTOBOT}/api/ipam/vrfs/", payload={"id": VRF_ID})
         m.post(
             f"{OVERLAYS_BASE}/overlay-assignments/",
@@ -485,12 +515,16 @@ async def test_provision_vrf_rolls_back_on_vxlan_failure():
         )
         # vxlan creation fails
         m.post(f"{OVERLAYS_BASE}/vxlans/", status=400, payload={"detail": "bad"})
-        # rollback: delete assignment and VRF (no VXLANs were created)
+        # rollback: delete assignment, VRF, and RT (no VXLANs were created)
         m.delete(
             f"{OVERLAYS_BASE}/overlay-assignments/{ASSIGNMENT_ID}/",
             status=204,
         )
         m.delete(f"{NAUTOBOT}/api/ipam/vrfs/{VRF_ID}/", status=204)
+        m.delete(
+            f"{NAUTOBOT}/api/ipam/route-targets/{ROUTE_TARGET_ID}/",
+            status=204,
+        )
 
         with pytest.raises(ApplicationError, match="Failed to provision VPC"):
             await provision_vrf(
@@ -528,6 +562,28 @@ async def test_provision_vrf_missing_tenant_raises():
         m.get(_r(f"{NAUTOBOT}/api/tenancy/tenants/"), payload={"results": []})
 
         with pytest.raises(ApplicationError, match="Tenant 'Public Demo' not found"):
+            await provision_vrf(
+                ProvisionVrfInput(
+                    namespaces=[NS_ID],
+                    route_distinguisher="*:60004",
+                    overlay_id="test-overlay-001",
+                    site=LOCATION_ID,
+                    tenant="Public Demo",
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_provision_vrf_missing_site_asn_raises():
+    with aioresponses() as m:
+        m.get(_r(f"{NAUTOBOT}/api/extras/statuses/"), payload=_lookup(STATUS_ID))
+        m.get(_r(f"{NAUTOBOT}/api/tenancy/tenants/"), payload=_lookup(TENANT_ID))
+        m.post(
+            f"{NAUTOBOT}/api/graphql/",
+            payload=_site_asn_graphql_response(site_asn=None),
+        )
+
+        with pytest.raises(ApplicationError, match="No site_asn config context found"):
             await provision_vrf(
                 ProvisionVrfInput(
                     namespaces=[NS_ID],


### PR DESCRIPTION
## Summary

Add a Spectrum-X L3 VXLAN panel to overlay detail page, show the linked VRF route distinguisher and import/export route targets and derive the Spectrum-X route target as `<site_asn>:<vni>` from the active site config context


## Validation

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run locally; this is a focused workflow-state fix covered by the deploy workflow suite.

Passing Kind Integration run:

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is not required because this restores the existing intended UI behavior.
- [x] Generated artifacts are not affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spectrum-X overlay pages now display L3 VXLANs with VRF routing details, including route distinguisher plus import/export route targets.
  * Overlay detail pages show an “L3 VXLANs and Route Targets” panel when applicable, and VXLAN listings include routing-related columns linked to related VRFs/route targets.
  * Spectrum-X VRF provisioning now auto-creates/reuses route targets based on site ASN and attaches them to created VRFs (with expanded rollback cleanup).
* **Tests**
  * Added/updated tests to verify the new routing columns, overlay rendering, route-target provisioning, and error handling when site ASN is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
