### PR TITLE
Only setup temporal schema if it is not yet setup.

### DIFF
--- a/deploy/helm/templates/temporal.yaml
+++ b/deploy/helm/templates/temporal.yaml
@@ -103,13 +103,33 @@ spec:
         args:
         - |
           set -e
+          PORT={{ $.Values.externalServices.postgres.port }}
+
+          # Idempotently provision a Temporal schema database.
+          # A fresh CNPG database has no schema_version table, so update-schema
+          # fails and we fall back to setup-schema + update-schema. A database
+          # restored from a backup/migration already has schema_version (and the
+          # seeded namespace_metadata row), so update-schema succeeds and applies
+          # only pending upgrades. We must NOT run setup-schema in that case:
+          # setup-schema -v 0.0 rewrites schema_version back to 0.0, causing
+          # update-schema to replay the v1.0 migration and fail on the
+          # namespace_metadata seed insert (duplicate key).
+          run_schema() {
+            ep="$1"; user="$2"; pass="$3"; db="$4"; dir="$5"
+            if temporal-sql-tool --ep "$ep" --user "$user" --password "$pass" --port "$PORT" --db "$db" --plugin postgres12 update-schema -d "$dir"; then
+              echo "Schema for '$db' already initialized; applied any pending updates."
+              return 0
+            fi
+            echo "Schema for '$db' not initialized; performing initial setup..."
+            temporal-sql-tool --ep "$ep" --user "$user" --password "$pass" --port "$PORT" --db "$db" --plugin postgres12 setup-schema -v 0.0
+            temporal-sql-tool --ep "$ep" --user "$user" --password "$pass" --port "$PORT" --db "$db" --plugin postgres12 update-schema -d "$dir"
+          }
+
           echo "Setting up temporal database schema..."
-          temporal-sql-tool --ep "${TEMPORAL_DB_HOST}" --user "${TEMPORAL_DB_USER}" --password "${TEMPORAL_DB_PASS}" --port {{ $.Values.externalServices.postgres.port }} --db {{ $.Values.externalServices.postgres.temporal.database }} --plugin postgres12 setup-schema -v 0.0 || echo "Schema may already exist"
-          temporal-sql-tool --ep "${TEMPORAL_DB_HOST}" --user "${TEMPORAL_DB_USER}" --password "${TEMPORAL_DB_PASS}" --port {{ $.Values.externalServices.postgres.port }} --db {{ $.Values.externalServices.postgres.temporal.database }} --plugin postgres12 update-schema -d /etc/temporal/schema/postgresql/v12/temporal/versioned
+          run_schema "${TEMPORAL_DB_HOST}" "${TEMPORAL_DB_USER}" "${TEMPORAL_DB_PASS}" {{ $.Values.externalServices.postgres.temporal.database }} /etc/temporal/schema/postgresql/v12/temporal/versioned
           
           echo "Setting up temporal visibility database schema..."
-          temporal-sql-tool --ep "${VISIBILITY_DB_HOST}" --user "${VISIBILITY_DB_USER}" --password "${VISIBILITY_DB_PASS}" --port {{ $.Values.externalServices.postgres.port }} --db {{ $.Values.externalServices.postgres.temporal.visibilityDatabase }} --plugin postgres12 setup-schema -v 0.0 || echo "Visibility schema may already exist"
-          temporal-sql-tool --ep "${VISIBILITY_DB_HOST}" --user "${VISIBILITY_DB_USER}" --password "${VISIBILITY_DB_PASS}" --port {{ $.Values.externalServices.postgres.port }} --db {{ $.Values.externalServices.postgres.temporal.visibilityDatabase }} --plugin postgres12 update-schema -d /etc/temporal/schema/postgresql/v12/visibility/versioned
+          run_schema "${VISIBILITY_DB_HOST}" "${VISIBILITY_DB_USER}" "${VISIBILITY_DB_PASS}" {{ $.Values.externalServices.postgres.temporal.visibilityDatabase }} /etc/temporal/schema/postgresql/v12/visibility/versioned
           
           echo "Schema setup complete!"
         env:


### PR DESCRIPTION
## Description

This PR fixes an issue in which the Temporal database will is not usable on restore from backup.
The error seen after restore comes from the `schema-setup` container:
```
``` schema-setup 2026-07-13T16:25:06.167Z    INFO    Processing schema file: v1.18/tasks_v2.sql    {"logging-call-at": "/home/runner/work/docker-builds/docker-builds/temporal/tools/common/schema/updatetask.go:232"}                              │
│ schema-setup 2026-07-13T16:25:06.167Z    DEBUG    running 19 updates for current version 0.0    {"logging-call-at": "/home/runner/work/docker-builds/docker-builds/temporal/tools/common/schema/updatetask.go:114"}                             │
│ schema-setup 2026-07-13T16:25:06.167Z    DEBUG    ---- Executing updates for version 1.0 ----    {"logging-call-at": "/home/runner/work/docker-builds/docker-builds/temporal/tools/common/schema/updatetask.go:133"}                            │
│ schema-setup 2026-07-13T16:25:06.167Z    DEBUG    CREATE TABLE namespaces( partition_id INTEGER NOT NULL, id BYTEA NOT NULL, name VARCHAR(255) UNIQUE NOT NULL, notification_version BIGINT NOT NULL, data BYTEA NOT NULL, data_encoding VARCHA │
│ R(16) NOT NULL, is_global BOOLEAN NOT NULL, PRIMARY KEY(partition_id, id) );    {"logging-call-at": "/home/runner/work/docker-builds/docker-builds/temporal/tools/common/schema/updatetask.go:135"}                                             │
│ schema-setup 2026-07-13T16:25:06.167Z    WARN    Duplicate update, most likely due to previous partially succeeded update attempt. Ignoring it and continue.    {"error": "pq: relation \"namespaces\" already exists", "logging-call-at": "/ho │
│ me/runner/work/docker-builds/docker-builds/temporal/tools/common/schema/updatetask.go:145"}                                                                                                                                                     │
│ schema-setup 2026-07-13T16:25:06.167Z    DEBUG    CREATE TABLE namespace_metadata ( partition_id INTEGER NOT NULL, notification_version BIGINT NOT NULL, PRIMARY KEY(partition_id) );    {"logging-call-at": "/home/runner/work/docker-builds/d │
│ ocker-builds/temporal/tools/common/schema/updatetask.go:135"}                                                                                                                                                                                   │
│ schema-setup 2026-07-13T16:25:06.167Z    WARN    Duplicate update, most likely due to previous partially succeeded update attempt. Ignoring it and continue.    {"error": "pq: relation \"namespace_metadata\" already exists", "logging-call-a │
│ t": "/home/runner/work/docker-builds/docker-builds/temporal/tools/common/schema/updatetask.go:145"}                                                                                                                                             │
│ schema-setup 2026-07-13T16:25:06.167Z    DEBUG    INSERT INTO namespace_metadata (partition_id, notification_version) VALUES (54321, 1);    {"logging-call-at": "/home/runner/work/docker-builds/docker-builds/temporal/tools/common/schema/upd │
│ atetask.go:135"}                                                                                                                                                                                                                                │
│ schema-setup 2026-07-13T16:25:06.167Z    ERROR    Unable to update SQL schema.    {"error": "error executing statement: pq: duplicate key value violates unique constraint \"namespace_metadata_pkey\"", "logging-call-at": "/home/runner/work/ │
│ docker-builds/docker-builds/temporal/tools/sql/handler.go:53"}
```

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Temporal database schema initialization for new and restored databases.
  * Schema setup is now idempotent, reducing initialization errors during deployments.
  * Applied consistent handling to both Temporal and visibility databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->