### PR TITLE
Add /kind test command for PR integration tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,8 @@ As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-
 `pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
 only while debugging.
 
+The completed workflow posts its conclusion and exact run URL as a PR comment.
+
 Passing Kind Integration run:
 <!-- Paste the workflow run URL here. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,17 @@
 - [ ] Standard CI passes.
 - [ ] Kind integration passes, or this PR explains why it was not run.
 
-The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review,
-run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
-`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite,
-or narrow it only while debugging.
+The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
+review, approve the current commit and start the suite with these PR comments:
+
+```text
+/ok to test <sha>
+/kind test
+```
+
+As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
+`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
+only while debugging.
 
 Passing Kind Integration run:
 <!-- Paste the workflow run URL here. -->

--- a/.github/scripts/kind-integration-command.js
+++ b/.github/scripts/kind-integration-command.js
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const pullNumber = context.payload.issue.number;
+  const username = context.payload.comment.user.login;
+
+  const reply = (body) =>
+    github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pullNumber,
+      body,
+    });
+  const reject = async (message) => {
+    await reply("ERROR: " + message);
+    core.setFailed(message);
+  };
+
+  let permission = "none";
+  try {
+    const response = await github.rest.repos.getCollaboratorPermissionLevel({
+      owner,
+      repo,
+      username,
+    });
+    permission = response.data.permission;
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+  }
+  if (!["admin", "write"].includes(permission)) {
+    await reject("@" + username + " needs write access to start Kind integration tests.");
+    return;
+  }
+
+  const { data: pull } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  if (pull.state !== "open") {
+    await reject("Kind integration tests can only be started for an open PR.");
+    return;
+  }
+
+  const currentSha = pull.head.sha.toLowerCase();
+  const trustedBranch = "pull-request/" + pullNumber;
+  let trustedRef;
+  try {
+    const response = await github.rest.git.getRef({
+      owner,
+      repo,
+      ref: "heads/" + trustedBranch,
+    });
+    trustedRef = response.data;
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+    await reject(
+      "Trusted branch " +
+        trustedBranch +
+        " does not exist. Run /ok to test " +
+        currentSha +
+        " first.",
+    );
+    return;
+  }
+
+  if (trustedRef.object.sha.toLowerCase() !== currentSha) {
+    await reject(
+      "Trusted branch " +
+        trustedBranch +
+        " is stale. Run /ok to test " +
+        currentSha +
+        " first.",
+    );
+    return;
+  }
+
+  const { data: runs } = await github.rest.actions.listWorkflowRuns({
+    owner,
+    repo,
+    workflow_id: "kind-integration.yml",
+    branch: trustedBranch,
+    event: "workflow_dispatch",
+    per_page: 20,
+  });
+  const activeRun = runs.workflow_runs.find(
+    (run) => run.head_sha.toLowerCase() === currentSha && run.status !== "completed",
+  );
+  if (activeRun) {
+    await reply("INFO: Kind integration is already running: " + activeRun.html_url);
+    return;
+  }
+
+  await github.rest.actions.createWorkflowDispatch({
+    owner,
+    repo,
+    workflow_id: "kind-integration.yml",
+    ref: trustedBranch,
+    inputs: {
+      test_path: "src/tests/integration/",
+      observability: "false",
+      approved_sha: currentSha,
+    },
+  });
+
+  await reply(
+    "Queued Kind integration for " +
+      currentSha +
+      ": https://github.com/" +
+      owner +
+      "/" +
+      repo +
+      "/actions/workflows/kind-integration.yml",
+  );
+};

--- a/.github/scripts/kind-integration-command.js
+++ b/.github/scripts/kind-integration-command.js
@@ -4,6 +4,7 @@
 module.exports = async ({ github, context, core }) => {
   const { owner, repo } = context.repo;
   const pullNumber = context.payload.issue.number;
+  const commentId = context.payload.comment.id;
   const username = context.payload.comment.user.login;
 
   const reply = (body) =>
@@ -17,6 +18,13 @@ module.exports = async ({ github, context, core }) => {
     await reply("ERROR: " + message);
     core.setFailed(message);
   };
+  const acknowledge = () =>
+    github.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      content: "+1",
+    });
 
   let permission = "none";
   try {
@@ -93,6 +101,7 @@ module.exports = async ({ github, context, core }) => {
     (run) => run.head_sha.toLowerCase() === currentSha && run.status !== "completed",
   );
   if (activeRun) {
+    await acknowledge();
     await reply("INFO: Kind integration is already running: " + activeRun.html_url);
     return;
   }
@@ -109,6 +118,7 @@ module.exports = async ({ github, context, core }) => {
     },
   });
 
+  await acknowledge();
   await reply(
     "Queued Kind integration for " +
       currentSha +

--- a/.github/scripts/kind-integration-command.test.js
+++ b/.github/scripts/kind-integration-command.test.js
@@ -13,11 +13,12 @@ function createFixture(options = {}) {
   const comments = [];
   const dispatches = [];
   const failures = [];
+  const reactions = [];
   const context = {
     repo: { owner: "NVIDIA", repo: "nv-config-manager" },
     payload: {
       issue: { number: 123 },
-      comment: { user: { login: "reviewer" } },
+      comment: { id: 456, user: { login: "reviewer" } },
     },
   };
 
@@ -25,6 +26,9 @@ function createFixture(options = {}) {
     rest: {
       issues: {
         createComment: async (args) => comments.push(args),
+      },
+      reactions: {
+        createForIssueComment: async (args) => reactions.push(args),
       },
       repos: {
         getCollaboratorPermissionLevel: async () => ({
@@ -72,6 +76,7 @@ function createFixture(options = {}) {
     dispatches,
     failures,
     github,
+    reactions,
   };
 }
 
@@ -86,6 +91,14 @@ test("dispatches Kind integration for the trusted current PR commit", async () =
 
   assert.deepEqual(result.failures, []);
   assert.equal(result.dispatches.length, 1);
+  assert.deepEqual(result.reactions, [
+    {
+      owner: "NVIDIA",
+      repo: "nv-config-manager",
+      comment_id: 456,
+      content: "+1",
+    },
+  ]);
   assert.deepEqual(result.dispatches[0], {
     owner: "NVIDIA",
     repo: "nv-config-manager",
@@ -104,6 +117,7 @@ test("rejects a commenter without write access", async () => {
   const result = await runFixture({ permission: "read" });
 
   assert.equal(result.dispatches.length, 0);
+  assert.equal(result.reactions.length, 0);
   assert.match(result.failures[0], /needs write access/);
   assert.match(result.comments[0].body, /ERROR/);
 });
@@ -112,6 +126,7 @@ test("rejects starting Kind integration for a non-open PR", async () => {
   const result = await runFixture({ pullState: "closed" });
 
   assert.equal(result.dispatches.length, 0);
+  assert.equal(result.reactions.length, 0);
   assert.match(result.failures[0], /only be started for an open PR/);
   assert.match(result.comments[0].body, /ERROR/);
 });
@@ -120,6 +135,7 @@ test("requires the copy-pr-bot trusted branch", async () => {
   const result = await runFixture({ missingTrustedBranch: true });
 
   assert.equal(result.dispatches.length, 0);
+  assert.equal(result.reactions.length, 0);
   assert.match(result.failures[0], /does not exist/);
   assert.match(result.comments[0].body, /\/ok to test/);
 });
@@ -128,6 +144,7 @@ test("rejects a trusted branch that does not match the current PR head", async (
   const result = await runFixture({ trustedSha: STALE_SHA });
 
   assert.equal(result.dispatches.length, 0);
+  assert.equal(result.reactions.length, 0);
   assert.match(result.failures[0], /is stale/);
   assert.match(result.comments[0].body, /\/ok to test/);
 });
@@ -145,5 +162,6 @@ test("does not duplicate an active Kind integration run", async () => {
 
   assert.deepEqual(result.failures, []);
   assert.equal(result.dispatches.length, 0);
+  assert.equal(result.reactions.length, 1);
   assert.match(result.comments[0].body, /already running/);
 });

--- a/.github/scripts/kind-integration-command.test.js
+++ b/.github/scripts/kind-integration-command.test.js
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const dispatchKindIntegration = require("./kind-integration-command.js");
+
+const CURRENT_SHA = "a".repeat(40);
+const STALE_SHA = "b".repeat(40);
+
+function createFixture(options = {}) {
+  const comments = [];
+  const dispatches = [];
+  const failures = [];
+  const context = {
+    repo: { owner: "NVIDIA", repo: "nv-config-manager" },
+    payload: {
+      issue: { number: 123 },
+      comment: { user: { login: "reviewer" } },
+    },
+  };
+
+  const github = {
+    rest: {
+      issues: {
+        createComment: async (args) => comments.push(args),
+      },
+      repos: {
+        getCollaboratorPermissionLevel: async () => ({
+          data: { permission: options.permission ?? "write" },
+        }),
+      },
+      pulls: {
+        get: async () => ({
+          data: {
+            state: options.pullState ?? "open",
+            head: { sha: options.currentSha ?? CURRENT_SHA },
+          },
+        }),
+      },
+      git: {
+        getRef: async () => {
+          if (options.missingTrustedBranch) {
+            const error = new Error("Not Found");
+            error.status = 404;
+            throw error;
+          }
+          return {
+            data: {
+              object: { sha: options.trustedSha ?? CURRENT_SHA },
+            },
+          };
+        },
+      },
+      actions: {
+        listWorkflowRuns: async () => ({
+          data: { workflow_runs: options.workflowRuns ?? [] },
+        }),
+        createWorkflowDispatch: async (args) => dispatches.push(args),
+      },
+    },
+  };
+  const core = {
+    setFailed: (message) => failures.push(message),
+  };
+
+  return {
+    comments,
+    context,
+    core,
+    dispatches,
+    failures,
+    github,
+  };
+}
+
+async function runFixture(options) {
+  const fixture = createFixture(options);
+  await dispatchKindIntegration(fixture);
+  return fixture;
+}
+
+test("dispatches Kind integration for the trusted current PR commit", async () => {
+  const result = await runFixture();
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.dispatches.length, 1);
+  assert.deepEqual(result.dispatches[0], {
+    owner: "NVIDIA",
+    repo: "nv-config-manager",
+    workflow_id: "kind-integration.yml",
+    ref: "pull-request/123",
+    inputs: {
+      test_path: "src/tests/integration/",
+      observability: "false",
+      approved_sha: CURRENT_SHA,
+    },
+  });
+  assert.match(result.comments[0].body, /Queued Kind integration/);
+});
+
+test("rejects a commenter without write access", async () => {
+  const result = await runFixture({ permission: "read" });
+
+  assert.equal(result.dispatches.length, 0);
+  assert.match(result.failures[0], /needs write access/);
+  assert.match(result.comments[0].body, /ERROR/);
+});
+
+test("requires the copy-pr-bot trusted branch", async () => {
+  const result = await runFixture({ missingTrustedBranch: true });
+
+  assert.equal(result.dispatches.length, 0);
+  assert.match(result.failures[0], /does not exist/);
+  assert.match(result.comments[0].body, /\/ok to test/);
+});
+
+test("rejects a trusted branch that does not match the current PR head", async () => {
+  const result = await runFixture({ trustedSha: STALE_SHA });
+
+  assert.equal(result.dispatches.length, 0);
+  assert.match(result.failures[0], /is stale/);
+  assert.match(result.comments[0].body, /\/ok to test/);
+});
+
+test("does not duplicate an active Kind integration run", async () => {
+  const result = await runFixture({
+    workflowRuns: [
+      {
+        head_sha: CURRENT_SHA,
+        status: "in_progress",
+        html_url: "https://github.com/NVIDIA/nv-config-manager/actions/runs/1",
+      },
+    ],
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.dispatches.length, 0);
+  assert.match(result.comments[0].body, /already running/);
+});

--- a/.github/scripts/kind-integration-command.test.js
+++ b/.github/scripts/kind-integration-command.test.js
@@ -108,6 +108,14 @@ test("rejects a commenter without write access", async () => {
   assert.match(result.comments[0].body, /ERROR/);
 });
 
+test("rejects starting Kind integration for a non-open PR", async () => {
+  const result = await runFixture({ pullState: "closed" });
+
+  assert.equal(result.dispatches.length, 0);
+  assert.match(result.failures[0], /only be started for an open PR/);
+  assert.match(result.comments[0].body, /ERROR/);
+});
+
 test("requires the copy-pr-bot trusted branch", async () => {
   const result = await runFixture({ missingTrustedBranch: true });
 

--- a/.github/scripts/kind-integration-result.js
+++ b/.github/scripts/kind-integration-result.js
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module.exports = async ({ github, context }) => {
+  const run = context.payload.workflow_run;
+  const branchMatch = /^pull-request\/(\d+)$/.exec(run.head_branch ?? "");
+
+  if (run.event !== "workflow_dispatch" || run.status !== "completed" || !branchMatch) {
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+  const conclusion = run.conclusion ?? "unknown";
+  const shortSha = run.head_sha.slice(0, 12);
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: Number(branchMatch[1]),
+    body: `Kind integration completed with **${conclusion}** for \`${shortSha}\`: ${run.html_url}`,
+  });
+};

--- a/.github/scripts/kind-integration-result.test.js
+++ b/.github/scripts/kind-integration-result.test.js
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const reportKindIntegrationResult = require("./kind-integration-result.js");
+
+const SHA = "a".repeat(40);
+const RUN_URL = "https://github.com/NVIDIA/nv-config-manager/actions/runs/123";
+
+function createFixture(options = {}) {
+  const comments = [];
+  const context = {
+    repo: { owner: "NVIDIA", repo: "nv-config-manager" },
+    payload: {
+      workflow_run: {
+        conclusion: options.conclusion ?? "success",
+        event: options.event ?? "workflow_dispatch",
+        head_branch: options.headBranch ?? "pull-request/72",
+        head_sha: SHA,
+        html_url: RUN_URL,
+        status: options.status ?? "completed",
+      },
+    },
+  };
+  const github = {
+    rest: {
+      issues: {
+        createComment: async (args) => comments.push(args),
+      },
+    },
+  };
+
+  return { comments, context, github };
+}
+
+async function runFixture(options) {
+  const fixture = createFixture(options);
+  await reportKindIntegrationResult(fixture);
+  return fixture;
+}
+
+test("comments on the PR with the completed Kind run", async () => {
+  const result = await runFixture();
+
+  assert.deepEqual(result.comments, [
+    {
+      owner: "NVIDIA",
+      repo: "nv-config-manager",
+      issue_number: 72,
+      body:
+        "Kind integration completed with **success** for `aaaaaaaaaaaa`: " + RUN_URL,
+    },
+  ]);
+});
+
+test("reports an unsuccessful Kind conclusion", async () => {
+  const result = await runFixture({ conclusion: "failure" });
+
+  assert.match(result.comments[0].body, /\*\*failure\*\*/);
+  assert.ok(result.comments[0].body.includes(RUN_URL));
+});
+
+test("ignores Kind runs that are not for a trusted PR branch", async () => {
+  const result = await runFixture({ headBranch: "main" });
+
+  assert.deepEqual(result.comments, []);
+});
+
+test("ignores Kind runs that were not manually dispatched", async () => {
+  const result = await runFixture({ event: "push" });
+
+  assert.deepEqual(result.comments, []);
+});

--- a/.github/scripts/kind-integration-result.test.js
+++ b/.github/scripts/kind-integration-result.test.js
@@ -15,7 +15,7 @@ function createFixture(options = {}) {
     repo: { owner: "NVIDIA", repo: "nv-config-manager" },
     payload: {
       workflow_run: {
-        conclusion: options.conclusion ?? "success",
+        conclusion: Object.hasOwn(options, "conclusion") ? options.conclusion : "success",
         event: options.event ?? "workflow_dispatch",
         head_branch: options.headBranch ?? "pull-request/72",
         head_sha: SHA,
@@ -62,8 +62,21 @@ test("reports an unsuccessful Kind conclusion", async () => {
   assert.ok(result.comments[0].body.includes(RUN_URL));
 });
 
+test("uses unknown when a completed Kind run has no conclusion", async () => {
+  const result = await runFixture({ conclusion: null });
+
+  assert.match(result.comments[0].body, /\*\*unknown\*\*/);
+  assert.ok(result.comments[0].body.includes(RUN_URL));
+});
+
 test("ignores Kind runs that are not for a trusted PR branch", async () => {
   const result = await runFixture({ headBranch: "main" });
+
+  assert.deepEqual(result.comments, []);
+});
+
+test("ignores Kind runs that have not completed", async () => {
+  const result = await runFixture({ status: "in_progress" });
 
   assert.deepEqual(result.comments, []);
 });

--- a/.github/workflows/kind-integration-command.yml
+++ b/.github/workflows/kind-integration-command.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-      startsWith(github.event.comment.body, '/kind test')
+      github.event.comment.body == '/kind test'
     runs-on: linux-amd64-cpu4
     permissions:
       actions: write
@@ -22,138 +22,15 @@ jobs:
       issues: write
       pull-requests: read
     steps:
+      # issue_comment workflows run from the default branch. Keep the checkout
+      # explicit so this privileged dispatcher never loads PR-controlled code.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - name: Authorize and dispatch
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { owner, repo } = context.repo;
-            const pullNumber = context.payload.issue.number;
-            const username = context.payload.comment.user.login;
-            const command = context.payload.comment.body.trim();
-            const match = command.match(/^\/kind test ([0-9a-f]{40})$/i);
-
-            const reply = async (body) => {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: pullNumber,
-                body,
-              });
-            };
-
-            if (!match) {
-              await reply("ERROR: Usage: /kind test <40-character-sha>");
-              core.setFailed("Invalid /kind test command");
-              return;
-            }
-
-            const requestedSha = match[1].toLowerCase();
-            let permission = "none";
-            try {
-              const { data: collaborator } =
-                await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner,
-                  repo,
-                  username,
-                });
-              permission = collaborator.permission;
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
-            }
-            if (!["admin", "write"].includes(permission)) {
-              await reply(
-                "ERROR: @" + username + " needs write access to start Kind integration tests.",
-              );
-              core.setFailed("Commenter does not have write access");
-              return;
-            }
-
-            const { data: pull } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pullNumber,
-            });
-            if (pull.state !== "open") {
-              await reply("ERROR: Kind integration tests can only be started for an open PR.");
-              core.setFailed("Pull request is not open");
-              return;
-            }
-            if (pull.head.sha.toLowerCase() !== requestedSha) {
-              await reply(
-                "ERROR: Requested SHA " + requestedSha +
-                  " is not the current PR head " + pull.head.sha + ".",
-              );
-              core.setFailed("Requested SHA is not the current PR head");
-              return;
-            }
-
-            const trustedBranch = "pull-request/" + pullNumber;
-            let trustedRef;
-            try {
-              ({ data: trustedRef } = await github.rest.git.getRef({
-                owner,
-                repo,
-                ref: "heads/" + trustedBranch,
-              }));
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
-              await reply(
-                "ERROR: Trusted branch " + trustedBranch +
-                  " does not exist. Run /ok to test " + requestedSha + " first.",
-              );
-              core.setFailed("Trusted PR branch does not exist");
-              return;
-            }
-
-            if (trustedRef.object.sha.toLowerCase() !== requestedSha) {
-              await reply(
-                "ERROR: Trusted branch " + trustedBranch +
-                  " does not point to " + requestedSha +
-                  ". Run /ok to test " + requestedSha + " first.",
-              );
-              core.setFailed("Trusted PR branch does not match requested SHA");
-              return;
-            }
-
-            const { data: runs } = await github.rest.actions.listWorkflowRuns({
-              owner,
-              repo,
-              workflow_id: "kind-integration.yml",
-              branch: trustedBranch,
-              event: "workflow_dispatch",
-              per_page: 20,
-            });
-            const activeRun = runs.workflow_runs.find(
-              (run) =>
-                run.head_sha.toLowerCase() === requestedSha &&
-                run.status !== "completed",
-            );
-            if (activeRun) {
-              await reply(
-                "INFO: Kind integration is already running for " + requestedSha +
-                  ": " + activeRun.html_url,
-              );
-              return;
-            }
-
-            await github.rest.actions.createWorkflowDispatch({
-              owner,
-              repo,
-              workflow_id: "kind-integration.yml",
-              ref: trustedBranch,
-              inputs: {
-                test_path: "src/tests/integration/",
-                observability: "false",
-                approved_sha: requestedSha,
-              },
-            });
-
-            await reply(
-              "Queued Kind integration for " + requestedSha + ": " +
-                "https://github.com/" + owner + "/" + repo +
-                "/actions/workflows/kind-integration.yml",
-            );
+            const dispatch = require("./.github/scripts/kind-integration-command.js");
+            await dispatch({ github, context, core });

--- a/.github/workflows/kind-integration-command.yml
+++ b/.github/workflows/kind-integration-command.yml
@@ -6,6 +6,7 @@ on:
   workflow_run:
     workflows: [Kind Integration]
     types: [completed]
+    branches: [pull-request/*]
 
 jobs:
   dispatch:

--- a/.github/workflows/kind-integration-command.yml
+++ b/.github/workflows/kind-integration-command.yml
@@ -3,10 +3,9 @@ name: Kind Integration Command
 on:
   issue_comment:
     types: [created]
-
-concurrency:
-  group: kind-integration-command-${{ github.event.issue.number }}
-  cancel-in-progress: false
+  workflow_run:
+    workflows: [Kind Integration]
+    types: [completed]
 
 jobs:
   dispatch:
@@ -16,6 +15,9 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       github.event.comment.body == '/kind test'
     runs-on: linux-amd64-cpu4
+    concurrency:
+      group: kind-integration-command-${{ github.event.issue.number }}
+      cancel-in-progress: false
     permissions:
       actions: write
       contents: read
@@ -34,3 +36,26 @@ jobs:
           script: |
             const dispatch = require("./.github/scripts/kind-integration-command.js");
             await dispatch({ github, context, core });
+
+  report-result:
+    name: Report Kind Integration Result
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
+      startsWith(github.event.workflow_run.head_branch, 'pull-request/')
+    runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # workflow_run is privileged, so load only the trusted default-branch helper.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - name: Comment with result
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const report = require("./.github/scripts/kind-integration-result.js");
+            await report({ github, context });

--- a/.github/workflows/kind-integration-command.yml
+++ b/.github/workflows/kind-integration-command.yml
@@ -1,0 +1,159 @@
+name: Kind Integration Command
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: kind-integration-command-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch Kind Integration
+    if: >-
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      startsWith(github.event.comment.body, '/kind test')
+    runs-on: linux-amd64-cpu4
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Authorize and dispatch
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.issue.number;
+            const username = context.payload.comment.user.login;
+            const command = context.payload.comment.body.trim();
+            const match = command.match(/^\/kind test ([0-9a-f]{40})$/i);
+
+            const reply = async (body) => {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullNumber,
+                body,
+              });
+            };
+
+            if (!match) {
+              await reply("ERROR: Usage: /kind test <40-character-sha>");
+              core.setFailed("Invalid /kind test command");
+              return;
+            }
+
+            const requestedSha = match[1].toLowerCase();
+            let permission = "none";
+            try {
+              const { data: collaborator } =
+                await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username,
+                });
+              permission = collaborator.permission;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+            if (!["admin", "write"].includes(permission)) {
+              await reply(
+                "ERROR: @" + username + " needs write access to start Kind integration tests.",
+              );
+              core.setFailed("Commenter does not have write access");
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            if (pull.state !== "open") {
+              await reply("ERROR: Kind integration tests can only be started for an open PR.");
+              core.setFailed("Pull request is not open");
+              return;
+            }
+            if (pull.head.sha.toLowerCase() !== requestedSha) {
+              await reply(
+                "ERROR: Requested SHA " + requestedSha +
+                  " is not the current PR head " + pull.head.sha + ".",
+              );
+              core.setFailed("Requested SHA is not the current PR head");
+              return;
+            }
+
+            const trustedBranch = "pull-request/" + pullNumber;
+            let trustedRef;
+            try {
+              ({ data: trustedRef } = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: "heads/" + trustedBranch,
+              }));
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              await reply(
+                "ERROR: Trusted branch " + trustedBranch +
+                  " does not exist. Run /ok to test " + requestedSha + " first.",
+              );
+              core.setFailed("Trusted PR branch does not exist");
+              return;
+            }
+
+            if (trustedRef.object.sha.toLowerCase() !== requestedSha) {
+              await reply(
+                "ERROR: Trusted branch " + trustedBranch +
+                  " does not point to " + requestedSha +
+                  ". Run /ok to test " + requestedSha + " first.",
+              );
+              core.setFailed("Trusted PR branch does not match requested SHA");
+              return;
+            }
+
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: "kind-integration.yml",
+              branch: trustedBranch,
+              event: "workflow_dispatch",
+              per_page: 20,
+            });
+            const activeRun = runs.workflow_runs.find(
+              (run) =>
+                run.head_sha.toLowerCase() === requestedSha &&
+                run.status !== "completed",
+            );
+            if (activeRun) {
+              await reply(
+                "INFO: Kind integration is already running for " + requestedSha +
+                  ": " + activeRun.html_url,
+              );
+              return;
+            }
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: "kind-integration.yml",
+              ref: trustedBranch,
+              inputs: {
+                test_path: "src/tests/integration/",
+                observability: "false",
+                approved_sha: requestedSha,
+              },
+            });
+
+            await reply(
+              "Queued Kind integration for " + requestedSha + ": " +
+                "https://github.com/" + owner + "/" + repo +
+                "/actions/workflows/kind-integration.yml",
+            );

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: false
         type: boolean
+      approved_sha:
+        description: Exact PR commit set by /kind test; leave blank for manual runs
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: kind-integration-${{ github.ref }}
@@ -47,6 +52,17 @@ jobs:
         timeout-minutes: 5
         with:
           persist-credentials: false
+      - name: Verify approved commit
+        if: inputs.approved_sha != ''
+        env:
+          APPROVED_SHA: ${{ inputs.approved_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          if [ "${actual_sha}" != "${APPROVED_SHA}" ]; then
+            echo "Expected approved commit ${APPROVED_SHA}, checked out ${actual_sha}"
+            exit 1
+          fi
       - name: Setup proxy cache
         timeout-minutes: 5
         uses: nv-gha-runners/setup-proxy-cache@14229018fe157c83e03c008f27d183d8e99bc67c

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -406,6 +406,8 @@ jobs:
         working-directory: ui
     steps:
       - uses: actions/checkout@v4
+      - name: Test GitHub automation helpers
+        run: node --test ../.github/scripts/*.test.js
       - name: Setup proxy cache
         uses: *setup_proxy_cache
       - name: Cache npm

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -392,6 +392,18 @@ jobs:
             exit 1
           fi
 
+  github-automation:
+    name: GitHub Automation Tests
+    runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - run: node --test .github/scripts/*.test.js
+
   ui-lint:
     name: UI Lint
     runs-on: linux-amd64-cpu8
@@ -406,8 +418,6 @@ jobs:
         working-directory: ui
     steps:
       - uses: actions/checkout@v4
-      - name: Test GitHub automation helpers
-        run: node --test ../.github/scripts/*.test.js
       - name: Setup proxy cache
         uses: *setup_proxy_cache
       - name: Cache npm

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -398,8 +398,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
       - run: node --test .github/scripts/*.test.js


### PR DESCRIPTION
## Description

Adds an opt-in `/kind test` PR comment command for the existing Kind integration workflow.
The expected sequence is:

```text
/ok to test <sha>
/kind test
```
- Uses the protected pull-request/<number> branches as the approved SHA source
- Requires repository write access by the person running the job
- Verifies that the trusted branch still matches the current PR head 
- Avoids dispatching a duplicate active run
- Verifies the approved SHA again immediately after checkout
- When the Kind workflow completes a comment will be posted with the result

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

All changes are related to github workflows, no need to run integration.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/kind test` comment command to launch integration testing for pull requests.
  * Added automated result reporting by commenting back with the run conclusion and URL.
  * Updated the pull request template with clearer step-by-step testing instructions.

* **Bug Fixes**
  * Integration runs now verify the approved commit SHA before proceeding.
  * Added stronger safeguards for permissions, non-open pull requests, missing/stale trusted branches, and duplicate “already running” runs.

* **Tests / Chores**
  * Added CI coverage for GitHub automation helper scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
