### PR TITLE
fix(ui): update distroless Node runtime to v4.0.10

### DIFF
--- a/build/ui.Dockerfile
+++ b/build/ui.Dockerfile
@@ -54,7 +54,7 @@ RUN npm run build
 # =============================================================================
 # Runtime stage - NVIDIA distroless Node.js
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/node:24-v4.0.9 AS runner
+FROM artifactory.pdx.nvidia.com/sw-distroless-docker-local/distroless/node:24-v4.0.10 AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

Update the UI runtime base image from NVIDIA distroless Node `24-v4.0.9` to
`24-v4.0.10`.

The updated image contains Node.js 24.18.0 and remediates the Node.js
vulnerabilities reported against the previous 24.16.0 runtime, including:

- CVE-2026-48933
- CVE-2026-48615
- CVE-2026-48619
- CVE-2026-48930

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run because this is a runtime base-image-only change
with no application, API, Helm, or cluster behavior changes. Standard image
build CI and the Pulse container scan provide the relevant validation.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

No application tests, documentation updates, or generated-artifact updates are
needed for this base-image-only dependency change.
