### PR TITLE
fix(ci): Unblock test and coverage jobs in gitlab pipeline

### DIFF
--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -407,6 +407,7 @@ integration-test:
 # Python tests for default branch and release tags
 test-main-py:
   stage: test
+  needs: []
   tags:
     - dca
     - linux/amd64
@@ -452,6 +453,7 @@ test-main-py:
 # Network template component tests for default branch and release tags
 test-main-network-templates:
   stage: test
+  needs: []
   tags:
     - dca
     - linux/amd64
@@ -483,6 +485,7 @@ test-main-network-templates:
 # Installer coverage for default-branch and release-tag Sonar analysis.
 test-main-installer:
   stage: test
+  needs: []
   tags:
     - dca
     - linux/amd64


### PR DESCRIPTION
## Description

Allow the default-branch Python, network-template, and installer coverage jobs to start without waiting for the earlier staged, since they don't depend on any artifacts from them.

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

No kind or tests needed, just gitlab ci change

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

No automated application tests, user-facing documentation changes, or generated artifact updates are needed for this GitLab scheduling-only change.