### PR TITLE
expand copy-pr-bot perms

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -4,7 +4,9 @@ auto_sync_ready: true
 trustees_override:
   - dmathur0
   - jojung1
+  - kiwueke2
   - polarweasel
+  - ross-bryan
   - ryanheffernan
   - spidercensus
   - susanhooks
@@ -12,7 +14,9 @@ trustees_override:
 vetters_override:
   - dmathur0
   - jojung1
+  - kiwueke2
   - polarweasel
+  - ross-bryan
   - ryanheffernan
   - spidercensus
   - susanhooks


### PR DESCRIPTION
## Description

Add Kezie and Ross to trustees/vetters

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
or narrow it only while debugging.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the set of approved reviewers and trustees for PR bot workflows.
  * Added two additional users to the allowed trustee and vetter lists, expanding who can participate in review-related automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->