### PR TITLE
fix(ci): skip Go module tag pipelines

### DIFF
--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -22,6 +22,9 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
       when: never
     - if: $CI_COMMIT_BRANCH
+    # Go module tags should not trigger release jobs.
+    - if: $CI_COMMIT_TAG =~ /^bindings\/go\/v/
+      when: never
     - if: $CI_COMMIT_TAG
 
 variables:


### PR DESCRIPTION
## Description

Skip GitLab pipelines for mirrored `bindings/go/v...` tags. These tags are created alongside product release tags for Go module versioning, but they are not valid product or Python package versions.

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run: Not run, only affects gitlab workflow

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to ignore certain tagged commits, preventing unnecessary pipeline runs for those tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->