### PR TITLE
(fix) Update pkey add call - fix for UFM behavior

### DIFF
--- a/components/nautobot/tests/test_middleware.py
+++ b/components/nautobot/tests/test_middleware.py
@@ -96,9 +96,7 @@ class TestJWTCookieMiddleware:
         request.COOKIES = {"NVConfigManagerAccessToken": "valid-jwt"}
 
         with (
-            patch(
-                "nv_config_manager_auth.jwt_authentication._get_providers", return_value=[provider]
-            ),
+            patch("nv_config_manager_auth.jwt_authentication._get_providers", return_value=[provider]),
             patch(
                 "nv_config_manager_auth.jwt_authentication._try_jwt_provider",
                 return_value=(mock_user, "oidc:jdoe"),
@@ -171,9 +169,7 @@ class TestJWTCookieMiddleware:
         request.COOKIES = {"NVConfigManagerAccessToken": "bad-jwt"}
 
         with (
-            patch(
-                "nv_config_manager_auth.jwt_authentication._get_providers", return_value=[provider]
-            ),
+            patch("nv_config_manager_auth.jwt_authentication._get_providers", return_value=[provider]),
             patch("nv_config_manager_auth.jwt_authentication._try_jwt_provider", return_value=None),
             patch("nv_config_manager_auth.middleware.login") as mock_login,
         ):

--- a/development/ufm_mock/mock_server.py
+++ b/development/ufm_mock/mock_server.py
@@ -71,8 +71,10 @@ def _load_fixture(name: str) -> list[dict[str, Any]]:
 class PKeyAddRequest(BaseModel):
     """Body of POST /resources/pkeys/add (create) and POST/PUT /resources/pkeys/.
 
-    ``membership`` (one value for all GUIDs) and ``memberships`` (one per GUID,
-    index-aligned) are mutually exclusive, mirroring UFM.
+    Mirrors UFM 6.19.x semantics: ``membership`` is a single string applied to every
+    GUID; the plural ``memberships`` is an index-aligned per-GUID list. The two
+    endpoints treat the plural array differently (see
+    ``_memberships_add``/``_memberships_set``).
     """
 
     pkey: str
@@ -83,14 +85,14 @@ class PKeyAddRequest(BaseModel):
     memberships: list[str] | None = None
 
 
-def _memberships_for(req: PKeyAddRequest) -> list[str]:
-    """Resolve a per-GUID membership list, enforcing UFM's mutual-exclusion rule."""
+def _memberships_add(req: PKeyAddRequest) -> list[str]:
+    """POST/Add: UFM ignores the plural ``memberships``; the single ``membership`` applies to all."""
+    return [req.membership] * len(req.guids)
+
+
+def _memberships_set(req: PKeyAddRequest) -> list[str]:
+    """PUT/Set: UFM honors the index-aligned ``memberships`` list, else the single ``membership``."""
     if req.memberships is not None:
-        if "membership" in req.model_fields_set:
-            raise HTTPException(
-                status_code=400,
-                detail="Only one of Memberships or Membership is allowed",
-            )
         if len(req.memberships) != len(req.guids):
             raise HTTPException(
                 status_code=400,
@@ -268,14 +270,14 @@ def create_app(store: _Store | None = None) -> FastAPI:
     @app.post("/ufmRest/resources/pkeys/")
     @app.post("/ufmRest/resources/pkeys")
     def add_members(payload: Annotated[PKeyAddRequest, Body()]) -> dict[str, Any]:
-        memberships = _memberships_for(payload)
+        memberships = _memberships_add(payload)
         added = store.add_members(payload.pkey, payload.guids, memberships)
         return {"pkey": payload.pkey, "added": added}
 
     @app.put("/ufmRest/resources/pkeys/")
     @app.put("/ufmRest/resources/pkeys")
     def set_members(payload: Annotated[PKeyAddRequest, Body()]) -> dict[str, Any]:
-        memberships = _memberships_for(payload)
+        memberships = _memberships_set(payload)
         count = store.set_members(
             payload.pkey,
             payload.guids,

--- a/development/ufm_mock/tests/test_mock_server.py
+++ b/development/ufm_mock/tests/test_mock_server.py
@@ -167,53 +167,61 @@ class TestAddMembers:
         )
         assert response.status_code == 404
 
-    def test_per_guid_memberships_array(self, client: TestClient) -> None:
-        """The plural `memberships` array assigns membership per GUID."""
+    def test_grouped_single_membership_posts_assign_per_guid(self, client: TestClient) -> None:
+        """Two single-membership POSTs assign per-GUID membership."""
         client.post(
             "/ufmRest/resources/pkeys/add",
             json={"pkey": "0x0001", "ip_over_ib": True},
         )
-        response = client.post(
+        client.post(
             "/ufmRest/resources/pkeys/",
-            json={
-                "pkey": "0x0001",
-                "guids": ["0xa", "0xb"],
-                "memberships": ["full", "limited"],
-            },
+            json={"pkey": "0x0001", "guids": ["0xa"], "membership": "full"},
         )
-        assert response.status_code == 200
+        client.post(
+            "/ufmRest/resources/pkeys/",
+            json={"pkey": "0x0001", "guids": ["0xb"], "membership": "limited"},
+        )
 
         state = client.get("/ufmRest/resources/pkeys/0x0001?guids_data=true").json()
         by_guid = {e["guid"]: e["membership"] for e in state["guids"]}
         assert by_guid == {"0xa": "full", "0xb": "limited"}
 
-    def test_membership_and_memberships_conflict_rejected(self, client: TestClient) -> None:
-        """Sending both scalar and array membership is rejected, mirroring UFM."""
+    def test_single_membership_applies_to_all(self, client: TestClient) -> None:
+        """A single `membership` string applies to every GUID."""
         client.post(
             "/ufmRest/resources/pkeys/add",
             json={"pkey": "0x0001", "ip_over_ib": True},
         )
         response = client.post(
             "/ufmRest/resources/pkeys/",
-            json={
-                "pkey": "0x0001",
-                "guids": ["0xa"],
-                "membership": "full",
-                "memberships": ["full"],
-            },
+            json={"pkey": "0x0001", "guids": ["0xa", "0xb"], "membership": "limited"},
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
 
-    def test_memberships_length_mismatch_rejected(self, client: TestClient) -> None:
+        state = client.get("/ufmRest/resources/pkeys/0x0001?guids_data=true").json()
+        by_guid = {e["guid"]: e["membership"] for e in state["guids"]}
+        assert by_guid == {"0xa": "limited", "0xb": "limited"}
+
+    def test_plural_memberships_key_is_ignored(self, client: TestClient) -> None:
+        """POST ignores the plural `memberships` and members default to "full".
+
+        Pins the mock to real UFM 6.19.x: the Add endpoint honors only a single
+        `membership` string and silently drops a plural `memberships` array. Keeping
+        the mock faithful to this quirk means integration tests that touch POST can't
+        pass against a mock that is quietly more forgiving than production.
+        """
         client.post(
             "/ufmRest/resources/pkeys/add",
             json={"pkey": "0x0001", "ip_over_ib": True},
         )
         response = client.post(
             "/ufmRest/resources/pkeys/",
-            json={"pkey": "0x0001", "guids": ["0xa", "0xb"], "memberships": ["full"]},
+            json={"pkey": "0x0001", "guids": ["0xa"], "memberships": ["limited"]},
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
+
+        state = client.get("/ufmRest/resources/pkeys/0x0001?guids_data=true").json()
+        assert {e["guid"]: e["membership"] for e in state["guids"]} == {"0xa": "full"}
 
 
 class TestRemoveMembers:
@@ -340,8 +348,8 @@ class TestSetMembers:
         assert by_guid["0xa"] == {"guid": "0xa", "membership": "full"}
         assert by_guid["0xb"]["membership"] == "full"
 
-    def test_put_per_guid_memberships_array(self, client: TestClient) -> None:
-        """PUT honors the per-GUID `memberships` array for an atomic set."""
+    def test_put_per_guid_memberships_list(self, client: TestClient) -> None:
+        """PUT honors the index-aligned plural `memberships` for an atomic set."""
         response = client.put(
             "/ufmRest/resources/pkeys/",
             json={
@@ -355,6 +363,14 @@ class TestSetMembers:
         state = client.get("/ufmRest/resources/pkeys/0x0001?guids_data=true").json()
         by_guid = {e["guid"]: e["membership"] for e in state["guids"]}
         assert by_guid == {"0xa": "limited", "0xb": "full"}
+
+    def test_put_memberships_length_mismatch_rejected(self, client: TestClient) -> None:
+        """A plural `memberships` whose length differs from `guids` is rejected."""
+        response = client.put(
+            "/ufmRest/resources/pkeys/",
+            json={"pkey": "0x0001", "guids": ["0xa", "0xb"], "memberships": ["full"]},
+        )
+        assert response.status_code == 400
 
 
 class TestDevHelpers:

--- a/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
+++ b/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
@@ -88,7 +88,8 @@ class AddGuidsInput(BaseModel):
     """Parameters for adding port GUIDs to an existing PKey partition.
 
     ``memberships`` is index-aligned with ``guids`` (one "full"/"limited" per
-    GUID), the per-port form UFM accepts via the ``memberships`` array.
+    GUID). The activity merges these into the partition's current members and
+    issues a single PUT, since UFM's Add endpoint cannot set per-GUID membership.
     """
 
     host: str
@@ -111,7 +112,8 @@ class SetGuidsInput(BaseModel):
     """Parameters for atomically setting a PKey's exact GUID membership.
 
     ``memberships`` is index-aligned with ``guids`` (one "full"/"limited" per
-    GUID), the per-port form UFM accepts via the ``memberships`` array.
+    GUID), the per-port form UFM's Set endpoint (PUT) accepts via the
+    ``memberships`` array.
     """
 
     host: str
@@ -163,6 +165,36 @@ def _validate_memberships_aligned(pkey: str, guids: list[str], memberships: list
             f"guids length ({len(guids)})",
             non_retryable=True,
         )
+
+
+async def _get_pkey_state(client: UFMClient, pkey: str) -> tuple[bool, dict[str, str], bool | None]:
+    """Read a PKey's current members from UFM."""
+    try:
+        pkey_data = await client.request(
+            "GET",
+            f"/resources/pkeys/{pkey}",
+            params={"guids_data": "true"},
+        )
+    except UFMClientError as e:
+        if e.status_code != 404:
+            raise
+        return False, {}, None
+
+    if not isinstance(pkey_data, dict):
+        raise ApplicationError(
+            f"PKey {pkey} returned an unexpected response from UFM",
+            non_retryable=True,
+        )
+
+    members: dict[str, str] = {}
+    for entry in pkey_data.get("guids", []):
+        if isinstance(entry, dict):
+            members[str(entry.get("guid", "")).lower()] = str(entry.get("membership", "")).lower()
+        else:
+            members[str(entry).lower()] = ""
+
+    ip_over_ib = pkey_data.get("ip_over_ib")
+    return True, members, ip_over_ib if isinstance(ip_over_ib, bool) else None
 
 
 def _parse_pkey_int(pkey_str: str) -> int:
@@ -298,7 +330,13 @@ async def verify_pkey_created(input: VerifyPKeyInput) -> VerifyPKeyOutput:
 
 @activity.defn
 async def add_guids_to_pkey(input: AddGuidsInput) -> AddGuidsOutput:
-    """Add port GUIDs to an existing PKey partition on UFM."""
+    """Add port GUIDs to an existing PKey partition on UFM.
+
+    UFM's Add endpoint (POST) cannot assign per-GUID membership in one call and
+    silently defaults added members to "full". To assign membership reliably and
+    without leaving partial state, this reads the partition's current members, merges
+    in the requested GUIDs, and issues a single PUT that UFM applies atomically.
+    """
     if not input.guids:
         log.info("No GUIDs to add to PKey %s — skipping", input.pkey)
         return AddGuidsOutput(
@@ -309,25 +347,35 @@ async def add_guids_to_pkey(input: AddGuidsInput) -> AddGuidsOutput:
 
     _validate_memberships_aligned(input.pkey, input.guids, input.memberships)
 
-    payload: dict[str, Any] = {
-        "pkey": input.pkey,
-        "guids": input.guids,
-        "memberships": input.memberships,
-        "ip_over_ib": input.ip_over_ib,
-        "index0": input.index0,
-    }
-
-    log.info(
-        "Adding %d GUIDs to PKey %s on UFM at %s: %s (memberships=%s)",
-        len(input.guids),
-        input.pkey,
-        input.host,
-        input.guids,
-        input.memberships,
-    )
-
     async with UFMClient(host=input.host, site=input.site) as client:
-        await client.request("POST", "/resources/pkeys/", json=payload)
+        _, current_members, current_ip_over_ib = await _get_pkey_state(client, input.pkey)
+
+        merged = dict(current_members)
+        for guid, membership in zip(input.guids, input.memberships, strict=True):
+            merged[guid.lower()] = membership.lower()
+
+        payload: dict[str, Any] = {
+            "pkey": input.pkey,
+            "guids": list(merged.keys()),
+            "memberships": list(merged.values()),
+            "ip_over_ib": (
+                current_ip_over_ib if current_ip_over_ib is not None else input.ip_over_ib
+            ),
+            "index0": input.index0,
+        }
+
+        log.info(
+            "Adding %d GUID(s) to PKey %s on UFM at %s via merge-and-PUT "
+            "(%d existing member(s), %d total after merge): %s",
+            len(input.guids),
+            input.pkey,
+            input.host,
+            len(current_members),
+            len(merged),
+            input.guids,
+        )
+
+        await client.request("PUT", "/resources/pkeys/", json=payload)
 
     return AddGuidsOutput(
         pkey=input.pkey,
@@ -379,16 +427,10 @@ async def fetch_pkey_members(input: FetchPKeyMembersInput) -> FetchPKeyMembersOu
     """
     log.info("Fetching members for PKey %s on UFM at %s", input.pkey, input.host)
 
-    try:
-        async with UFMClient(host=input.host, site=input.site) as client:
-            pkey_data = await client.request(
-                "GET",
-                f"/resources/pkeys/{input.pkey}",
-                params={"guids_data": "true"},
-            )
-    except UFMClientError as e:
-        if e.status_code != 404:
-            raise
+    async with UFMClient(host=input.host, site=input.site) as client:
+        exists, members, ip_over_ib = await _get_pkey_state(client, input.pkey)
+
+    if not exists:
         log.info("PKey %s does not exist on UFM", input.pkey)
         return FetchPKeyMembersOutput(
             pkey=input.pkey,
@@ -399,24 +441,8 @@ async def fetch_pkey_members(input: FetchPKeyMembersInput) -> FetchPKeyMembersOu
             display=f"PKey {input.pkey} does not exist on UFM",
         )
 
-    if not isinstance(pkey_data, dict):
-        raise ApplicationError(
-            f"PKey {input.pkey} returned an unexpected response from UFM at {input.host}",
-            non_retryable=True,
-        )
-
-    raw_guids = pkey_data.get("guids", [])
-    guids: list[str] = []
-    memberships: list[str] = []
-    for entry in raw_guids:
-        if isinstance(entry, dict):
-            guids.append(str(entry.get("guid", "")).lower())
-            memberships.append(str(entry.get("membership", "")).lower())
-        else:
-            guids.append(str(entry).lower())
-            memberships.append("")
-
-    ip_over_ib = pkey_data.get("ip_over_ib")
+    guids = list(members.keys())
+    memberships = list(members.values())
     log.info("PKey %s has %d current member(s): %s", input.pkey, len(guids), guids)
 
     return FetchPKeyMembersOutput(
@@ -424,7 +450,7 @@ async def fetch_pkey_members(input: FetchPKeyMembersInput) -> FetchPKeyMembersOu
         exists=True,
         guids=guids,
         memberships=memberships,
-        ip_over_ib=ip_over_ib if isinstance(ip_over_ib, bool) else None,
+        ip_over_ib=ip_over_ib,
         display=f"PKey {input.pkey} has {len(guids)} current member(s)",
     )
 

--- a/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
+++ b/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
@@ -187,11 +187,15 @@ async def _get_pkey_state(client: UFMClient, pkey: str) -> tuple[bool, dict[str,
         )
 
     members: dict[str, str] = {}
-    for entry in pkey_data.get("guids", []):
-        if isinstance(entry, dict):
-            members[str(entry.get("guid", "")).lower()] = str(entry.get("membership", "")).lower()
-        else:
-            members[str(entry).lower()] = ""
+    for entry in pkey_data.get("guids") or []:
+        guid = str(entry.get("guid", "")).lower() if isinstance(entry, dict) else ""
+        membership = str(entry.get("membership", "")).lower() if isinstance(entry, dict) else ""
+        if not guid or not membership:
+            raise ApplicationError(
+                f"PKey {pkey}: UFM returned a member with no guid or membership: {entry!r}",
+                non_retryable=True,
+            )
+        members[guid] = membership
 
     ip_over_ib = pkey_data.get("ip_over_ib")
     return True, members, ip_over_ib if isinstance(ip_over_ib, bool) else None

--- a/src/tests/temporal/activities/test_ib_pkey_member.py
+++ b/src/tests/temporal/activities/test_ib_pkey_member.py
@@ -110,7 +110,8 @@ class TestAddGuidsToPKey:
     @pytest.mark.asyncio
     async def test_adds_guids_successfully(self, mock_ufm_config):
         with aioresponses() as m:
-            m.post(f"{UFM_BASE}/resources/pkeys/", payload={})
+            m.get(_pkey_url("0x0005"), payload={"guids": []})
+            m.put(f"{UFM_BASE}/resources/pkeys/", payload={})
 
             result = await add_guids_to_pkey(
                 AddGuidsInput(
@@ -125,8 +126,12 @@ class TestAddGuidsToPKey:
         assert result.guids_added == [GUID_1, GUID_2]
 
     @pytest.mark.asyncio
-    async def test_per_guid_memberships_in_payload(self, mock_ufm_config):
-        """The POST payload carries index-aligned memberships."""
+    async def test_mixed_memberships_sent_in_single_put(self, mock_ufm_config):
+        """A mixed add resolves to one PUT whose plural `memberships` is index-aligned.
+
+        The add reads current members and issues a single atomic PUT, which UFM honors
+        per-GUID via the plural `memberships` array -- no partial multi-call state.
+        """
         captured: dict = {}
 
         def _capture(url, **kwargs):
@@ -134,7 +139,8 @@ class TestAddGuidsToPKey:
             return CallbackResult(status=200, payload={})
 
         with aioresponses() as m:
-            m.post(f"{UFM_BASE}/resources/pkeys/", callback=_capture)
+            m.get(_pkey_url("0x0005"), payload={"guids": []})
+            m.put(f"{UFM_BASE}/resources/pkeys/", callback=_capture)
 
             result = await add_guids_to_pkey(
                 AddGuidsInput(
@@ -149,6 +155,117 @@ class TestAddGuidsToPKey:
         assert captured["guids"] == [GUID_1, GUID_2]
         assert captured["memberships"] == ["full", "limited"]
         assert "membership" not in captured
+
+    @pytest.mark.asyncio
+    async def test_merges_with_existing_members(self, mock_ufm_config):
+        """New GUIDs merge onto the partition's current members instead of replacing them."""
+        captured: dict = {}
+
+        def _capture(url, **kwargs):
+            captured.update(kwargs.get("json") or {})
+            return CallbackResult(status=200, payload={})
+
+        with aioresponses() as m:
+            m.get(
+                _pkey_url("0x0005"),
+                payload={"guids": [{"guid": GUID_1, "membership": "full"}]},
+            )
+            m.put(f"{UFM_BASE}/resources/pkeys/", callback=_capture)
+
+            await add_guids_to_pkey(
+                AddGuidsInput(
+                    host="ufm.example.com",
+                    pkey="0x0005",
+                    guids=[GUID_2],
+                    memberships=["limited"],
+                )
+            )
+
+        by_guid = dict(zip(captured["guids"], captured["memberships"], strict=True))
+        assert by_guid == {GUID_1: "full", GUID_2: "limited"}
+
+    @pytest.mark.asyncio
+    async def test_requested_membership_wins_over_existing(self, mock_ufm_config):
+        """Re-adding an existing GUID with a new membership updates it in the merged PUT."""
+        captured: dict = {}
+
+        def _capture(url, **kwargs):
+            captured.update(kwargs.get("json") or {})
+            return CallbackResult(status=200, payload={})
+
+        with aioresponses() as m:
+            m.get(
+                _pkey_url("0x0005"),
+                payload={"guids": [{"guid": GUID_1, "membership": "full"}]},
+            )
+            m.put(f"{UFM_BASE}/resources/pkeys/", callback=_capture)
+
+            await add_guids_to_pkey(
+                AddGuidsInput(
+                    host="ufm.example.com",
+                    pkey="0x0005",
+                    guids=[GUID_1],
+                    memberships=["limited"],
+                )
+            )
+
+        by_guid = dict(zip(captured["guids"], captured["memberships"], strict=True))
+        assert by_guid == {GUID_1: "limited"}
+
+    @pytest.mark.asyncio
+    async def test_single_limited_member_sent_via_plural_memberships(self, mock_ufm_config):
+        """A lone limited member goes out under the plural `memberships` UFM's PUT honors.
+
+        UFM defaults members to "full" when the type is sent under a key it ignores;
+        asserting the plural `memberships` on the PUT guards that regression.
+        """
+        captured: dict = {}
+
+        def _capture(url, **kwargs):
+            captured.update(kwargs.get("json") or {})
+            return CallbackResult(status=200, payload={})
+
+        with aioresponses() as m:
+            m.get(_pkey_url("0x0005"), payload={"guids": []})
+            m.put(f"{UFM_BASE}/resources/pkeys/", callback=_capture)
+
+            await add_guids_to_pkey(
+                AddGuidsInput(
+                    host="ufm.example.com",
+                    pkey="0x0005",
+                    guids=[GUID_1],
+                    memberships=["limited"],
+                )
+            )
+
+        assert captured["guids"] == [GUID_1]
+        assert captured["memberships"] == ["limited"]
+        assert "membership" not in captured
+
+    @pytest.mark.asyncio
+    async def test_preserves_existing_ip_over_ib(self, mock_ufm_config):
+        """The merged PUT reuses the partition's existing ip_over_ib, not the input default."""
+        captured: dict = {}
+
+        def _capture(url, **kwargs):
+            captured.update(kwargs.get("json") or {})
+            return CallbackResult(status=200, payload={})
+
+        with aioresponses() as m:
+            m.get(_pkey_url("0x0005"), payload={"guids": [], "ip_over_ib": False})
+            m.put(f"{UFM_BASE}/resources/pkeys/", callback=_capture)
+
+            await add_guids_to_pkey(
+                AddGuidsInput(
+                    host="ufm.example.com",
+                    pkey="0x0005",
+                    guids=[GUID_1],
+                    memberships=["full"],
+                    ip_over_ib=True,
+                )
+            )
+
+        assert captured["ip_over_ib"] is False
 
     @pytest.mark.asyncio
     async def test_misaligned_memberships_rejected_without_http(self, mock_ufm_config):
@@ -168,7 +285,8 @@ class TestAddGuidsToPKey:
     @pytest.mark.asyncio
     async def test_ufm_error_raises(self, mock_ufm_config):
         with aioresponses() as m:
-            m.post(f"{UFM_BASE}/resources/pkeys/", status=400, payload={"error": "bad"})
+            m.get(_pkey_url("0x0005"), payload={"guids": []})
+            m.put(f"{UFM_BASE}/resources/pkeys/", status=400, payload={"error": "bad"})
 
             with pytest.raises(UFMClientError):
                 await add_guids_to_pkey(

--- a/src/tests/temporal/ngc/activities/test_ib_pkey_update.py
+++ b/src/tests/temporal/ngc/activities/test_ib_pkey_update.py
@@ -350,8 +350,7 @@ class TestSetPKeyMembers:
 
         assert captured["pkey"] == "0x0005"
         assert captured["guids"] == [GUID_1, GUID_2]
-        # Per-GUID memberships use UFM's plural `memberships` array, never the
-        # scalar `membership` (the two are mutually exclusive on UFM).
+        # UFM's Set endpoint (PUT) honors the index-aligned plural `memberships`.
         assert captured["memberships"] == ["full", "limited"]
         assert "membership" not in captured
 

--- a/src/tests/temporal/ngc/activities/test_ib_pkey_update.py
+++ b/src/tests/temporal/ngc/activities/test_ib_pkey_update.py
@@ -226,19 +226,46 @@ class TestFetchPKeyMembers:
         assert result.ip_over_ib is False
 
     @pytest.mark.asyncio
-    async def test_handles_plain_string_guids(self, mock_ufm_config):
-        """UFM may return guids as plain strings rather than dicts."""
+    async def test_plain_string_guids_rejected(self, mock_ufm_config):
+        """A guids_data read must carry a membership per member; bare strings are malformed."""
         with aioresponses() as m:
             m.get(
                 _pkey_members_url("0x0005"),
                 payload={"guids": [GUID_1, GUID_2]},
             )
 
+            with pytest.raises(ApplicationError, match="no guid or membership"):
+                await fetch_pkey_members(
+                    FetchPKeyMembersInput(host="ufm.example.com", pkey="0x0005")
+                )
+
+    @pytest.mark.asyncio
+    async def test_member_without_membership_rejected(self, mock_ufm_config):
+        """A member entry lacking a membership fails loudly rather than defaulting a type."""
+        with aioresponses() as m:
+            m.get(
+                _pkey_members_url("0x0005"),
+                payload={"guids": [{"guid": GUID_1}]},
+            )
+
+            with pytest.raises(ApplicationError, match="no guid or membership"):
+                await fetch_pkey_members(
+                    FetchPKeyMembersInput(host="ufm.example.com", pkey="0x0005")
+                )
+
+    @pytest.mark.asyncio
+    async def test_null_guids_treated_as_empty(self, mock_ufm_config):
+        """A null `guids` value is treated as an empty member list, not a crash."""
+        with aioresponses() as m:
+            m.get(_pkey_members_url("0x0005"), payload={"guids": None})
+
             result = await fetch_pkey_members(
                 FetchPKeyMembersInput(host="ufm.example.com", pkey="0x0005")
             )
 
-        assert len(result.guids) == 2
+        assert result.exists is True
+        assert result.guids == []
+        assert result.memberships == []
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/temporal/ngc/workflows/test_ib_pkey_member_update.py
+++ b/src/tests/temporal/ngc/workflows/test_ib_pkey_member_update.py
@@ -550,6 +550,7 @@ async def test_membership_only_change_sent_to_ufm(mock_all_configs, time_skippin
     assert result.members_removed == 0
     assert result.members_unchanged == 1
     # The membership-only change must still produce one UFM PUT with the new membership.
+    # UFM's Set endpoint (PUT) honors the index-aligned plural `memberships`.
     assert len(put_bodies) == 1
     assert put_bodies[0].get("guids") == [GUID_1]
     assert put_bodies[0].get("memberships") == ["limited"]

--- a/src/tests/temporal/workflows/test_ib_pkey_member_add.py
+++ b/src/tests/temporal/workflows/test_ib_pkey_member_add.py
@@ -167,8 +167,9 @@ def _stub_full_run(m: aioresponses) -> None:
         },
     )
 
-    # Stage 2: add GUIDs to PKey
-    m.post(f"{UFM_BASE}/resources/pkeys/", payload={})
+    # Stage 2: add GUIDs to PKey (read current members, then PUT the merged set)
+    m.get(_pkey_verify_url("0x0005"), payload={"guids": []})
+    m.put(f"{UFM_BASE}/resources/pkeys/", payload={})
 
     # Stage 3: verify members (exact URL with query param)
     m.get(
@@ -233,12 +234,12 @@ async def test_full_workflow_happy_path(mock_all_configs, time_skipping_env):
 
 @pytest.mark.asyncio
 async def test_per_interface_membership_sent_to_ufm(mock_all_configs, time_skipping_env):
-    """A per-interface membership override flows into the UFM add memberships[]."""
+    """A per-interface membership override rides the single merged PUT to UFM."""
     task_queue = str(uuid.uuid4())
-    post_bodies: list[dict] = []
+    put_bodies: list[dict] = []
 
     def _record_add(url, **kwargs):
-        post_bodies.append(kwargs.get("json") or {})
+        put_bodies.append(kwargs.get("json") or {})
         return CallbackResult(status=200, payload={})
 
     async with time_skipping_env() as env:
@@ -274,7 +275,8 @@ async def test_per_interface_membership_sent_to_ufm(mock_all_configs, time_skipp
                         ]
                     },
                 )
-                m.post(f"{UFM_BASE}/resources/pkeys/", callback=_record_add)
+                m.get(_pkey_verify_url("0x0005"), payload={"guids": []})
+                m.put(f"{UFM_BASE}/resources/pkeys/", callback=_record_add)
                 m.get(
                     _pkey_verify_url("0x0005"),
                     payload={
@@ -313,19 +315,20 @@ async def test_per_interface_membership_sent_to_ufm(mock_all_configs, time_skipp
                 )
 
     assert result.verified is True
-    assert post_bodies[0].get("guids") == [GUID_1, GUID_2]
-    assert post_bodies[0].get("memberships") == ["full", "limited"]
-    assert "membership" not in post_bodies[0]
+    assert len(put_bodies) == 1
+    assert put_bodies[0].get("guids") == [GUID_1, GUID_2]
+    assert put_bodies[0].get("memberships") == ["full", "limited"]
+    assert "membership" not in put_bodies[0]
 
 
 @pytest.mark.asyncio
 async def test_per_guid_membership_sent_to_ufm(mock_all_configs, time_skipping_env):
-    """Per-GUID memberships from the guids input flow into the UFM add memberships[]."""
+    """Per-GUID memberships ride the single merged PUT, index-aligned with guids."""
     task_queue = str(uuid.uuid4())
-    post_bodies: list[dict] = []
+    put_bodies: list[dict] = []
 
     def _record_add(url, **kwargs):
-        post_bodies.append(kwargs.get("json") or {})
+        put_bodies.append(kwargs.get("json") or {})
         return CallbackResult(status=200, payload={})
 
     async with time_skipping_env() as env:
@@ -339,7 +342,8 @@ async def test_per_guid_membership_sent_to_ufm(mock_all_configs, time_skipping_e
                 stub_graphql_resolve_ib_context(m, pkey="0x0005", overlay_id=OVERLAY_UUID)
                 stub_graphql_resolve_guids(m, [(GUID_1, IFACE_UUID_1), (GUID_2, IFACE_UUID_2)])
 
-                m.post(f"{UFM_BASE}/resources/pkeys/", callback=_record_add)
+                m.get(_pkey_verify_url("0x0005"), payload={"guids": []})
+                m.put(f"{UFM_BASE}/resources/pkeys/", callback=_record_add)
                 m.get(
                     _pkey_verify_url("0x0005"),
                     payload={
@@ -376,9 +380,10 @@ async def test_per_guid_membership_sent_to_ufm(mock_all_configs, time_skipping_e
                 )
 
     assert result.verified is True
-    assert post_bodies[0].get("guids") == [GUID_1, GUID_2]
-    assert post_bodies[0].get("memberships") == ["limited", "full"]
-    assert "membership" not in post_bodies[0]
+    assert len(put_bodies) == 1
+    assert put_bodies[0].get("guids") == [GUID_1, GUID_2]
+    assert put_bodies[0].get("memberships") == ["limited", "full"]
+    assert "membership" not in put_bodies[0]
 
 
 @pytest.mark.asyncio
@@ -407,7 +412,8 @@ async def test_idempotent_existing_assignments(mock_all_configs, time_skipping_e
                         ]
                     },
                 )
-                m.post(f"{UFM_BASE}/resources/pkeys/", payload={})
+                m.get(_pkey_verify_url("0x0005"), payload={"guids": []})
+                m.put(f"{UFM_BASE}/resources/pkeys/", payload={})
                 m.get(
                     _pkey_verify_url("0x0005"),
                     payload={"guids": [{"guid": GUID_1, "membership": "full"}]},
@@ -541,7 +547,8 @@ async def test_guids_only_path(mock_all_configs, time_skipping_env):
                 stub_graphql_resolve_ib_context(m, pkey="0x0005", overlay_id=OVERLAY_UUID)
                 stub_graphql_resolve_guids(m, [(GUID_1, IFACE_UUID_1)])
 
-                m.post(f"{UFM_BASE}/resources/pkeys/", payload={})
+                m.get(_pkey_verify_url("0x0005"), payload={"guids": []})
+                m.put(f"{UFM_BASE}/resources/pkeys/", payload={})
 
                 m.get(
                     _pkey_verify_url("0x0005"),


### PR DESCRIPTION
## Description

**Problem**
Adding a member with membership: limited reported a workflow failure, but UFM had already added the member as full. The add activity sent the requested memberships to UFM's Add endpoint (POST /resources/pkeys/) under the plural memberships array. On UFM 6.19.1, POST silently ignores memberships and defaults every added GUID to full — so the write "succeeded" (200) with the wrong type, and the downstream verify stage then failed on the mismatch.

**Root cause**
Confirmed empirically against UFM 6.19.1 via curl probes. The Add and Set endpoints are asymmetric:

POST /resources/pkeys/ (Add): honors only a single membership string; ignores the plural memberships array (defaults to full); rejects a list under membership (400).
PUT /resources/pkeys/ (Set): honors the index-aligned plural memberships array.
The client used the plural form on POST, which that endpoint doesn't read.

**Fix**
Reworked add_guids_to_pkey into an atomic read-merge-write:

GET the partition's current members.
Merge in the requested GUIDs (requested membership wins on conflict; existing members preserved, so the op stays additive).
Issue a single PUT of the full set, which UFM applies atomically and honors per-GUID via memberships.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->
Updated mock ufm for real behavior, curls against the UFM verified that the POST to add didn't work, but the PUT did. 
- [x] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PKey member updates now preserve existing memberships when adding GUIDs, rather than replacing the full set.
  - Membership updates now handle both single-value and per-GUID membership inputs more consistently.

- **Bug Fixes**
  - Fixed cases where membership data could be interpreted incorrectly during add and update flows.
  - Improved handling of empty or missing member data so existing partitions are reported more reliably.

- **Tests**
  - Updated coverage for add/update behavior, merged memberships, and validation of membership payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->