### PR TITLE
add appProtocol for mcp, allow for disabling cross-zone lb

### DIFF
--- a/deploy/helm/templates/dhcp.yaml
+++ b/deploy/helm/templates/dhcp.yaml
@@ -322,7 +322,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "9090"
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /healthcheck
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: {{ dig "cross_zone_load_balancing_enabled" true .Values.networkDhcp.ingress.nlb | quote }}
     {{- end }}
     {{- /* Cilium annotations */ -}}
     {{- if and .Values.networkDhcp.ingress.cilium .Values.networkDhcp.ingress.cilium.staticIP }}

--- a/deploy/helm/templates/envoy-proxy.yaml
+++ b/deploy/helm/templates/envoy-proxy.yaml
@@ -40,7 +40,7 @@ spec:
           {{- if .Values.gateway.nlb.ips }}
           service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: {{ .Values.gateway.nlb.ips }}
           {{- end }}
-          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+          service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: {{ dig "cross_zone_load_balancing_enabled" true .Values.gateway.nlb | quote }}
           {{- if .Values.gateway.nlb.dns_name }}
           external-dns.alpha.kubernetes.io/hostname: {{ .Values.gateway.nlb.dns_name }}
           {{- end }}

--- a/deploy/helm/templates/mcp.yaml
+++ b/deploy/helm/templates/mcp.yaml
@@ -107,6 +107,7 @@ spec:
     targetPort: 9000
     protocol: TCP
     name: http
+    appProtocol: agentgateway.dev/mcp
   selector:
     app: {{ $mcpName }}
     component: api

--- a/deploy/helm/templates/ztp.yaml
+++ b/deploy/helm/templates/ztp.yaml
@@ -274,7 +274,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "8000"
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /healthcheck
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: {{ dig "cross_zone_load_balancing_enabled" true .Values.networkZtp.ingress.nlb | quote }}
     {{- end }}
     {{- /* Cilium annotations */ -}}
     {{- if and .Values.networkZtp.ingress.cilium .Values.networkZtp.ingress.cilium.staticIP }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -666,6 +666,7 @@ gateway:
   #   sg: "sg-xxxxxxxxx,sg-yyyyyyyyy"  # Security groups
   #   subnets: "subnet-xxxxxxxx,subnet-yyyyyyyy"  # Specific subnets
   #   ips: "10.x.x.x,10.y.y.y"  # Optional: static IPs
+  #   cross_zone_load_balancing_enabled: true  # Set false to disable cross-zone load balancing
   #   dns_name: "*.config-manager.example.com"  # Optional: external-dns hostname
 
   # Base hostname for the gateway - services prepend their subdomain to this
@@ -1302,6 +1303,7 @@ networkZtp:
     #   sg: "sg-xxxxxxxxx,sg-yyyyyyyyy"
     #   subnets: "subnet-xxxxxxxx,subnet-yyyyyyyy"
     #   ips: "10.x.x.x,10.y.y.y"
+    #   cross_zone_load_balancing_enabled: true  # Set false to disable cross-zone load balancing
     #   dns_name: "ztp-ext.config-manager.example.com"
 
     # -------------------------------------------------------------------------
@@ -1474,6 +1476,7 @@ networkDhcp:
     #   sg: "sg-xxxxxxxxx,sg-yyyyyyyyy"
     #   subnets: "subnet-xxxxxxxx,subnet-yyyyyyyy"
     #   ips: "10.x.x.x,10.y.y.y"
+    #   cross_zone_load_balancing_enabled: true  # Set false to disable cross-zone load balancing
     #   dns_name: "dhcp-ext.config-manager.example.com"
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Description

* add appProtocol to MCP service for agent-gateway compatibility
* Make cross-zone load-balancing configurable

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:

https://github.com/NVIDIA/nv-config-manager/actions/runs/28827044801/job/85492417028

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable AWS NLB cross-zone load balancing across service deployments, with sensible defaults when not set.
  * Added an application protocol hint for the MCP service port to improve service compatibility and discovery.

* **Documentation**
  * Added example configuration comments for cross-zone load balancing settings in the values file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->