### PR TITLE
fix(ci): Update internal Pulse Scanner CI config to use recommended component

### DIFF
--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -81,7 +81,6 @@ charts or updating downstream values.
 | `NVCM_CI_IMAGE_GO` | Go CI image |
 | `NVCM_CI_IMAGE_NODE` | Node.js CI image |
 | `NVCM_CI_IMAGE_PLAYWRIGHT` | Playwright CI image |
-| `NVCM_CI_IMAGE_PULSE_SCANNER` | Pulse scanner image |
 | `NVCM_CI_IMAGE_PYTHON_311_BOOKWORM` | Python 3.11 Debian CI image |
 | `NVCM_CI_IMAGE_PYTHON_313` | Python 3.13 CI image |
 | `NVCM_CI_IMAGE_SONAR` | Sonar scanner image |
@@ -103,7 +102,10 @@ charts or updating downstream values.
 | `PULSE_NSPECT_ID` | Pulse project or engagement identifier |
 | `SSA_CLIENT_ID` | Service account client ID used by Pulse scanner authentication |
 | `SSA_CLIENT_SECRET` | Service account client secret used by Pulse scanner authentication |
-| `CONTAINER_SCAN_POLICY` | Optional path to an Anchore policy JSON file, typically provided as a GitLab file variable |
+| `NV_CONFIG_MANAGER_CONTAINER_SCAN_POLICY_TOKEN` | Token that can read the internal container scan policy file |
+| `NVCM_CONTAINER_SCAN_POLICY_PROJECT` | URL-encoded GitLab project path for the internal scan policy project |
+| `NVCM_CONTAINER_SCAN_POLICY_FILE` | URL-encoded internal scan policy file path |
+| `NVCM_CONTAINER_SCAN_POLICY_REF` | Ref for the internal scan policy file, defaults to `main` |
 | `SONAR_HOST_URL` | SonarQube URL |
 | `SONAR_TOKEN` | Token authorized to analyze the SonarQube project and export its report |
 | `NVCM_SONAR_PROJECT_KEY` | SonarQube project key; configure as a protected CI/CD variable |
@@ -116,11 +118,11 @@ analysis rather than replacing valid dashboard coverage with 0% if an expected
 artifact is missing. Generated Go API clients under `bindings/go/` are excluded
 from Sonar analysis.
 
-Pulse scan jobs run the configured scanner image directly with Docker. Each job
-scans one published image from the selected `NVCM_IMAGE_TARGETS` repository for
-either `linux/amd64` or `linux/arm64`, mints a fresh SSA token at scan time,
-and passes `CONTAINER_SCAN_POLICY` to the scanner when a custom policy file is
-configured.
+Pulse scan jobs use the versioned Pulse `scan-images` CI/CD component. The
+component scans each published image from the selected `NVCM_IMAGE_TARGETS`
+repository for both `linux/amd64` and `linux/arm64`, mints a fresh SSA token at
+scan time, and applies the configured internal policy file fetched from
+`NVCM_CONTAINER_SCAN_POLICY_PROJECT`.
 
 ## Downstream Deployments
 

--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -25,16 +25,15 @@ the public repository.
 
 | Variable | Purpose |
 | -------- | ------- |
-| `NGC_REGISTRY_TOKEN` | Registry token used for image pulls, image pushes, and NGC chart publishing |
-| `NGC_REGISTRY_TOKEN_DSX` | Registry token used by the secondary DSX OCI chart target |
-| `NVCM_IMAGE_TARGETS` | Newline-delimited image targets, one `name|repository_prefix|token_variable` record per target |
+| `NVCM_IMAGE_TARGETS` | Newline-delimited image targets, one `name\|repository_prefix\|token_variable` record per target |
 | `NVCM_IMAGE_TARGET` | Optional default image target for build/publish jobs; the first `NVCM_IMAGE_TARGETS` record is used when unset |
 | `NVCM_VALUES_IMAGE_TARGET` | Image target name used when publishing charts and updating downstream `kiwi-argocd` values |
-| `NVCM_IMAGE_REPOSITORY` | Compatibility repository prefix used by config-time GitLab component inputs; set to the same repository as the selected internal image target |
-| `NVCM_NGC_API_BASE` | Base NGC API URL |
-| `NVCM_NGC_ORG` | NGC organization used by tag existence checks |
-| `NVCM_NGC_TEAM` | NGC team used by tag existence checks |
-| `NVCM_CHART_TARGETS` | Newline-delimited chart targets, one `type|repository|token_variable|options` record per target |
+| `NVCM_IMAGE_REPOSITORY` | Legacy/default image repository prefix; when `NVCM_IMAGE_TARGETS` is set, jobs derive this from the selected image target |
+| `NVCM_NGC_API_BASE` | Base registry API URL |
+| `NVCM_NGC_ORG` | Registry organization used by tag existence checks |
+| `NVCM_NGC_TEAM` | Registry team used by tag existence checks |
+| `NVCM_CHART_TARGETS` | Newline-delimited chart targets, one `type\|repository\|token_variable\|options` record per target |
+| Token variables referenced by target records | Registry credentials used for configured image and chart targets |
 | `CI_PUSH_TOKEN` | Token allowed to push CI-generated commits, chart branches, and package uploads |
 | `CI_PUSH_EMAIL` | Commit email used by CI-generated commits |
 
@@ -46,7 +45,7 @@ Example image target layout:
 
 ```text
 NVCM_IMAGE_TARGETS
-internal|nvcr.io/nvidian/cfa|NGC_REGISTRY_TOKEN
+internal|registry.example.com/example/team|REGISTRY_TOKEN
 
 NVCM_VALUES_IMAGE_TARGET
 internal
@@ -56,12 +55,11 @@ Example chart target layout:
 
 ```text
 NVCM_CHART_TARGETS
-ngc|nvidian/cfa|NGC_REGISTRY_TOKEN|org=nvidian
-oci|nvcr.io/0837451325059433/components-dev|NGC_REGISTRY_TOKEN_DSX
+oci|registry.example.com/example/components|CHART_REGISTRY_TOKEN
 ```
 
-Supported chart target types are `ngc` and `oci`. Supported optional chart
-options are `org`, `registry`, `username`, and `label`.
+Supported optional chart target options are `org`, `registry`, `username`,
+and `label`.
 
 `deploy/helm/values.yaml` uses `registry.example.com/nvidia/...` placeholders
 for checked-in service image repositories. Internal publishing and deployment
@@ -83,6 +81,7 @@ charts or updating downstream values.
 | `NVCM_CI_IMAGE_GO` | Go CI image |
 | `NVCM_CI_IMAGE_NODE` | Node.js CI image |
 | `NVCM_CI_IMAGE_PLAYWRIGHT` | Playwright CI image |
+| `NVCM_CI_IMAGE_PULSE_SCANNER` | Pulse scanner image |
 | `NVCM_CI_IMAGE_PYTHON_311_BOOKWORM` | Python 3.11 Debian CI image |
 | `NVCM_CI_IMAGE_PYTHON_313` | Python 3.13 CI image |
 | `NVCM_CI_IMAGE_SONAR` | Sonar scanner image |
@@ -104,10 +103,7 @@ charts or updating downstream values.
 | `PULSE_NSPECT_ID` | Pulse project or engagement identifier |
 | `SSA_CLIENT_ID` | Service account client ID used by Pulse scanner authentication |
 | `SSA_CLIENT_SECRET` | Service account client secret used by Pulse scanner authentication |
-| `NV_CONFIG_MANAGER_CONTAINER_SCAN_POLICY_TOKEN` | Token that can read the container scan policy file |
-| `NVCM_CONTAINER_SCAN_POLICY_PROJECT` | URL-encoded GitLab project path for the scan policy project |
-| `NVCM_CONTAINER_SCAN_POLICY_FILE` | URL-encoded scan policy file path |
-| `NVCM_CONTAINER_SCAN_POLICY_REF` | Ref for the scan policy file, usually `main` |
+| `CONTAINER_SCAN_POLICY` | Optional path to an Anchore policy JSON file, typically provided as a GitLab file variable |
 | `SONAR_HOST_URL` | SonarQube URL |
 | `SONAR_TOKEN` | Token authorized to analyze the SonarQube project and export its report |
 | `NVCM_SONAR_PROJECT_KEY` | SonarQube project key; configure as a protected CI/CD variable |
@@ -119,6 +115,12 @@ scan so all configured coverage reports are available; the scanner skips an
 analysis rather than replacing valid dashboard coverage with 0% if an expected
 artifact is missing. Generated Go API clients under `bindings/go/` are excluded
 from Sonar analysis.
+
+Pulse scan jobs run the configured scanner image directly with Docker. Each job
+scans one published image from the selected `NVCM_IMAGE_TARGETS` repository for
+either `linux/amd64` or `linux/arm64`, mints a fresh SSA token at scan time,
+and passes `CONTAINER_SCAN_POLICY` to the scanner when a custom policy file is
+configured.
 
 ## Downstream Deployments
 

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -35,15 +35,14 @@ variables:
   NVCM_CI_IMAGE_GO: "golang:1.25-alpine"
   NVCM_CI_IMAGE_NODE: "node:24-alpine"
   NVCM_CI_IMAGE_PLAYWRIGHT: "mcr.microsoft.com/playwright:v1.56.1-noble"
+  NVCM_CI_IMAGE_PULSE_SCANNER: "nvcr.io/0898940053369630/general/pulse-container-scanner-cli:stable"
   NVCM_CI_IMAGE_PYTHON_311_BOOKWORM: "python:3.11-bookworm"
   NVCM_CI_IMAGE_PYTHON_313: "python:3.13"
   NVCM_CI_IMAGE_SONAR: "sonarsource/sonar-scanner-cli:11"
   NVCM_CI_IMAGE_UBUNTU: "ubuntu:24.04"
-  NVCM_CONTAINER_SCAN_POLICY_REF: "main"
   APT_MIRROR: "$NVCM_APT_MIRROR"
   APT_MIRROR_DEBIAN: "$NVCM_APT_MIRROR_DEBIAN"
   APT_MIRROR_GPG_KEY_URL: "$NVCM_APT_MIRROR_GPG_KEY_URL"
-  PULSE_REGISTRY_NGC_PASSWORD: $NGC_REGISTRY_TOKEN
 
 # Always-run job to ensure pipeline has at least one job
 # Prevents GitLab UI confusion when all other jobs are skipped

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -35,7 +35,6 @@ variables:
   NVCM_CI_IMAGE_GO: "golang:1.25-alpine"
   NVCM_CI_IMAGE_NODE: "node:24-alpine"
   NVCM_CI_IMAGE_PLAYWRIGHT: "mcr.microsoft.com/playwright:v1.56.1-noble"
-  NVCM_CI_IMAGE_PULSE_SCANNER: "nvcr.io/0898940053369630/general/pulse-container-scanner-cli:stable"
   NVCM_CI_IMAGE_PYTHON_311_BOOKWORM: "python:3.11-bookworm"
   NVCM_CI_IMAGE_PYTHON_313: "python:3.13"
   NVCM_CI_IMAGE_SONAR: "sonarsource/sonar-scanner-cli:11"

--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -47,32 +47,14 @@
       changes: *artifact-paths
       when: on_success
     - when: never
-
-.pulse-scan-image:
-  stage: security
-  tags: *pulse-scan-tags
-  needs: *pulse-scan-needs
-  image: $NVCM_CI_IMAGE_DOCKER
-  services:
-    - name: $NVCM_CI_IMAGE_DOCKER_DIND
-      alias: docker
-      command: ["--tls=false"]
-  rules: *pulse-scan-rules
-  variables:
-    DOCKER_HOST: tcp://docker:2375/
-    DOCKER_TLS_CERTDIR: ""
-    DOCKER_DRIVER: overlay2
-    PULSE_CONTAINER_SCANNER_PLATFORM: linux/amd64
-  before_script:
-    - apk add -q bash curl jq coreutils
+  before_script: &pulse-scan-before-script
     - |
-      set -eu
+      set -euo pipefail
 
-      : "${NVCM_CI_IMAGE_PULSE_SCANNER:?Set NVCM_CI_IMAGE_PULSE_SCANNER}"
+      : "${PULSE_IMAGE_NAME:?Set PULSE_IMAGE_NAME}"
       : "${PULSE_NSPECT_ID:?Set PULSE_NSPECT_ID}"
       : "${SSA_CLIENT_ID:?Set SSA_CLIENT_ID}"
       : "${SSA_CLIENT_SECRET:?Set SSA_CLIENT_SECRET}"
-      : "${PULSE_IMAGE_NAME:?Set PULSE_IMAGE_NAME}"
 
       image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
       eval "$image_target_exports"
@@ -83,151 +65,55 @@
         exit 1
       fi
 
-      export PULSE_CONTAINER_IMAGE="${PULSE_CONTAINER_IMAGE:-${NVCM_IMAGE_REPOSITORY}/${PULSE_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}}"
+      : "${NVCM_CONTAINER_SCAN_POLICY_PROJECT:?Set NVCM_CONTAINER_SCAN_POLICY_PROJECT}"
+      : "${NVCM_CONTAINER_SCAN_POLICY_FILE:?Set NVCM_CONTAINER_SCAN_POLICY_FILE}"
+      : "${NV_CONFIG_MANAGER_CONTAINER_SCAN_POLICY_TOKEN:?Set NV_CONFIG_MANAGER_CONTAINER_SCAN_POLICY_TOKEN}"
 
-      mkdir -p "$CI_PROJECT_DIR/.pulse-scanner-docker" "$CI_PROJECT_DIR/.pulse-target-docker"
-      scanner_registry="${NVCM_CI_IMAGE_PULSE_SCANNER%%/*}"
-      printf '%s' "$image_token" | docker --config "$CI_PROJECT_DIR/.pulse-scanner-docker" login "$scanner_registry" -u '$oauthtoken' --password-stdin
-      printf '%s' "$image_token" | docker --config "$CI_PROJECT_DIR/.pulse-target-docker" login "$NVCM_IMAGE_REGISTRY" -u "$NVCM_IMAGE_USERNAME" --password-stdin
-    - |
-      set -eu
+      mkdir -p "$CI_PROJECT_DIR/.pulse-policy"
+      policy_path="$CI_PROJECT_DIR/.pulse-policy/policy.json"
+      curl --silent --show-error --fail --location \
+        --header "PRIVATE-TOKEN: ${NV_CONFIG_MANAGER_CONTAINER_SCAN_POLICY_TOKEN}" \
+        "${CI_API_V4_URL}/projects/${NVCM_CONTAINER_SCAN_POLICY_PROJECT}/repository/files/${NVCM_CONTAINER_SCAN_POLICY_FILE}/raw?ref=${NVCM_CONTAINER_SCAN_POLICY_REF:-main}" \
+        --output "$policy_path"
+      jq -e . "$policy_path" >/dev/null
+      # The internal scanner image uses CONTAINER_SCAN_POLICY_REF for the policy path.
+      export CONTAINER_SCAN_POLICY_REF="$policy_path"
 
-      token_response="$(curl --silent --show-error --fail --location --request POST \
-        "https://x9thwm-cootr2q1jdv5p7b8iw4fs4ob3x6nqqsoznyk.ssa.nvidia.com/token" \
-        --user "${SSA_CLIENT_ID}:${SSA_CLIENT_SECRET}" \
-        --header "Content-Type: application/x-www-form-urlencoded" \
-        --data-urlencode "grant_type=client_credentials" \
-        --data-urlencode "scope=nspect.verify scan.anchore")"
-      export SSA_TOKEN="$(printf '%s' "$token_response" | jq -r '.access_token // empty')"
-      if [ -z "$SSA_TOKEN" ]; then
-        echo "ERROR: Failed to obtain SSA_TOKEN."
-        exit 1
-      fi
-    - |
-      set -eu
+      export CONTAINER_IMAGE="${NVCM_IMAGE_REPOSITORY}/${PULSE_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}"
+      export PULSE_REGISTRY_NGC_PASSWORD="$image_token"
 
-      export PULSE_POLICY_PATH=""
-      if [ -n "${CONTAINER_SCAN_POLICY:-}" ]; then
-        if [ ! -f "$CONTAINER_SCAN_POLICY" ]; then
-          echo "ERROR: CONTAINER_SCAN_POLICY is set to '${CONTAINER_SCAN_POLICY}', but that file does not exist."
-          exit 1
-        fi
-        mkdir -p "$CI_PROJECT_DIR/.pulse-policy"
-        cp "$CONTAINER_SCAN_POLICY" "$CI_PROJECT_DIR/.pulse-policy/policy.json"
-        export PULSE_POLICY_PATH=/workspace/.pulse-policy/policy.json
-      fi
-  script:
-    - |
-      set -eu
+include:
+  - component: $CI_SERVER_FQDN/security/devops-tools/ci-cd-components/pulse-container-scanner/scan-images@3.0.5
+    inputs:
+      nspect_id: "$PULSE_NSPECT_ID"
+      use_default_policy: true
+      container_scan_policy: ""
+      before_script: *pulse-scan-before-script
+      job_prefix: pulse-scan-images
+      stage: security
+      tags: *pulse-scan-tags
+      needs: *pulse-scan-needs
+      rules: *pulse-scan-rules
+      vault_auth_role: ""
+      sbom_output_format: json
+      scan_matrix:
+        # The component requires CONTAINER_IMAGE in the matrix, but the selected
+        # repository comes from NVCM_IMAGE_TARGETS at runtime.
+        - CONTAINER_IMAGE: computed-by-before-script
+          PULSE_IMAGE_NAME:
+            - nv-config-manager
+            - nv-config-manager-kea
+            - nv-config-manager-kea-admin
+            - nv-config-manager-ui
+            - nv-config-manager-nautobot
+            - nv-config-manager-nats-ready
+          PULSE_CONTAINER_SCANNER_PLATFORM:
+            - linux/amd64
+            - linux/arm64
 
-      if [ -n "${PULSE_POLICY_PATH:-}" ]; then
-        docker --config "$CI_PROJECT_DIR/.pulse-scanner-docker" run --rm \
-          -e SSA_TOKEN \
-          -e NSPECT_ID="$PULSE_NSPECT_ID" \
-          -e CONTAINER_IMAGE="$PULSE_CONTAINER_IMAGE" \
-          -e PULSE_CONTAINER_SCANNER_PLATFORM \
-          -v "$CI_PROJECT_DIR/.pulse-target-docker:/root/.docker:ro" \
-          -v "$CI_PROJECT_DIR:/workspace" \
-          -w /workspace \
-          "$NVCM_CI_IMAGE_PULSE_SCANNER" \
-          pulse-cli -n "$PULSE_NSPECT_ID" scan-image \
-          -i "$PULSE_CONTAINER_IMAGE" \
-          --platform "$PULSE_CONTAINER_SCANNER_PLATFORM" \
-          -p "$PULSE_POLICY_PATH" \
-          --sbom json \
-          -o \
-          --output-dir=.
-      else
-        docker --config "$CI_PROJECT_DIR/.pulse-scanner-docker" run --rm \
-          -e SSA_TOKEN \
-          -e NSPECT_ID="$PULSE_NSPECT_ID" \
-          -e CONTAINER_IMAGE="$PULSE_CONTAINER_IMAGE" \
-          -e PULSE_CONTAINER_SCANNER_PLATFORM \
-          -v "$CI_PROJECT_DIR/.pulse-target-docker:/root/.docker:ro" \
-          -v "$CI_PROJECT_DIR:/workspace" \
-          -w /workspace \
-          "$NVCM_CI_IMAGE_PULSE_SCANNER" \
-          pulse-cli -n "$PULSE_NSPECT_ID" scan-image \
-          -i "$PULSE_CONTAINER_IMAGE" \
-          --platform "$PULSE_CONTAINER_SCANNER_PLATFORM" \
-          --sbom json \
-          -o \
-          --output-dir=.
-      fi
-  artifacts:
-    when: always
-    expire_in: 1 week
-    paths:
-      - pulse-cli.log
-      - licenses.json
-      - sbom.json
-      - cyclonedx_sbom.json
-      - vulns.json
-      - global_policy_evaluation.json
-      - policy_evaluation.json
-
-pulse-scan-nv-config-manager:
-  extends: .pulse-scan-image
+# The component's template-usage jobs only post pipeline metadata. Avoid a
+# repository checkout so they can still run after a merged source branch has
+# been deleted while its pipeline is queued.
+.track_template_usage:
   variables:
-    PULSE_IMAGE_NAME: nv-config-manager
-
-pulse-scan-kea:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-kea
-
-pulse-scan-kea-admin:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-kea-admin
-
-pulse-scan-ui:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-ui
-
-pulse-scan-nautobot:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-nautobot
-
-pulse-scan-nats-ready:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-nats-ready
-
-pulse-scan-nv-config-manager-arm64:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager
-    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
-
-pulse-scan-kea-arm64:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-kea
-    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
-
-pulse-scan-kea-admin-arm64:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-kea-admin
-    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
-
-pulse-scan-ui-arm64:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-ui
-    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
-
-pulse-scan-nautobot-arm64:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-nautobot
-    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
-
-pulse-scan-nats-ready-arm64:
-  extends: .pulse-scan-image
-  variables:
-    PULSE_IMAGE_NAME: nv-config-manager-nats-ready
-    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
+    GIT_STRATEGY: empty

--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -47,160 +47,187 @@
       changes: *artifact-paths
       when: on_success
     - when: never
-  before_script: &pulse-scan-before-script
-    - mkdir -p /tmp/nv-config-manager-scan-policy
-    - |
-      policy_project="${NVCM_CONTAINER_SCAN_POLICY_PROJECT}"
-      policy_file="/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      curl --silent --show-error --fail --location \
-        --header "PRIVATE-TOKEN: ${NV_CONFIG_MANAGER_CONTAINER_SCAN_POLICY_TOKEN:?Set NV_CONFIG_MANAGER_CONTAINER_SCAN_POLICY_TOKEN to a read token for ${NVCM_CONTAINER_SCAN_POLICY_PROJECT}}" \
-        "${CI_API_V4_URL}/projects/${policy_project}/repository/files/${NVCM_CONTAINER_SCAN_POLICY_FILE}/raw?ref=${NVCM_CONTAINER_SCAN_POLICY_REF}" \
-        --output "$policy_file"
-    - jq -e . /tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE} >/dev/null
 
-include:
-  - component: &pulse-scan-component gitlab-master.nvidia.com/security/devops-tools/ci-cd-components/pulse-container-scanner/scan-image@3.0.3
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-nv-config-manager
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-kea:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-kea
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-kea-admin:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-kea-admin
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-ui:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-ui
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-nautobot:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-nautobot
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-nats-ready:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-nats-ready
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-nv-config-manager-arm64
-      pulse_container_scan_platform: linux/arm64
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-kea:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-kea-arm64
-      pulse_container_scan_platform: linux/arm64
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-kea-admin:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-kea-admin-arm64
-      pulse_container_scan_platform: linux/arm64
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-ui:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-ui-arm64
-      pulse_container_scan_platform: linux/arm64
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-nautobot:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-nautobot-arm64
-      pulse_container_scan_platform: linux/arm64
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-  - component: *pulse-scan-component
-    inputs:
-      nspect_id: "$PULSE_NSPECT_ID"
-      container_image: "${NVCM_IMAGE_REPOSITORY}/nv-config-manager-nats-ready:${CI_COMMIT_SHORT_SHA}"
-      container_scan_policy: "/tmp/nv-config-manager-scan-policy/${NVCM_CONTAINER_SCAN_POLICY_FILE}"
-      before_script: *pulse-scan-before-script
-      job_prefix: pulse-scan-nats-ready-arm64
-      pulse_container_scan_platform: linux/arm64
-      tags: *pulse-scan-tags
-      needs: *pulse-scan-needs
-      rules: *pulse-scan-rules
-      vault_auth_role: ""
-
-# The component's template-usage jobs only post pipeline metadata. Avoid a
-# repository checkout so they can still run after a merged source branch has
-# been deleted while its pipeline is queued.
-.track_template_usage:
+.pulse-scan-image:
+  stage: security
+  tags: *pulse-scan-tags
+  needs: *pulse-scan-needs
+  image: $NVCM_CI_IMAGE_DOCKER
+  services:
+    - name: $NVCM_CI_IMAGE_DOCKER_DIND
+      alias: docker
+      command: ["--tls=false"]
+  rules: *pulse-scan-rules
   variables:
-    GIT_STRATEGY: empty
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_TLS_CERTDIR: ""
+    DOCKER_DRIVER: overlay2
+    PULSE_CONTAINER_SCANNER_PLATFORM: linux/amd64
+  before_script:
+    - apk add -q bash curl jq coreutils
+    - |
+      set -eu
+
+      : "${NVCM_CI_IMAGE_PULSE_SCANNER:?Set NVCM_CI_IMAGE_PULSE_SCANNER}"
+      : "${PULSE_NSPECT_ID:?Set PULSE_NSPECT_ID}"
+      : "${SSA_CLIENT_ID:?Set SSA_CLIENT_ID}"
+      : "${SSA_CLIENT_SECRET:?Set SSA_CLIENT_SECRET}"
+      : "${PULSE_IMAGE_NAME:?Set PULSE_IMAGE_NAME}"
+
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh)" || exit $?
+      eval "$image_target_exports"
+
+      image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
+      if [ -z "$image_token" ]; then
+        echo "ERROR: Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset."
+        exit 1
+      fi
+
+      export PULSE_CONTAINER_IMAGE="${PULSE_CONTAINER_IMAGE:-${NVCM_IMAGE_REPOSITORY}/${PULSE_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}}"
+
+      mkdir -p "$CI_PROJECT_DIR/.pulse-scanner-docker" "$CI_PROJECT_DIR/.pulse-target-docker"
+      scanner_registry="${NVCM_CI_IMAGE_PULSE_SCANNER%%/*}"
+      printf '%s' "$image_token" | docker --config "$CI_PROJECT_DIR/.pulse-scanner-docker" login "$scanner_registry" -u '$oauthtoken' --password-stdin
+      printf '%s' "$image_token" | docker --config "$CI_PROJECT_DIR/.pulse-target-docker" login "$NVCM_IMAGE_REGISTRY" -u "$NVCM_IMAGE_USERNAME" --password-stdin
+    - |
+      set -eu
+
+      token_response="$(curl --silent --show-error --fail --location --request POST \
+        "https://x9thwm-cootr2q1jdv5p7b8iw4fs4ob3x6nqqsoznyk.ssa.nvidia.com/token" \
+        --user "${SSA_CLIENT_ID}:${SSA_CLIENT_SECRET}" \
+        --header "Content-Type: application/x-www-form-urlencoded" \
+        --data-urlencode "grant_type=client_credentials" \
+        --data-urlencode "scope=nspect.verify scan.anchore")"
+      export SSA_TOKEN="$(printf '%s' "$token_response" | jq -r '.access_token // empty')"
+      if [ -z "$SSA_TOKEN" ]; then
+        echo "ERROR: Failed to obtain SSA_TOKEN."
+        exit 1
+      fi
+    - |
+      set -eu
+
+      export PULSE_POLICY_PATH=""
+      if [ -n "${CONTAINER_SCAN_POLICY:-}" ]; then
+        if [ ! -f "$CONTAINER_SCAN_POLICY" ]; then
+          echo "ERROR: CONTAINER_SCAN_POLICY is set to '${CONTAINER_SCAN_POLICY}', but that file does not exist."
+          exit 1
+        fi
+        mkdir -p "$CI_PROJECT_DIR/.pulse-policy"
+        cp "$CONTAINER_SCAN_POLICY" "$CI_PROJECT_DIR/.pulse-policy/policy.json"
+        export PULSE_POLICY_PATH=/workspace/.pulse-policy/policy.json
+      fi
+  script:
+    - |
+      set -eu
+
+      if [ -n "${PULSE_POLICY_PATH:-}" ]; then
+        docker --config "$CI_PROJECT_DIR/.pulse-scanner-docker" run --rm \
+          -e SSA_TOKEN \
+          -e NSPECT_ID="$PULSE_NSPECT_ID" \
+          -e CONTAINER_IMAGE="$PULSE_CONTAINER_IMAGE" \
+          -e PULSE_CONTAINER_SCANNER_PLATFORM \
+          -v "$CI_PROJECT_DIR/.pulse-target-docker:/root/.docker:ro" \
+          -v "$CI_PROJECT_DIR:/workspace" \
+          -w /workspace \
+          "$NVCM_CI_IMAGE_PULSE_SCANNER" \
+          pulse-cli -n "$PULSE_NSPECT_ID" scan-image \
+          -i "$PULSE_CONTAINER_IMAGE" \
+          --platform "$PULSE_CONTAINER_SCANNER_PLATFORM" \
+          -p "$PULSE_POLICY_PATH" \
+          --sbom json \
+          -o \
+          --output-dir=.
+      else
+        docker --config "$CI_PROJECT_DIR/.pulse-scanner-docker" run --rm \
+          -e SSA_TOKEN \
+          -e NSPECT_ID="$PULSE_NSPECT_ID" \
+          -e CONTAINER_IMAGE="$PULSE_CONTAINER_IMAGE" \
+          -e PULSE_CONTAINER_SCANNER_PLATFORM \
+          -v "$CI_PROJECT_DIR/.pulse-target-docker:/root/.docker:ro" \
+          -v "$CI_PROJECT_DIR:/workspace" \
+          -w /workspace \
+          "$NVCM_CI_IMAGE_PULSE_SCANNER" \
+          pulse-cli -n "$PULSE_NSPECT_ID" scan-image \
+          -i "$PULSE_CONTAINER_IMAGE" \
+          --platform "$PULSE_CONTAINER_SCANNER_PLATFORM" \
+          --sbom json \
+          -o \
+          --output-dir=.
+      fi
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - pulse-cli.log
+      - licenses.json
+      - sbom.json
+      - cyclonedx_sbom.json
+      - vulns.json
+      - global_policy_evaluation.json
+      - policy_evaluation.json
+
+pulse-scan-nv-config-manager:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager
+
+pulse-scan-kea:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-kea
+
+pulse-scan-kea-admin:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-kea-admin
+
+pulse-scan-ui:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-ui
+
+pulse-scan-nautobot:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-nautobot
+
+pulse-scan-nats-ready:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-nats-ready
+
+pulse-scan-nv-config-manager-arm64:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager
+    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
+
+pulse-scan-kea-arm64:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-kea
+    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
+
+pulse-scan-kea-admin-arm64:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-kea-admin
+    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
+
+pulse-scan-ui-arm64:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-ui
+    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
+
+pulse-scan-nautobot-arm64:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-nautobot
+    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64
+
+pulse-scan-nats-ready-arm64:
+  extends: .pulse-scan-image
+  variables:
+    PULSE_IMAGE_NAME: nv-config-manager-nats-ready
+    PULSE_CONTAINER_SCANNER_PLATFORM: linux/arm64


### PR DESCRIPTION
## Description

Updates GitLab Pulse container scanning to use the current scan-images CI/CD component.

## Validation

- Ran a copy of these changes on internal mirror to confirm the pulse jobs build and run

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind not needed since this is gitlab CI changes only.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
* **Documentation**
  * Clarified CI variable formats for image/chart target records and rewrote container scan policy guidance.
* **New Features**
  * Introduced a unified, versioned Pulse image scanning workflow that scans multiple `nv-config-manager*` images across `linux/amd64` and `linux/arm64`.
* **Bug Fixes**
  * Improved scan-time security by minting fresh SSA credentials and validating the fetched scan policy.
* **Refactor**
  * Consolidated Pulse scan job logic into a shared matrix-based configuration.
* **Chores**
  * Removed an obsolete scan-related CI variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->