### PR TITLE
remove index0 param

### DIFF
--- a/development/ufm_mock/mock_server.py
+++ b/development/ufm_mock/mock_server.py
@@ -79,6 +79,8 @@ class PKeyAddRequest(BaseModel):
 
     pkey: str
     ip_over_ib: bool = True
+    # Deprecated: UFM auto-generates index0 on init; accepted for back-compat but ignored.
+    index0: bool | None = None
     guids: list[str] = Field(default_factory=list)
     membership: str = "full"
     memberships: list[str] | None = None

--- a/development/ufm_mock/mock_server.py
+++ b/development/ufm_mock/mock_server.py
@@ -79,7 +79,6 @@ class PKeyAddRequest(BaseModel):
 
     pkey: str
     ip_over_ib: bool = True
-    index0: bool = True
     guids: list[str] = Field(default_factory=list)
     membership: str = "full"
     memberships: list[str] | None = None
@@ -105,10 +104,9 @@ def _memberships_set(req: PKeyAddRequest) -> list[str]:
 class _PKeyState:
     """In-memory state for a single mock PKey partition."""
 
-    def __init__(self, *, pkey: str, ip_over_ib: bool, index0: bool) -> None:
+    def __init__(self, *, pkey: str, ip_over_ib: bool) -> None:
         self.pkey = pkey
         self.ip_over_ib = ip_over_ib
-        self.index0 = index0
         # Members keyed by lowercase GUID for case-insensitive comparison.
         self.guids: dict[str, dict[str, str]] = {}
 
@@ -117,7 +115,6 @@ class _PKeyState:
         return {
             "partition": f"ib-pkey-{self.pkey}",
             "ip_over_ib": self.ip_over_ib,
-            "index0": self.index0,
         }
 
     def to_detail(self) -> dict[str, Any]:
@@ -149,11 +146,11 @@ class _Store:
         with self._lock:
             return {pkey: state.to_summary() for pkey, state in self._pkeys.items()}
 
-    def create(self, pkey: str, *, ip_over_ib: bool, index0: bool) -> None:
+    def create(self, pkey: str, *, ip_over_ib: bool) -> None:
         with self._lock:
             if pkey in self._pkeys:
                 raise HTTPException(status_code=409, detail=f"PKey {pkey} already exists")
-            self._pkeys[pkey] = _PKeyState(pkey=pkey, ip_over_ib=ip_over_ib, index0=index0)
+            self._pkeys[pkey] = _PKeyState(pkey=pkey, ip_over_ib=ip_over_ib)
 
     def get(self, pkey: str, *, with_guids: bool) -> dict[str, Any]:
         with self._lock:
@@ -169,7 +166,6 @@ class _Store:
         memberships: list[str],
         *,
         ip_over_ib: bool,
-        index0: bool,
     ) -> int:
         """Atomically replace a partition's member list, mirroring UFM's PUT.
 
@@ -181,12 +177,11 @@ class _Store:
         with self._lock:
             state = self._pkeys.get(pkey)
             if state is None:
-                state = _PKeyState(pkey=pkey, ip_over_ib=ip_over_ib, index0=index0)
+                state = _PKeyState(pkey=pkey, ip_over_ib=ip_over_ib)
                 self._pkeys[pkey] = state
             # UFM's PUT overwrites the whole partition, so refresh flags too,
             # not just the member list, even when the partition already exists.
             state.ip_over_ib = ip_over_ib
-            state.index0 = index0
             state.guids = {guid: {"membership": membership} for guid, membership in pairs}
             return len(state.guids)
 
@@ -260,7 +255,7 @@ def create_app(store: _Store | None = None) -> FastAPI:
 
     @app.post("/ufmRest/resources/pkeys/add")
     def create_pkey(payload: Annotated[PKeyAddRequest, Body()]) -> dict[str, str]:
-        store.create(payload.pkey, ip_over_ib=payload.ip_over_ib, index0=payload.index0)
+        store.create(payload.pkey, ip_over_ib=payload.ip_over_ib)
         return {"pkey": payload.pkey, "status": "created"}
 
     @app.get("/ufmRest/resources/pkeys/{pkey}")
@@ -283,7 +278,6 @@ def create_app(store: _Store | None = None) -> FastAPI:
             payload.guids,
             memberships,
             ip_over_ib=payload.ip_over_ib,
-            index0=payload.index0,
         )
         return {"pkey": payload.pkey, "guids_set": count}
 

--- a/development/ufm_mock/tests/test_mock_server.py
+++ b/development/ufm_mock/tests/test_mock_server.py
@@ -65,20 +65,6 @@ class TestCreatePKey:
         assert response.status_code == 200
         assert response.json() == {"pkey": "0x0042", "status": "created"}
 
-    def test_index0_round_trips(self, client: TestClient) -> None:
-        client.post(
-            "/ufmRest/resources/pkeys/add",
-            json={"pkey": "0x0001", "ip_over_ib": True, "index0": False},
-        )
-        client.post(
-            "/ufmRest/resources/pkeys/add",
-            json={"pkey": "0x0002", "ip_over_ib": True},  # default index0=True
-        )
-
-        body = client.get("/ufmRest/resources/pkeys").json()
-        assert body["0x0001"]["index0"] is False
-        assert body["0x0002"]["index0"] is True
-
     def test_409_on_duplicate(self, client: TestClient) -> None:
         client.post(
             "/ufmRest/resources/pkeys/add",
@@ -320,16 +306,15 @@ class TestSetMembers:
         """PUT overwrites partition flags too, not just members, when it exists."""
         client.put(
             "/ufmRest/resources/pkeys/",
-            json={"pkey": "0x0001", "guids": ["0xa"], "ip_over_ib": True, "index0": True},
+            json={"pkey": "0x0001", "guids": ["0xa"], "ip_over_ib": True},
         )
         client.put(
             "/ufmRest/resources/pkeys/",
-            json={"pkey": "0x0001", "guids": ["0xa"], "ip_over_ib": False, "index0": False},
+            json={"pkey": "0x0001", "guids": ["0xa"], "ip_over_ib": False},
         )
 
         body = client.get("/ufmRest/resources/pkeys/0x0001?guids_data=true").json()
         assert body["ip_over_ib"] is False
-        assert body["index0"] is False
 
     def test_unchanged_member_preserved(self, client: TestClient) -> None:
         """Re-setting a superset leaves the existing member's record intact."""

--- a/development/ufm_mock/tests/test_mock_server.py
+++ b/development/ufm_mock/tests/test_mock_server.py
@@ -76,6 +76,17 @@ class TestCreatePKey:
         )
         assert response.status_code == 409
 
+    def test_deprecated_index0_accepted_but_ignored(self, client: TestClient) -> None:
+        """The deprecated index0 field is accepted for back-compat but not stored/returned."""
+        response = client.post(
+            "/ufmRest/resources/pkeys/add",
+            json={"pkey": "0x0043", "ip_over_ib": True, "index0": False},
+        )
+        assert response.status_code == 200
+
+        body = client.get("/ufmRest/resources/pkeys").json()
+        assert "index0" not in body["0x0043"]
+
 
 class TestGetPKey:
     def test_404_for_unknown(self, client: TestClient) -> None:

--- a/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
+++ b/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
@@ -58,6 +58,9 @@ class CreatePKeyInput(BaseModel):
     site: str | None = None
     pkey: str
     ip_over_ib: bool = True
+    # Deprecated: UFM auto-generates the management PKey (index0) on init; retained
+    # for back-compat but no longer sent to UFM.
+    index0: bool | None = None
 
 
 class CreatePKeyOutput(StageOutput):
@@ -97,6 +100,9 @@ class AddGuidsInput(BaseModel):
     guids: list[str]
     memberships: list[str]
     ip_over_ib: bool = True
+    # Deprecated: UFM auto-generates the management PKey (index0) on init; retained
+    # for back-compat but no longer sent to UFM.
+    index0: bool | None = None
 
 
 class AddGuidsOutput(StageOutput):
@@ -120,6 +126,9 @@ class SetGuidsInput(BaseModel):
     guids: list[str]
     memberships: list[str]
     ip_over_ib: bool = True
+    # Deprecated: UFM auto-generates the management PKey (index0) on init; retained
+    # for back-compat but no longer sent to UFM.
+    index0: bool | None = None
 
 
 class SetGuidsOutput(StageOutput):

--- a/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
+++ b/src/nv_config_manager/temporal/ngc/activities/ib_pkey.py
@@ -58,7 +58,6 @@ class CreatePKeyInput(BaseModel):
     site: str | None = None
     pkey: str
     ip_over_ib: bool = True
-    index0: bool = False
 
 
 class CreatePKeyOutput(StageOutput):
@@ -98,7 +97,6 @@ class AddGuidsInput(BaseModel):
     guids: list[str]
     memberships: list[str]
     ip_over_ib: bool = True
-    index0: bool = False
 
 
 class AddGuidsOutput(StageOutput):
@@ -122,7 +120,6 @@ class SetGuidsInput(BaseModel):
     guids: list[str]
     memberships: list[str]
     ip_over_ib: bool = True
-    index0: bool = False
 
 
 class SetGuidsOutput(StageOutput):
@@ -287,7 +284,6 @@ async def create_pkey_on_ufm(input: CreatePKeyInput) -> CreatePKeyOutput:
     payload: dict[str, Any] = {
         "pkey": input.pkey,
         "ip_over_ib": input.ip_over_ib,
-        "index0": input.index0,
     }
 
     log.info("Creating PKey %s on UFM at %s", input.pkey, input.host)
@@ -365,7 +361,6 @@ async def add_guids_to_pkey(input: AddGuidsInput) -> AddGuidsOutput:
             "ip_over_ib": (
                 current_ip_over_ib if current_ip_over_ib is not None else input.ip_over_ib
             ),
-            "index0": input.index0,
         }
 
         log.info(
@@ -511,7 +506,6 @@ async def set_pkey_members(input: SetGuidsInput) -> SetGuidsOutput:
         "guids": input.guids,
         "memberships": input.memberships,
         "ip_over_ib": input.ip_over_ib,
-        "index0": input.index0,
     }
 
     log.info(

--- a/src/tests/temporal/activities/test_ib_pkey.py
+++ b/src/tests/temporal/activities/test_ib_pkey.py
@@ -209,6 +209,23 @@ class TestCreatePKeyOnUfm:
             assert request_body["ip_over_ib"] is False
             assert "guids" not in request_body
             assert "membership" not in request_body
+            assert "index0" not in request_body
+
+    @pytest.mark.asyncio
+    async def test_deprecated_index0_not_sent(self, mock_config):
+        """The deprecated index0 field is accepted for back-compat but never sent to UFM."""
+        assert CreatePKeyInput(host="ufm.example.com", pkey="0x8001").index0 is None
+
+        with aioresponses() as m:
+            m.post(f"{UFM_BASE}/resources/pkeys/add", payload={})
+
+            await create_pkey_on_ufm(
+                CreatePKeyInput(host="ufm.example.com", pkey="0x8001", index0=True)
+            )
+
+            request_key = next(iter(m.requests))
+            request_body = m.requests[request_key][0].kwargs.get("json", {})
+            assert "index0" not in request_body
 
 
 class TestVerifyPKeyCreated:


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->
Removed the _index0_ param from ibpkey workflows. It is used to set the management pkey, and is auto generated on initialization of the UFM. Should not be modified in these workflows, and was essentially dead code. 

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow posts its conclusion and exact run URL as a PR comment.

Passing Kind Integration run:
<!-- Paste the workflow run URL here. -->
https://github.com/NVIDIA/nv-config-manager/actions/runs/29029739379
## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecated the `index0` PKey flag: it is still accepted for backwards compatibility, but ignored.
  * Create and update requests no longer send `index0` to the UFM API.
  * In-memory/mock PKey responses and summaries now omit `index0`.
  * Partition “set members” refresh behavior now updates only the supported `ip_over_ib` setting.

* **Tests**
  * Updated and extended tests to verify `index0` is ignored and not included in request payloads/responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->