### PR TITLE
fix(workflow): Preserve pending state after tenant deploy

### DIFF
--- a/src/nv_config_manager/temporal/ngc/workflows/backup.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/backup.py
@@ -306,7 +306,8 @@ class BackupWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, ArchiveMixi
             ),
         )
 
-        # If no drift update it to match the latest commit ID
+        # No full-config drift means the device matches the latest intended
+        # content, even when this backup follows a partial tenant deployment.
         if not drift_output.has_drift and not workflow_input.intended_config_commit_id:
             workflow_input.intended_config_commit_id = drift_output.commit_id
 

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -699,7 +699,6 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
         """Backup Stage Input."""
 
         device_id: str
-        commit_id: str
 
     class BackupStageOutput(StageOutput):
         """Backup Stage Output."""
@@ -781,7 +780,6 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
         await self.perform_backup(
             TenantDeployWorkflow.BackupStageInput(
                 device_id=load_config_output.device.id,
-                commit_id=load_config_output.intended_config_commit_id,
             )
         )
         await self.archive_results()

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -718,7 +718,6 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
             trigger=TriggerEnum.WORKFLOW,
             user="nv-config-manager-temporal",
             user_domain=None,
-            intended_config_commit_id=stage_input.commit_id,
             workflow_id=workflow.info().workflow_id,
         )
 

--- a/src/tests/temporal/conftest.py
+++ b/src/tests/temporal/conftest.py
@@ -44,6 +44,7 @@ from nv_config_manager.temporal.common.search_attributes import (
 )
 from nv_config_manager.temporal.converter import get_data_converter
 from nv_config_manager.temporal.ngc.activities.nats import PublishNatsInput
+from nv_config_manager.temporal.ngc.activities.slack import SlackMessageInput
 
 _SEARCH_ATTRIBUTES = {
     USER_SEARCH_ATTRIBUTE: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
@@ -81,6 +82,11 @@ async def _register_search_attributes(env: WorkflowEnvironment) -> None:
 @activity.defn(name="publish_nats")
 async def mock_publish_nats(activity_input: PublishNatsInput) -> None:
     """No-op mock for the publish_nats activity."""
+
+
+@activity.defn(name="send_slack_message")
+async def mock_send_slack_message(activity_input: SlackMessageInput) -> None:
+    """No-op mock for the send_slack_message activity."""
 
 
 # UNCOMMENT THIS WHEN TROUBLESHOOTING HUNG TESTS

--- a/src/tests/temporal/ngc/workflows/test_backup_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_backup_workflow.py
@@ -38,8 +38,8 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     GetNetworkDeviceInput,
     GetNetworkDeviceOutput,
 )
-from nv_config_manager.temporal.ngc.activities.slack import SlackMessageInput
 from nv_config_manager.temporal.ngc.workflows.backup import BackupInput, BackupWorkflow, TriggerEnum
+from tests.temporal.conftest import mock_send_slack_message
 
 # Test-specific retry policy and timeout
 TEST_RETRY_POLICY = RetryPolicy(maximum_attempts=1)
@@ -128,12 +128,6 @@ async def mock_record_backup_config_manager_plugin(
         True,
         "Persisted new backup configuration:\n\n[Configuration Backup](https://config-manager.example.com/device/mock_device_uuid/startup.yaml?file_type=backup)\n[Latest Commit](https://config-manager.example.com/commits/mock_commit_id)\n",
     )
-
-
-@activity.defn(name="send_slack_message")
-async def mock_send_slack_message(activity_input: SlackMessageInput) -> None:
-    """Mock send slack message activity."""
-    return None
 
 
 @activity.defn(name="publish_nats")

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -42,6 +42,7 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     GetNetworkDeviceInput,
     GetNetworkDeviceOutput,
 )
+from nv_config_manager.temporal.ngc.activities.slack import SlackMessageInput
 from nv_config_manager.temporal.ngc.workflows.backup import BackupWorkflow
 from nv_config_manager.temporal.ngc.workflows.deploy import (
     INTENDED_CONFIG_COMMIT_ID_DESCRIPTION,
@@ -234,6 +235,11 @@ async def mock_record_backup_config_manager_plugin(
 @activity.defn(name="get_ui_base_url")
 async def mock_get_ui_base_url() -> str:
     return "config-manager.example.com"
+
+
+@activity.defn(name="send_slack_message")
+async def mock_send_slack_message(_activity_input: SlackMessageInput) -> None:
+    return None
 
 
 @pytest.mark.asyncio
@@ -955,6 +961,7 @@ async def test_execute_tenant_deploy_workflow(
             mock_persist_config_backup,
             mock_record_backup_config_manager_plugin,
             mock_get_ui_base_url,
+            mock_send_slack_message,
             publish_nats,
         ],
         activity_executor=ThreadPoolExecutor(5),
@@ -1212,14 +1219,16 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                 "execution_time": 0.0,
                 "input": {
                     "device_id": "mock_device_uuid",
-                    "intended_config_commit_id": "11",
+                    "intended_config_commit_id": None,
                 },
                 "name": "check_drift",
                 "output": {
-                    "commit_id": "11",
-                    "diff": "",
-                    "display": "No drift detected between running and intended configuration.",
-                    "has_drift": False,
+                    "commit_id": "mock_commit_id",
+                    "diff": mock_tenant_diff,
+                    "display": "Loaded intended configuration from "
+                    "[mock_device_uuid/startup.yaml](https://config-manager.example.com/device/mock_device_uuid/startup.yaml?file_type=intended&commit=mock_commit_id).\n"
+                    f"Configuration Drift Detected:\n```\n{mock_tenant_diff}\n```",
+                    "has_drift": True,
                 },
                 "rejecters": [],
                 "requires_approval": False,
@@ -1265,7 +1274,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                         "ztp_enabled": False,
                         "config_context": None,
                     },
-                    "intended_config_commit_id": "11",
+                    "intended_config_commit_id": None,
                     "running_config": "mock running config",
                     "trigger": "WORKFLOW",
                     "user": "nv-config-manager-temporal",
@@ -1299,7 +1308,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
 
         expected_backup_input = {
             "device_id": "mock_device_uuid",
-            "intended_config_commit_id": "11",
+            "intended_config_commit_id": None,
             "trigger": "WORKFLOW",
             "user": "nv-config-manager-temporal",
             "user_domain": None,
@@ -1525,6 +1534,7 @@ async def test_execute_tenant_deploy_workflow_newer_commit_allowed(
             mock_persist_config_backup,
             mock_record_backup_config_manager_plugin,
             mock_get_ui_base_url,
+            mock_send_slack_message,
             publish_nats,
         ],
         activity_executor=ThreadPoolExecutor(5),
@@ -1571,7 +1581,7 @@ nv set interface swp2 ip vrf test-vrf
         backup_workflow_id = stages[-1]["child_workflows"][0]
         backup_handle = client.get_workflow_handle(backup_workflow_id)
         backup_input = await backup_handle.query("input")
-        assert backup_input["intended_config_commit_id"] == "11"
+        assert backup_input["intended_config_commit_id"] is None
 
     # Reset state for other tests
     _newer_commit_mock_state["use_newer_commit"] = False

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -42,7 +42,6 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     GetNetworkDeviceInput,
     GetNetworkDeviceOutput,
 )
-from nv_config_manager.temporal.ngc.activities.slack import SlackMessageInput
 from nv_config_manager.temporal.ngc.workflows.backup import BackupWorkflow
 from nv_config_manager.temporal.ngc.workflows.deploy import (
     INTENDED_CONFIG_COMMIT_ID_DESCRIPTION,
@@ -52,6 +51,7 @@ from nv_config_manager.temporal.ngc.workflows.deploy import (
     TenantDeployInput,
     TenantDeployWorkflow,
 )
+from tests.temporal.conftest import mock_send_slack_message
 
 
 @activity.defn(name="get_network_device")
@@ -235,11 +235,6 @@ async def mock_record_backup_config_manager_plugin(
 @activity.defn(name="get_ui_base_url")
 async def mock_get_ui_base_url() -> str:
     return "config-manager.example.com"
-
-
-@activity.defn(name="send_slack_message")
-async def mock_send_slack_message(_activity_input: SlackMessageInput) -> None:
-    return None
 
 
 @pytest.mark.asyncio
@@ -1135,10 +1130,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                 "depends_on": ["perform_configuration_diff"],
                 "description": "Run the backup workflow for the device..",
                 "execution_time": 0.0,
-                "input": {
-                    "commit_id": "11",
-                    "device_id": "mock_device_uuid",
-                },
+                "input": {"device_id": "mock_device_uuid"},
                 "name": "perform_backup",
                 "output": {"display": ANY},
                 "rejecters": [],
@@ -1576,7 +1568,7 @@ nv set interface swp2 ip vrf test-vrf
         assert load_stage is not None
         assert load_stage["output"]["commit_id"] == "7"
         assert load_stage["output"]["intended_config_commit_id"] == "11"
-        assert stages[-1]["input"]["commit_id"] == "11"
+        assert stages[-1]["input"] == {"device_id": "mock_device_uuid"}
 
         backup_workflow_id = stages[-1]["child_workflows"][0]
         backup_handle = client.get_workflow_handle(backup_workflow_id)


### PR DESCRIPTION
## Description

The Tenant deploy workflow does a partial config deploy but then passes the full startup.yaml intended commit ID to the backup workflow, which results in the deployed_commit_id getting set to the full intended startup commit ID, which makes nautobot think there is no deploy pending even if there are still pending startup.yaml changes.

This PR ensures the tenant deploy workflow invokes the backup with no commit ID, preserving any pending nautobot deploy states if the backup detects drift. The test now detects drift in the backup so we need to mock the slack notification activity, which was moved to a shared mock helper for reusability.

## Validation
Verified on simulator:
1. Create overlay A and B
2. Assign port 1 to overlay A and port 2 to overlay B using Overlay tenant change workflow
3. Config deploys, nautobot shows no pending
4. Reassign port 2 to to overlay A, leaving overlay B with no members
5. Config deploys, nautobot shows pending because VRF B is not deleted by this workflow (intentional)
6. Deploying full config removes VRF B, nautobot shows no deploy pending

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run:
https://github.com/NVIDIA/nv-config-manager/actions/runs/28604068810

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is not required because this restores the existing intended UI behavior.
- [x] Generated artifacts are not affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the tenant deploy flow so backup-related steps no longer propagate an outdated intended-config commit ID in their inputs.

* **Tests**
  * Added/standardized a Slack message activity mock for Temporal worker tests.
  * Updated deploy and backup workflow tests to align stage inputs/expectations, including drift-detection outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->