### PR TITLE
fix(ci): Keep Pulse scans informational

### DIFF
--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -114,6 +114,7 @@ include:
 # Parallel scans can race while registering a newly changed policy. The first
 # upload wins and the remaining jobs can safely reuse it on retry.
 pulse-scan-images:
+  allow_failure: true
   retry:
     max: 1
     when:


### PR DESCRIPTION
## Description

Prevent pulse job failures from blocking gitlab pipelines.

## Validation

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

n/a, gitlab ci only change

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the image-scanning pipeline to allow the image scan step to fail without failing the entire job, reducing unnecessary pipeline disruptions.  
* **Bug Fixes**
  * Improved failure tolerance in the scanning workflow so non-critical scan issues are handled more gracefully rather than causing job failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->