### PR TITLE
fix(ci): retry transient Pulse policy conflicts

### DIFF
--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -111,6 +111,14 @@ include:
             - linux/amd64
             - linux/arm64
 
+# Parallel scans can race while registering a newly changed policy. The first
+# upload wins and the remaining jobs can safely reuse it on retry.
+pulse-scan-images:
+  retry:
+    max: 1
+    when:
+      - script_failure
+
 # The component's template-usage jobs only post pipeline metadata. Avoid a
 # repository checkout so they can still run after a merged source branch has
 # been deleted while its pipeline is queued.


### PR DESCRIPTION
## Description

Pulse image scans run in parallel and can race while registering a newly changed scan policy. One job uploads the content-addressed policy successfully while competing jobs can receive HTTP 409 because the policy now exists. Allowing for one retry works around this.

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

No testable changes - internal gitlab CI tweaks only.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

