### PR TITLE
Route Pulse tracking jobs to protected runners

### DIFF
--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -95,6 +95,7 @@ include:
       needs: *pulse-scan-needs
       rules: *pulse-scan-rules
       vault_auth_role: ""
+      vault_track_usage_tags: *pulse-scan-tags
       sbom_output_format: json
       scan_matrix:
         # The component requires CONTAINER_IMAGE in the matrix, but the selected


### PR DESCRIPTION
## Description

Routes the Pulse component's nested vault-sidecar usage-tracking job to the same protected Docker runners used by the Pulse scan jobs.

## Validation
Unneeded, gitlab ci only change.


## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved scan job tracking by propagating Vault usage tags through the container scanning workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->