### PR TITLE
fix handling of nullable fields in workflow-cli

### DIFF
--- a/src/nv_config_manager/temporal/cli.py
+++ b/src/nv_config_manager/temporal/cli.py
@@ -80,7 +80,7 @@ class WorkflowInfo:
 
     def _extract_parameters(self) -> dict[str, dict[str, Any]]:
         """Extract parameter information from input model."""
-        parameters = {}
+        parameters: dict[str, dict[str, Any]] = {}
 
         try:
             # Try Pydantic v2 first
@@ -621,7 +621,7 @@ def create_workflow_command(workflow_name: str, workflow_info: WorkflowInfo) -> 
 
         # Preserve nulls for nullable workflow fields. A missing required-but-nullable
         # field is not equivalent to an explicit JSON null and produces a 422.
-        parameters = {}
+        parameters: dict[str, Any] = {}
         for key, value in kwargs.items():
             param_info = workflow_info.parameters.get(key, {})
             if value is None:

--- a/src/nv_config_manager/temporal/cli.py
+++ b/src/nv_config_manager/temporal/cli.py
@@ -25,7 +25,7 @@ OIDCAuth class from nv_config_manager.common.oidc.
 import json
 import re
 import sys
-from typing import Any, NoReturn, get_type_hints
+from typing import Any, NoReturn, get_args, get_type_hints
 
 import click
 import requests
@@ -87,17 +87,19 @@ class WorkflowInfo:
             if hasattr(self.input_class, "model_fields"):
                 fields = self.input_class.model_fields
                 for field_name, field_info in fields.items():
+                    required = (
+                        field_info.is_required() if hasattr(field_info, "is_required") else True
+                    )
                     param_info = {
                         "type": field_info.annotation if hasattr(field_info, "annotation") else str,
-                        "required": field_info.is_required()
-                        if hasattr(field_info, "is_required")
-                        else True,
+                        "required": required,
                         "default": field_info.default
-                        if hasattr(field_info, "default") and field_info.default is not ...
+                        if not required and hasattr(field_info, "default")
                         else None,
                         "description": field_info.description
                         if hasattr(field_info, "description")
                         else None,
+                        "nullable": _allows_none(field_info.annotation),
                     }
                     parameters[field_name] = param_info
             # Fallback to type hints
@@ -111,6 +113,7 @@ class WorkflowInfo:
                         "required": True,  # Default assumption
                         "default": None,
                         "description": None,
+                        "nullable": _allows_none(field_type),
                     }
                     parameters[field_name] = param_info
         except Exception:
@@ -125,6 +128,7 @@ class WorkflowInfo:
                         "required": True,
                         "default": None,
                         "description": None,
+                        "nullable": _allows_none(field_type),
                     }
                     parameters[field_name] = param_info
             except Exception as ex:
@@ -134,6 +138,13 @@ class WorkflowInfo:
                 )
 
         return parameters
+
+
+def _allows_none(annotation: Any) -> bool:
+    """Return whether a workflow input annotation accepts ``None``."""
+    if annotation is None or annotation is type(None):
+        return True
+    return type(None) in get_args(annotation)
 
 
 def _debug_dump_jwt(access_token: str, context: str = "") -> None:
@@ -608,24 +619,27 @@ def create_workflow_command(workflow_name: str, workflow_info: WorkflowInfo) -> 
                 except Exception as e:
                     raise click.ClickException(f"Failed to convert device name to ID: {e}") from e
 
-        # Filter out None values and convert types as needed
+        # Preserve nulls for nullable workflow fields. A missing required-but-nullable
+        # field is not equivalent to an explicit JSON null and produces a 422.
         parameters = {}
         for key, value in kwargs.items():
-            if value is not None:
-                # Handle list parameters (comma-separated strings)
-                param_info = workflow_info.parameters.get(key, {})
-                param_type = param_info.get("type", str)
+            param_info = workflow_info.parameters.get(key, {})
+            if value is None:
+                if param_info.get("nullable", False):
+                    parameters[key] = None
+                continue
 
-                if hasattr(param_type, "__origin__") and param_type.__origin__ is list:
-                    # Convert comma-separated string to list
-                    if isinstance(value, str):
-                        parameters[key] = [
-                            item.strip() for item in value.split(",") if item.strip()
-                        ]
-                    else:
-                        parameters[key] = value
+            # Handle list parameters (comma-separated strings)
+            param_type = param_info.get("type", str)
+
+            if hasattr(param_type, "__origin__") and param_type.__origin__ is list:
+                # Convert comma-separated string to list
+                if isinstance(value, str):
+                    parameters[key] = [item.strip() for item in value.split(",") if item.strip()]
                 else:
                     parameters[key] = value
+            else:
+                parameters[key] = value
 
         # Create client and invoke workflow
         client = WorkflowClient(

--- a/src/tests/temporal/test_cli_nullable_fields.py
+++ b/src/tests/temporal/test_cli_nullable_fields.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+from pydantic import BaseModel
+
+from nv_config_manager.temporal import cli as temporal_cli
+
+
+class NullableWorkflowInput(BaseModel):
+    required_nullable: str | None
+    optional_nullable: str | None = None
+    nonnullable_default: str = "default-value"
+
+
+class NullableWorkflow:
+    """Workflow used to verify CLI request serialization."""
+
+
+def test_workflow_command_sends_omitted_nullable_fields_as_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_parameters: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        temporal_cli,
+        "_build_auth",
+        lambda *_args: (None, "https://workflow.example.com/v1/workflow"),
+    )
+
+    def capture_invoke(
+        _self: temporal_cli.WorkflowClient,
+        _workflow_info: temporal_cli.WorkflowInfo,
+        parameters: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured_parameters.update(parameters)
+        return {}
+
+    monkeypatch.setattr(temporal_cli.WorkflowClient, "invoke_workflow", capture_invoke)
+
+    workflow_info = temporal_cli.WorkflowInfo(
+        NullableWorkflow,
+        NullableWorkflowInput,
+        "/nullable",
+    )
+    command = temporal_cli.create_workflow_command("nullable", workflow_info)
+
+    result = CliRunner().invoke(command, ["--hostname", "config-manager.example.com"])
+
+    assert result.exit_code == 0, result.output
+    assert captured_parameters == {
+        "required_nullable": None,
+        "optional_nullable": None,
+        "nonnullable_default": "default-value",
+    }


### PR DESCRIPTION
## Description

CLI was not properly handling nullable fields

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow command input handling so nullable fields now serialize with explicit `null` when omitted, while non-nullable fields are still excluded when empty.
  * Preserved existing list behavior, including comma-separated input conversion.

* **Tests**
  * Added coverage for nullable workflow inputs to confirm omitted nullable fields are sent as `null`, and non-nullable defaults remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->