### PR TITLE
fix(ci): report kind results from dispatched workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,10 +21,12 @@ As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-
 `pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
 only while debugging.
 
-The completed workflow posts its conclusion and exact run URL as a PR comment.
+The completed workflow updates this PR description with its conclusion and exact run URL.
 
-Passing Kind Integration run:
-<!-- Paste the workflow run URL here. -->
+Passing Kind Integration run, if not automatically reported:
+<!-- kind-integration-result:start -->
+<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
+<!-- kind-integration-result:end -->
 
 ## Checklist
 

--- a/.github/scripts/kind-integration-command.js
+++ b/.github/scripts/kind-integration-command.js
@@ -18,13 +18,25 @@ module.exports = async ({ github, context, core }) => {
     await reply("ERROR: " + message);
     core.setFailed(message);
   };
-  const acknowledge = () =>
-    github.rest.reactions.createForIssueComment({
-      owner,
-      repo,
-      comment_id: commentId,
-      content: "+1",
-    });
+  const acknowledge = async () => {
+    try {
+      await github.rest.reactions.createForIssueComment({
+        owner,
+        repo,
+        comment_id: commentId,
+        content: "+1",
+      });
+    } catch (error) {
+      const message =
+        "Kind integration was accepted, but the acknowledgement reaction failed: " +
+        (error.message || String(error));
+      if (core.warning) {
+        core.warning(message);
+      } else {
+        console.warn(message);
+      }
+    }
+  };
 
   let permission = "none";
   try {

--- a/.github/scripts/kind-integration-command.test.js
+++ b/.github/scripts/kind-integration-command.test.js
@@ -189,6 +189,29 @@ test("still reports queued run when acknowledgement reaction fails", async () =>
   assert.match(result.comments[0].body, /Queued Kind integration/);
 });
 
+test("still reports already-running run when acknowledgement reaction fails", async () => {
+  const reactionError = new Error("Resource not accessible by integration");
+  reactionError.status = 403;
+
+  const result = await runFixture({
+    reactionError,
+    workflowRuns: [
+      {
+        head_sha: CURRENT_SHA,
+        status: "in_progress",
+        html_url: "https://github.com/NVIDIA/nv-config-manager/actions/runs/1",
+      },
+    ],
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.dispatches.length, 0);
+  assert.equal(result.reactions.length, 0);
+  assert.match(result.warnings[0], /acknowledgement reaction failed/);
+  assert.match(result.comments[0].body, /already running/);
+  assert.match(result.comments[0].body, /actions\/runs\/1/);
+});
+
 test("warns to console when acknowledgement reaction fails without core.warning", async () => {
   const originalWarn = console.warn;
   const consoleWarnings = [];
@@ -208,6 +231,38 @@ test("warns to console when acknowledgement reaction fails without core.warning"
     assert.deepEqual(result.warnings, []);
     assert.match(consoleWarnings[0], /acknowledgement reaction failed/);
     assert.match(result.comments[0].body, /Queued Kind integration/);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("already-running acknowledgement failure falls back to console without core.warning", async () => {
+  const originalWarn = console.warn;
+  const consoleWarnings = [];
+  const reactionError = new Error("Resource not accessible by integration");
+  reactionError.status = 403;
+
+  console.warn = (message) => consoleWarnings.push(message);
+  try {
+    const result = await runFixture({
+      omitCoreWarning: true,
+      reactionError,
+      workflowRuns: [
+        {
+          head_sha: CURRENT_SHA,
+          status: "in_progress",
+          html_url: "https://github.com/NVIDIA/nv-config-manager/actions/runs/1",
+        },
+      ],
+    });
+
+    assert.deepEqual(result.failures, []);
+    assert.equal(result.dispatches.length, 0);
+    assert.equal(result.reactions.length, 0);
+    assert.deepEqual(result.warnings, []);
+    assert.match(consoleWarnings[0], /acknowledgement reaction failed/);
+    assert.match(result.comments[0].body, /already running/);
+    assert.match(result.comments[0].body, /actions\/runs\/1/);
   } finally {
     console.warn = originalWarn;
   }

--- a/.github/scripts/kind-integration-command.test.js
+++ b/.github/scripts/kind-integration-command.test.js
@@ -14,6 +14,7 @@ function createFixture(options = {}) {
   const dispatches = [];
   const failures = [];
   const reactions = [];
+  const warnings = [];
   const context = {
     repo: { owner: "NVIDIA", repo: "nv-config-manager" },
     payload: {
@@ -28,7 +29,12 @@ function createFixture(options = {}) {
         createComment: async (args) => comments.push(args),
       },
       reactions: {
-        createForIssueComment: async (args) => reactions.push(args),
+        createForIssueComment: async (args) => {
+          if (options.reactionError) {
+            throw options.reactionError;
+          }
+          reactions.push(args);
+        },
       },
       repos: {
         getCollaboratorPermissionLevel: async () => ({
@@ -68,6 +74,9 @@ function createFixture(options = {}) {
   const core = {
     setFailed: (message) => failures.push(message),
   };
+  if (!options.omitCoreWarning) {
+    core.warning = (message) => warnings.push(message);
+  }
 
   return {
     comments,
@@ -77,6 +86,7 @@ function createFixture(options = {}) {
     failures,
     github,
     reactions,
+    warnings,
   };
 }
 
@@ -164,4 +174,41 @@ test("does not duplicate an active Kind integration run", async () => {
   assert.equal(result.dispatches.length, 0);
   assert.equal(result.reactions.length, 1);
   assert.match(result.comments[0].body, /already running/);
+});
+
+test("still reports queued run when acknowledgement reaction fails", async () => {
+  const reactionError = new Error("Resource not accessible by integration");
+  reactionError.status = 403;
+
+  const result = await runFixture({ reactionError });
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.dispatches.length, 1);
+  assert.equal(result.reactions.length, 0);
+  assert.match(result.warnings[0], /acknowledgement reaction failed/);
+  assert.match(result.comments[0].body, /Queued Kind integration/);
+});
+
+test("warns to console when acknowledgement reaction fails without core.warning", async () => {
+  const originalWarn = console.warn;
+  const consoleWarnings = [];
+  const reactionError = new Error("Resource not accessible by integration");
+  reactionError.status = 403;
+
+  console.warn = (message) => consoleWarnings.push(message);
+  try {
+    const result = await runFixture({
+      omitCoreWarning: true,
+      reactionError,
+    });
+
+    assert.deepEqual(result.failures, []);
+    assert.equal(result.dispatches.length, 1);
+    assert.equal(result.reactions.length, 0);
+    assert.deepEqual(result.warnings, []);
+    assert.match(consoleWarnings[0], /acknowledgement reaction failed/);
+    assert.match(result.comments[0].body, /Queued Kind integration/);
+  } finally {
+    console.warn = originalWarn;
+  }
 });

--- a/.github/scripts/kind-integration-result.js
+++ b/.github/scripts/kind-integration-result.js
@@ -25,7 +25,7 @@ function updatePullRequestBody(body, resultLine) {
     return currentBody.replace(legacyPattern, `$1${resultBlock}$3`);
   }
 
-  return `${currentBody.trimEnd()}\n\n## Kind Integration\n\n${resultLine}\n`;
+  return `${currentBody.trimEnd()}\n\n## Kind Integration\n\n${resultBlock}\n`;
 }
 
 module.exports = async ({ github, context, run: explicitRun }) => {

--- a/.github/scripts/kind-integration-result.js
+++ b/.github/scripts/kind-integration-result.js
@@ -28,7 +28,20 @@ function updatePullRequestBody(body, resultLine) {
   return `${currentBody.trimEnd()}\n\n## Kind Integration\n\n${resultBlock}\n`;
 }
 
-module.exports = async ({ github, context, run: explicitRun }) => {
+function warn(core, message) {
+  if (typeof core?.warning === "function") {
+    core.warning(message);
+    return;
+  }
+
+  console.warn(message);
+}
+
+function getErrorMessage(error) {
+  return error?.message || String(error);
+}
+
+module.exports = async ({ github, context, core, run: explicitRun }) => {
   const run = explicitRun ?? context.payload.workflow_run;
   if (!run) {
     return;
@@ -42,23 +55,30 @@ module.exports = async ({ github, context, run: explicitRun }) => {
 
   const { owner, repo } = context.repo;
   const pullNumber = Number(branchMatch[1]);
-  const { data: pull } = await github.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: pullNumber,
-  });
-  if (pull.head.sha.toLowerCase() !== run.head_sha.toLowerCase()) {
-    return;
+  try {
+    const { data: pull } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+    if (pull.head.sha.toLowerCase() !== run.head_sha.toLowerCase()) {
+      return;
+    }
+
+    const conclusion = run.conclusion ?? "unknown";
+    const shortSha = run.head_sha.slice(0, 12);
+    const resultLine = `Kind integration completed with **${conclusion}** for [\`${shortSha}\`](${run.html_url}).`;
+
+    await github.rest.pulls.update({
+      owner,
+      repo,
+      pull_number: pullNumber,
+      body: updatePullRequestBody(pull.body, resultLine),
+    });
+  } catch (error) {
+    warn(
+      core,
+      `Failed to update PR #${pullNumber} with Kind integration result: ${getErrorMessage(error)}`,
+    );
   }
-
-  const conclusion = run.conclusion ?? "unknown";
-  const shortSha = run.head_sha.slice(0, 12);
-  const resultLine = `Kind integration completed with **${conclusion}** for [\`${shortSha}\`](${run.html_url}).`;
-
-  await github.rest.pulls.update({
-    owner,
-    repo,
-    pull_number: pullNumber,
-    body: updatePullRequestBody(pull.body, resultLine),
-  });
 };

--- a/.github/scripts/kind-integration-result.js
+++ b/.github/scripts/kind-integration-result.js
@@ -1,8 +1,39 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-module.exports = async ({ github, context }) => {
-  const run = context.payload.workflow_run;
+const RESULT_START = "<!-- kind-integration-result:start -->";
+const RESULT_END = "<!-- kind-integration-result:end -->";
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function updatePullRequestBody(body, resultLine) {
+  const currentBody = body ?? "";
+  const resultBlock = `${RESULT_START}\n${resultLine}\n${RESULT_END}`;
+  const markerPattern = new RegExp(
+    `${escapeRegExp(RESULT_START)}[\\s\\S]*?${escapeRegExp(RESULT_END)}`,
+  );
+
+  if (markerPattern.test(currentBody)) {
+    return currentBody.replace(markerPattern, resultBlock);
+  }
+
+  const legacyPattern =
+    /(Passing Kind Integration run, if not automatically reported:\n)([\s\S]*?)(\n## )/;
+  if (legacyPattern.test(currentBody)) {
+    return currentBody.replace(legacyPattern, `$1${resultBlock}$3`);
+  }
+
+  return `${currentBody.trimEnd()}\n\n## Kind Integration\n\n${resultLine}\n`;
+}
+
+module.exports = async ({ github, context, run: explicitRun }) => {
+  const run = explicitRun ?? context.payload.workflow_run;
+  if (!run) {
+    return;
+  }
+
   const branchMatch = /^pull-request\/(\d+)$/.exec(run.head_branch ?? "");
 
   if (run.event !== "workflow_dispatch" || run.status !== "completed" || !branchMatch) {
@@ -22,11 +53,12 @@ module.exports = async ({ github, context }) => {
 
   const conclusion = run.conclusion ?? "unknown";
   const shortSha = run.head_sha.slice(0, 12);
+  const resultLine = `Kind integration completed with **${conclusion}** for [\`${shortSha}\`](${run.html_url}).`;
 
-  await github.rest.issues.createComment({
+  await github.rest.pulls.update({
     owner,
     repo,
-    issue_number: pullNumber,
-    body: `Kind integration completed with **${conclusion}** for \`${shortSha}\`: ${run.html_url}`,
+    pull_number: pullNumber,
+    body: updatePullRequestBody(pull.body, resultLine),
   });
 };

--- a/.github/scripts/kind-integration-result.test.js
+++ b/.github/scripts/kind-integration-result.test.js
@@ -26,6 +26,7 @@ Passing Kind Integration run, if not automatically reported:
 
 function createFixture(options = {}) {
   const updates = [];
+  const warnings = [];
   const context = {
     repo: { owner: "NVIDIA", repo: "nv-config-manager" },
     payload: {},
@@ -43,18 +44,33 @@ function createFixture(options = {}) {
   const github = {
     rest: {
       pulls: {
-        get: async () => ({
-          data: {
-            body: Object.hasOwn(options, "pullBody") ? options.pullBody : TEMPLATE_BODY,
-            head: { sha: options.pullHeadSha ?? SHA },
-          },
-        }),
-        update: async (args) => updates.push(args),
+        get: async () => {
+          if (options.pullGetError) {
+            throw options.pullGetError;
+          }
+
+          return {
+            data: {
+              body: Object.hasOwn(options, "pullBody") ? options.pullBody : TEMPLATE_BODY,
+              head: { sha: options.pullHeadSha ?? SHA },
+            },
+          };
+        },
+        update: async (args) => {
+          if (options.pullUpdateError) {
+            throw options.pullUpdateError;
+          }
+
+          updates.push(args);
+        },
       },
     },
   };
+  const core = {
+    warning: (message) => warnings.push(message),
+  };
 
-  return { context, github, updates };
+  return { context, github, core, updates, warnings };
 }
 
 async function runFixture(options) {
@@ -156,6 +172,22 @@ test("uses unknown when a completed Kind run has no conclusion", async () => {
 
   assert.match(result.updates[0].body, /\*\*unknown\*\*/);
   assert.ok(result.updates[0].body.includes(RUN_URL));
+});
+
+test("warns instead of failing when fetching the PR fails", async () => {
+  const result = await runFixture({ pullGetError: new Error("Not Found") });
+
+  assert.deepEqual(result.updates, []);
+  assert.match(result.warnings[0], /Failed to update PR #72/);
+  assert.match(result.warnings[0], /Not Found/);
+});
+
+test("warns instead of failing when updating the PR body fails", async () => {
+  const result = await runFixture({ pullUpdateError: new Error("Bad credentials") });
+
+  assert.deepEqual(result.updates, []);
+  assert.match(result.warnings[0], /Failed to update PR #72/);
+  assert.match(result.warnings[0], /Bad credentials/);
 });
 
 test("falls back to appending when the PR body lacks the Kind result slot", async () => {

--- a/.github/scripts/kind-integration-result.test.js
+++ b/.github/scripts/kind-integration-result.test.js
@@ -169,7 +169,31 @@ No validation section.
 
 ## Kind Integration
 
+<!-- kind-integration-result:start -->
 Kind integration completed with **success** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+<!-- kind-integration-result:end -->
+`,
+  );
+});
+
+test("fallback append includes replaceable Kind result markers", async () => {
+  const firstResult = await runFixture({ pullBody: "## Description\n\nNo validation section.\n" });
+  const secondResult = await runFixture({
+    conclusion: "failure",
+    pullBody: firstResult.updates[0].body,
+  });
+
+  assert.equal(
+    secondResult.updates[0].body,
+    `## Description
+
+No validation section.
+
+## Kind Integration
+
+<!-- kind-integration-result:start -->
+Kind integration completed with **failure** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+<!-- kind-integration-result:end -->
 `,
   );
 });

--- a/.github/scripts/kind-integration-result.test.js
+++ b/.github/scripts/kind-integration-result.test.js
@@ -8,52 +8,114 @@ const reportKindIntegrationResult = require("./kind-integration-result.js");
 
 const SHA = "a".repeat(40);
 const RUN_URL = "https://github.com/NVIDIA/nv-config-manager/actions/runs/123";
+const TEMPLATE_BODY = `## Description
+
+Example PR.
+
+## Validation
+
+Passing Kind Integration run, if not automatically reported:
+<!-- kind-integration-result:start -->
+<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
+<!-- kind-integration-result:end -->
+
+## Checklist
+
+- [ ] Standard CI passes.
+`;
 
 function createFixture(options = {}) {
-  const comments = [];
+  const updates = [];
   const context = {
     repo: { owner: "NVIDIA", repo: "nv-config-manager" },
-    payload: {
-      workflow_run: {
-        conclusion: Object.hasOwn(options, "conclusion") ? options.conclusion : "success",
-        event: options.event ?? "workflow_dispatch",
-        head_branch: options.headBranch ?? "pull-request/72",
-        head_sha: SHA,
-        html_url: RUN_URL,
-        status: options.status ?? "completed",
-      },
-    },
+    payload: {},
   };
+  if (!options.omitWorkflowRun) {
+    context.payload.workflow_run = {
+      conclusion: Object.hasOwn(options, "conclusion") ? options.conclusion : "success",
+      event: options.event ?? "workflow_dispatch",
+      head_branch: options.headBranch ?? "pull-request/72",
+      head_sha: SHA,
+      html_url: RUN_URL,
+      status: options.status ?? "completed",
+    };
+  }
   const github = {
     rest: {
-      issues: {
-        createComment: async (args) => comments.push(args),
-      },
       pulls: {
-        get: async () => ({ data: { head: { sha: options.pullHeadSha ?? SHA } } }),
+        get: async () => ({
+          data: {
+            body: Object.hasOwn(options, "pullBody") ? options.pullBody : TEMPLATE_BODY,
+            head: { sha: options.pullHeadSha ?? SHA },
+          },
+        }),
+        update: async (args) => updates.push(args),
       },
     },
   };
 
-  return { comments, context, github };
+  return { context, github, updates };
 }
 
 async function runFixture(options) {
   const fixture = createFixture(options);
-  await reportKindIntegrationResult(fixture);
+  await reportKindIntegrationResult({
+    ...fixture,
+    run: options?.run,
+  });
   return fixture;
 }
 
-test("comments on the PR with the completed Kind run", async () => {
+test("updates the PR body with the completed Kind run", async () => {
   const result = await runFixture();
 
-  assert.deepEqual(result.comments, [
+  assert.equal(result.updates.length, 1);
+  assert.deepEqual(result.updates[0], {
+    owner: "NVIDIA",
+    repo: "nv-config-manager",
+    pull_number: 72,
+    body: `## Description
+
+Example PR.
+
+## Validation
+
+Passing Kind Integration run, if not automatically reported:
+<!-- kind-integration-result:start -->
+Kind integration completed with **success** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+<!-- kind-integration-result:end -->
+
+## Checklist
+
+- [ ] Standard CI passes.
+`,
+  });
+});
+
+test("replaces an existing automatic Kind result", async () => {
+  const result = await runFixture({
+    conclusion: "failure",
+    pullBody: `## Validation
+
+Passing Kind Integration run, if not automatically reported:
+<!-- kind-integration-result:start -->
+Kind integration completed with **success** for [\`bbbbbbbbbbbb\`](https://old.example/run).
+<!-- kind-integration-result:end -->
+`,
+  });
+
+  assert.deepEqual(result.updates, [
     {
       owner: "NVIDIA",
       repo: "nv-config-manager",
-      issue_number: 72,
-      body:
-        "Kind integration completed with **success** for `aaaaaaaaaaaa`: " + RUN_URL,
+      pull_number: 72,
+      body: `## Validation
+
+Passing Kind Integration run, if not automatically reported:
+<!-- kind-integration-result:start -->
+Kind integration completed with **failure** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+<!-- kind-integration-result:end -->
+`,
     },
   ]);
 });
@@ -61,33 +123,73 @@ test("comments on the PR with the completed Kind run", async () => {
 test("reports an unsuccessful Kind conclusion", async () => {
   const result = await runFixture({ conclusion: "failure" });
 
-  assert.match(result.comments[0].body, /\*\*failure\*\*/);
-  assert.ok(result.comments[0].body.includes(RUN_URL));
+  assert.match(result.updates[0].body, /\*\*failure\*\*/);
+  assert.ok(result.updates[0].body.includes(RUN_URL));
+});
+
+test("updates from explicit run details when workflow_run did not fire", async () => {
+  const result = await runFixture({
+    omitWorkflowRun: true,
+    run: {
+      conclusion: "success",
+      event: "workflow_dispatch",
+      head_branch: "pull-request/72",
+      head_sha: SHA,
+      html_url: RUN_URL,
+      status: "completed",
+    },
+  });
+
+  assert.equal(result.updates.length, 1);
+  assert.match(result.updates[0].body, /\*\*success\*\*/);
+  assert.ok(result.updates[0].body.includes(RUN_URL));
+});
+
+test("does nothing without workflow_run or explicit run details", async () => {
+  const result = await runFixture({ omitWorkflowRun: true });
+
+  assert.deepEqual(result.updates, []);
 });
 
 test("uses unknown when a completed Kind run has no conclusion", async () => {
   const result = await runFixture({ conclusion: null });
 
-  assert.match(result.comments[0].body, /\*\*unknown\*\*/);
-  assert.ok(result.comments[0].body.includes(RUN_URL));
+  assert.match(result.updates[0].body, /\*\*unknown\*\*/);
+  assert.ok(result.updates[0].body.includes(RUN_URL));
+});
+
+test("falls back to appending when the PR body lacks the Kind result slot", async () => {
+  const result = await runFixture({ pullBody: "## Description\n\nNo validation section.\n" });
+
+  assert.equal(
+    result.updates[0].body,
+    `## Description
+
+No validation section.
+
+## Kind Integration
+
+Kind integration completed with **success** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+`,
+  );
 });
 
 test("ignores Kind runs that are not for a trusted PR branch", async () => {
   const result = await runFixture({ headBranch: "main" });
 
-  assert.deepEqual(result.comments, []);
+  assert.deepEqual(result.updates, []);
 });
 
 test("ignores Kind runs that have not completed", async () => {
   const result = await runFixture({ status: "in_progress" });
 
-  assert.deepEqual(result.comments, []);
+  assert.deepEqual(result.updates, []);
 });
 
 test("ignores Kind runs that were not manually dispatched", async () => {
   const result = await runFixture({ event: "push" });
 
-  assert.deepEqual(result.comments, []);
+  assert.deepEqual(result.updates, []);
 });
 
 test("ignores canceled Kind runs for stale PR commits", async () => {
@@ -96,5 +198,5 @@ test("ignores canceled Kind runs for stale PR commits", async () => {
     pullHeadSha: "b".repeat(40),
   });
 
-  assert.deepEqual(result.comments, []);
+  assert.deepEqual(result.updates, []);
 });

--- a/.github/workflows/kind-integration-command.yml
+++ b/.github/workflows/kind-integration-command.yml
@@ -3,10 +3,6 @@ name: Kind Integration Command
 on:
   issue_comment:
     types: [created]
-  workflow_run:
-    workflows: [Kind Integration]
-    types: [completed]
-    branches: [pull-request/*]
 
 jobs:
   dispatch:
@@ -37,27 +33,3 @@ jobs:
           script: |
             const dispatch = require("./.github/scripts/kind-integration-command.js");
             await dispatch({ github, context, core });
-
-  report-result:
-    name: Report Kind Integration Result
-    if: >-
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.event == 'workflow_dispatch' &&
-      startsWith(github.event.workflow_run.head_branch, 'pull-request/')
-    runs-on: linux-amd64-cpu4
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-    steps:
-      # workflow_run is privileged, so load only the trusted default-branch helper.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false
-      - name: Comment with result
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const report = require("./.github/scripts/kind-integration-result.js");
-            await report({ github, context });

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -265,6 +265,7 @@ jobs:
             await report({
               github,
               context,
+              core,
               run: {
                 conclusion: process.env.KIND_RESULT_CONCLUSION,
                 event: process.env.KIND_RESULT_EVENT,

--- a/.github/workflows/kind-integration.yml
+++ b/.github/workflows/kind-integration.yml
@@ -48,7 +48,7 @@ jobs:
       NV_CONFIG_MANAGER_HOSTNAME: config-manager.local
       TEST_PATH: ${{ inputs.test_path }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         timeout-minutes: 5
         with:
           persist-credentials: false
@@ -231,3 +231,46 @@ jobs:
           path: |
             integration-test-logs/
             integration-test-results.xml
+
+  report-result:
+    name: Report Kind Integration Result
+    needs: integration
+    if: always() && startsWith(github.ref, 'refs/heads/pull-request/')
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # The slash-command dispatcher uses GITHUB_TOKEN, so a follow-on
+      # workflow_run event is not reliable. Report from the dispatched workflow
+      # instead, using the same approved pull-request/* SHA that Kind tested.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        timeout-minutes: 5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Update PR with result
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        timeout-minutes: 5
+        env:
+          KIND_RESULT_CONCLUSION: ${{ needs.integration.result }}
+          KIND_RESULT_EVENT: ${{ github.event_name }}
+          KIND_RESULT_HEAD_BRANCH: ${{ github.ref_name }}
+          KIND_RESULT_HEAD_SHA: ${{ github.sha }}
+          KIND_RESULT_HTML_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const report = require("./.github/scripts/kind-integration-result.js");
+            await report({
+              github,
+              context,
+              run: {
+                conclusion: process.env.KIND_RESULT_CONCLUSION,
+                event: process.env.KIND_RESULT_EVENT,
+                head_branch: process.env.KIND_RESULT_HEAD_BRANCH,
+                head_sha: process.env.KIND_RESULT_HEAD_SHA,
+                html_url: process.env.KIND_RESULT_HTML_URL,
+                status: "completed",
+              },
+            });


### PR DESCRIPTION
## Description

Fix the `/kind test` result-reporting path.

The slash-command dispatcher starts Kind Integration with `GITHUB_TOKEN`, so GitHub does not reliably emit the follow-on `workflow_run` event that previously posted the final PR comment. This moves result reporting into a final job in the dispatched Kind workflow itself.

Update the PR template with placeholders for kind result reports, and have the result reporting update the PR description in addition to posting a comment.

This also makes the `/kind test` acknowledgement reaction best-effort, so a GitHub `403` while adding the `+1` reaction no longer fails the dispatcher after Kind has already been queued.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

no kind run, github workflow change only

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Kind integration results are now written to the pull request description with a dedicated section and run URL placeholder.
* **Bug Fixes**
  * `/kind test` dispatch continues even when the acknowledgement reaction fails; a warning is emitted instead of failing the workflow.
  * Missing workflow run details no longer prevent clean completion handling.
* **Documentation**
  * Updated the pull request template to reflect that completed-workflow information is added to the PR description (not as a comment).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->