### PR TITLE
feat(ztp): make ZTP resilient to slow/unhealthy Nautobot

### DIFF
--- a/deploy/helm/templates/ztp.yaml
+++ b/deploy/helm/templates/ztp.yaml
@@ -114,7 +114,15 @@ spec:
         image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
-        {{- include "nv-config-manager.networkZtpEntrypoint" (dict "root" . "command" (list "nv-config-manager-ztp-api") "args" (list "--port" "8000")) | nindent 8 }}
+        {{- /* Device-facing listener: run N uvicorn workers so per-pod device
+               concurrency is spread across event loops (one loop per worker),
+               preventing a single loop from stalling under a boot storm. */}}
+        {{- $lbArgs := list "--port" "8000" }}
+        {{- $lbWorkers := int (dig "httpLb" "workers" 0 .Values.networkZtp) }}
+        {{- if gt $lbWorkers 0 }}
+        {{- $lbArgs = concat $lbArgs (list "--workers" (toString $lbWorkers)) }}
+        {{- end }}
+        {{- include "nv-config-manager.networkZtpEntrypoint" (dict "root" . "command" (list "nv-config-manager-ztp-api") "args" $lbArgs) | nindent 8 }}
         env:
         - name: NV_CONFIG_MANAGER_INI
           value: {{ include "nv-config-manager.vaultAgent.configManagerIniPathApp" . | quote }}

--- a/deploy/helm/templates/ztp.yaml
+++ b/deploy/helm/templates/ztp.yaml
@@ -80,14 +80,32 @@ spec:
         {{- end }}
         {{- include "nv-config-manager.authVolumeMounts" . | nindent 8 }}
         {{- end }}
+        # startupProbe gives the app time to come up without the (lenient) liveness
+        # probe racing it. Liveness only asserts the process is alive: /healthcheck
+        # has no dependencies, so it must NOT restart the pod just because Nautobot
+        # (or any downstream) is slow — that turns a dependency slowdown into a
+        # crashloop. Generous timeout/period/failureThreshold ride out transient
+        # event-loop stalls under load; traffic shedding is handled in-app (503s).
+        startupProbe:
+          httpGet:
+            path: /healthcheck
+            port: 9000
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthcheck
             port: 9000
+          timeoutSeconds: 5
+          periodSeconds: 15
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /healthcheck
             port: 9000
+          timeoutSeconds: 3
+          periodSeconds: 10
+          failureThreshold: 3
 
       # HTTP API container for device access via LoadBalancer (IP-based authorization)
       # No ACCEPT_REQUEST_HEADERS - uses client IP validation against Nautobot device addresses
@@ -118,14 +136,28 @@ spec:
           readOnly: true
         {{- end }}
         {{- end }}
+        # See http-api container above: lenient liveness so a slow Nautobot can't
+        # crashloop the device-facing listener; startupProbe covers slow starts.
+        startupProbe:
+          httpGet:
+            path: /healthcheck
+            port: 8000
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthcheck
             port: 8000
+          timeoutSeconds: 5
+          periodSeconds: 15
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /healthcheck
             port: 8000
+          timeoutSeconds: 3
+          periodSeconds: 10
+          failureThreshold: 3
       {{- end }}
 
       # SFTP server container

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1382,6 +1382,18 @@ networkZtp:
     idleTimeout: 300s
   # Deployment configuration
   replicas: 3
+  # Device-facing (http-lb) listener tuning
+  httpLb:
+    # Number of uvicorn worker processes for the device-facing http-lb container.
+    # Each worker is its own process (own event loop + GIL + CPU core), so raising
+    # this spreads a pod's concurrent device sessions across loops and stops a
+    # single loop from stalling under a boot storm — the stall otherwise fails the
+    # liveness probe and restarts the container. 0/unset => single worker (uvicorn
+    # default). Load testing (~100 concurrent devices / 3 pods) showed 1 worker
+    # crashlooped while 4 held 0 restarts at ~4x throughput. Each worker adds
+    # ~100Mi RSS; size against resources.http and consider raising resources.http
+    # requests.cpu to match the worker count on busy nodes.
+    workers: 4
   # Resources per container type
   resources:
     http:

--- a/src/nv_config_manager/common/client/nautobot.py
+++ b/src/nv_config_manager/common/client/nautobot.py
@@ -56,6 +56,7 @@ class NautobotClient:
         verify: bool | str = True,
         timeout: int = 30,
         headers: dict[str, str] | Callable[[], dict[str, str]] | None = None,
+        connection_limit: int = 100,
     ) -> None:
         """Initialize the Nautobot client.
 
@@ -66,12 +67,17 @@ class NautobotClient:
             timeout: Default request timeout in seconds
             headers: Static dict or callable returning fresh headers per-request.
                 If set, these headers take precedence over token auth.
+            connection_limit: Max simultaneous TCP connections in the session's
+                pool. Only meaningful when the client (and therefore its session)
+                is shared across requests; a per-request client gets its own pool
+                and this cap does not bound total concurrency toward Nautobot.
         """
         self.nautobot_url = nautobot_url.rstrip("/") + "/"
         self.token = token
         self._verify = verify
         self._timeout = timeout
         self._headers = headers
+        self._connection_limit = connection_limit
         self.graphql_endpoint = f"{self.nautobot_url}api/graphql/"
         self.rest_endpoint = f"{self.nautobot_url}api/"
         self._session: aiohttp.ClientSession | None = None
@@ -142,8 +148,8 @@ class NautobotClient:
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE
 
-            connector = TCPConnector(ssl=ssl_context)
-            timeout = ClientTimeout(total=self._timeout, connect=10)
+            connector = TCPConnector(ssl=ssl_context, limit=self._connection_limit)
+            timeout = ClientTimeout(total=self._timeout, connect=min(10, self._timeout))
 
             self._session = aiohttp.ClientSession(
                 connector=connector,

--- a/src/nv_config_manager/ztp/api/clients.py
+++ b/src/nv_config_manager/ztp/api/clients.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared, process-wide clients for the ZTP API.
+
+A single Nautobot client is reused across requests so its aiohttp session
+(connection pool / keepalive), concurrency limiter, device-data cache, and
+circuit breaker are shared. Creating a fresh client per request would give each
+request its own connection pool, defeating the global connection cap and
+backpressure, and would pay a TCP+TLS handshake on every call.
+"""
+
+from __future__ import annotations
+
+from nv_config_manager.ztp.nautobot import NautobotClient
+
+_nautobot_client: NautobotClient | None = None
+
+
+def get_nautobot_client() -> NautobotClient:
+    """Return the process-wide shared ZTP Nautobot client, creating it lazily."""
+    global _nautobot_client
+    if _nautobot_client is None:
+        _nautobot_client = NautobotClient()
+    return _nautobot_client
+
+
+async def close_nautobot_client() -> None:
+    """Close and drop the shared Nautobot client (called on app shutdown)."""
+    global _nautobot_client
+    if _nautobot_client is not None:
+        await _nautobot_client.close()
+        _nautobot_client = None
+
+
+def reset_nautobot_client() -> None:
+    """Drop the shared client without awaiting (test isolation helper)."""
+    global _nautobot_client
+    _nautobot_client = None

--- a/src/nv_config_manager/ztp/api/device_v1.py
+++ b/src/nv_config_manager/ztp/api/device_v1.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """V1 Device API Endpoints."""
 
+import aiohttp
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
@@ -24,7 +25,11 @@ from nv_config_manager.common.config import get_storage_client, temporal_client
 from nv_config_manager.common.log import LogCategory, get_logger
 from nv_config_manager.ztp.api.clients import get_nautobot_client
 from nv_config_manager.ztp.api.schemas import ChecksumResponse
-from nv_config_manager.ztp.api.storage_clients import get_object_storage_client, guarded_storage
+from nv_config_manager.ztp.api.storage_clients import (
+    StorageUnavailableError,
+    get_object_storage_client,
+    guarded_storage,
+)
 from nv_config_manager.ztp.api.streaming import create_object_storage_streaming_response
 from nv_config_manager.ztp.nautobot import NotFoundError
 from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
@@ -32,6 +37,24 @@ from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
 logger = get_logger(__name__, category=LogCategory.ZTP_API)
 
 router = APIRouter(prefix="/device", tags=["device"], responses={404: {"description": "Not found"}})
+
+# HTTP statuses the Config Store client itself retries; if one still surfaces it
+# means the backend is transiently unhealthy, so treat it as retryable (503).
+_CONFIG_STORE_RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
+
+
+def _config_store_error_is_transient(exc: ConfigStoreException) -> bool:
+    """Return True if a ConfigStoreException stems from a transient backend blip.
+
+    The Config Store client wraps the underlying failure as the ``__cause__``:
+    a raw ``aiohttp.ClientError`` (connection reset/disconnect/timeout) is always
+    transient, while a ``ClientResponseError`` is transient only for retryable
+    5xx/429 statuses (a 4xx is a genuine client error and stays a 500).
+    """
+    cause = exc.__cause__
+    if isinstance(cause, aiohttp.ClientResponseError):
+        return cause.status in _CONFIG_STORE_RETRYABLE_STATUSES
+    return isinstance(cause, aiohttp.ClientError)
 
 
 async def _authorize_request(request: Request, device_uuid: str) -> None:
@@ -95,6 +118,12 @@ async def load_configuration(
     except (NotFoundError, ConfigStoreFileNotFound) as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ConfigStoreException as exc:
+        # A transient Config Store blip (connection reset/disconnect, or a 5xx/429
+        # that outlived the client's own retries) should shed as a retryable 503,
+        # mirroring how Nautobot/S3 saturation is handled — not masquerade as a hard
+        # 500 that reads as "ZTP is broken". Genuine errors (e.g. a 4xx) stay 500.
+        if _config_store_error_is_transient(exc):
+            raise StorageUnavailableError(str(exc)) from exc
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/src/nv_config_manager/ztp/api/device_v1.py
+++ b/src/nv_config_manager/ztp/api/device_v1.py
@@ -24,6 +24,7 @@ from nv_config_manager.common.config import get_storage_client, temporal_client
 from nv_config_manager.common.log import LogCategory, get_logger
 from nv_config_manager.ztp.api.clients import get_nautobot_client
 from nv_config_manager.ztp.api.schemas import ChecksumResponse
+from nv_config_manager.ztp.api.storage_clients import get_object_storage_client, guarded_storage
 from nv_config_manager.ztp.api.streaming import create_object_storage_streaming_response
 from nv_config_manager.ztp.nautobot import NotFoundError
 from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
@@ -136,12 +137,11 @@ async def load_firmware_checksum(device_uuid: str, request: Request) -> Checksum
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-    storage_client = get_storage_client()
+    storage_client = await get_object_storage_client()
     try:
-        async with storage_client:
-            checksum = await storage_client.get_firmware_checksum(
-                device_data.platform, device_data.version
-            )
+        checksum = await guarded_storage(
+            lambda: storage_client.get_firmware_checksum(device_data.platform, device_data.version)
+        )
         return ChecksumResponse(checksum=checksum)
     except ObjectStorageNotFoundException as exc:
         raise HTTPException(status_code=404, detail="Firmware image not found in S3.") from exc

--- a/src/nv_config_manager/ztp/api/device_v1.py
+++ b/src/nv_config_manager/ztp/api/device_v1.py
@@ -22,9 +22,10 @@ from nv_config_manager.common.auth import auth_required, require_sso_or_device
 from nv_config_manager.common.client import ConfigStoreException, ConfigStoreFileNotFound
 from nv_config_manager.common.config import get_storage_client, temporal_client
 from nv_config_manager.common.log import LogCategory, get_logger
+from nv_config_manager.ztp.api.clients import get_nautobot_client
 from nv_config_manager.ztp.api.schemas import ChecksumResponse
 from nv_config_manager.ztp.api.streaming import create_object_storage_streaming_response
-from nv_config_manager.ztp.nautobot import NautobotClient, NotFoundError
+from nv_config_manager.ztp.nautobot import NotFoundError
 from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
 
 logger = get_logger(__name__, category=LogCategory.ZTP_API)
@@ -46,9 +47,7 @@ async def _authorize_request(request: Request, device_uuid: str) -> None:
         return
 
     try:
-        nb_client = NautobotClient()
-        async with nb_client:
-            device_data = await nb_client.get_device_data(device_uuid)
+        device_data = await get_nautobot_client().get_device_data(device_uuid)
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -89,9 +88,7 @@ async def load_configuration(
     """Load the specified configuration file for the given nautobot device UUID."""
     await _authorize_request(request, device_uuid)
     try:
-        nb_client = NautobotClient()
-        async with nb_client:
-            device_data = await nb_client.get_device_data(device_uuid)
+        device_data = await get_nautobot_client().get_device_data(device_uuid)
         content = await device_data.load_file(configlet)
         return PlainTextResponse(content)
     except (NotFoundError, ConfigStoreFileNotFound) as exc:
@@ -110,9 +107,7 @@ async def load_firmware(device_uuid: str, request: Request) -> StreamingResponse
     """Load the firmware for the given device."""
     await _authorize_request(request, device_uuid)
     try:
-        nb_client = NautobotClient()
-        async with nb_client:
-            device_data = await nb_client.get_device_data(device_uuid)
+        device_data = await get_nautobot_client().get_device_data(device_uuid)
         if device_data.platform is None or device_data.version is None:
             raise HTTPException(status_code=404, detail="Device firware data not found")
     except NotFoundError as exc:
@@ -135,9 +130,7 @@ async def load_firmware_checksum(device_uuid: str, request: Request) -> Checksum
     """Load the firmware checksum for the given device."""
     await _authorize_request(request, device_uuid)
     try:
-        nb_client = NautobotClient()
-        async with nb_client:
-            device_data = await nb_client.get_device_data(device_uuid)
+        device_data = await get_nautobot_client().get_device_data(device_uuid)
         if device_data.platform is None or device_data.version is None:
             raise HTTPException(status_code=404, detail="Device firware data not found")
     except NotFoundError as exc:
@@ -158,9 +151,7 @@ async def load_firmware_checksum(device_uuid: str, request: Request) -> Checksum
 async def mark_provisioned(device_uuid: str, request: Request) -> str:
     """Mark the ZTP process complete for the given device."""
     await _authorize_request(request, device_uuid)
-    nb_client = NautobotClient()
-    async with nb_client:
-        await nb_client.set_status_provisioned(device_uuid)
+    await get_nautobot_client().set_status_provisioned(device_uuid)
     # Trigger a backup workflow
     try:
         client = temporal_client()
@@ -195,10 +186,8 @@ def _compare_serials(expected: str, observed: str) -> bool:
 async def validate_serial(device_uuid: str, body: ValidateSerialBody, request: Request) -> str:
     """Validate the device serial number matches nautobot."""
     await _authorize_request(request, device_uuid)
-    nb_client = NautobotClient()
     try:
-        async with nb_client:
-            expected_serial = await nb_client.get_device_serial(device_uuid)
+        expected_serial = await get_nautobot_client().get_device_serial(device_uuid)
         if not _compare_serials(expected_serial, body.serial):
             logger.error(
                 "Serial number mismatch observed on device %s, expected: %s, observed: %s.",

--- a/src/nv_config_manager/ztp/api/firmware_v1.py
+++ b/src/nv_config_manager/ztp/api/firmware_v1.py
@@ -20,6 +20,7 @@ from fastapi.responses import StreamingResponse
 from nv_config_manager.common.config import get_storage_client
 from nv_config_manager.common.log import LogCategory, get_logger
 from nv_config_manager.ztp.api.schemas import ChecksumResponse
+from nv_config_manager.ztp.api.storage_clients import get_object_storage_client, guarded_storage
 from nv_config_manager.ztp.api.streaming import create_object_storage_streaming_response
 from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
 
@@ -49,10 +50,11 @@ async def load_firmware(platform: str, version: str) -> StreamingResponse:
 @router.get("/{platform}/{version}/checksum")
 async def load_firmware_checksum(platform: str, version: str) -> ChecksumResponse:
     """Load the firmware checksum by platform and version."""
-    storage_client = get_storage_client()
+    storage_client = await get_object_storage_client()
     try:
-        async with storage_client:
-            checksum = await storage_client.get_firmware_checksum(platform, version)
+        checksum = await guarded_storage(
+            lambda: storage_client.get_firmware_checksum(platform, version)
+        )
         return ChecksumResponse(checksum=checksum)
     except ObjectStorageNotFoundException as exc:
         raise HTTPException(status_code=404, detail="Firmware image not found in S3.") from exc

--- a/src/nv_config_manager/ztp/api/main.py
+++ b/src/nv_config_manager/ztp/api/main.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -47,12 +48,24 @@ def main() -> None:
         "--host", type=str, default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)"
     )
     parser.add_argument("--port", type=int, default=9000, help="Port to listen on (default: 9000)")
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=int(os.environ.get("ZTP_API_WORKERS") or os.environ.get("WEB_CONCURRENCY") or "1"),
+        help=(
+            "Number of uvicorn worker processes (default: 1, or $ZTP_API_WORKERS / "
+            "$WEB_CONCURRENCY). Each worker runs its own event loop and its own shared "
+            "backend-client singletons, spreading per-pod device concurrency across loops "
+            "so a single loop is less likely to stall (liveness kill) under a boot storm."
+        ),
+    )
     args = parser.parse_args()
 
     uvicorn.run(
         "nv_config_manager.ztp.api.main:app",
         host=args.host,
         port=args.port,
+        workers=args.workers,
         proxy_headers=True,
         log_config=None,
         timeout_keep_alive=75,

--- a/src/nv_config_manager/ztp/api/main.py
+++ b/src/nv_config_manager/ztp/api/main.py
@@ -108,7 +108,11 @@ instrumentator.expose(app, include_in_schema=False)
 
 
 @app.get("/healthcheck")
-def healthcheck() -> str:
+async def healthcheck() -> str:
+    # Async so the liveness/readiness probe runs directly on the event loop
+    # instead of the anyio threadpool. Under a boot storm the threadpool can be
+    # saturated by blocking per-request I/O, which would otherwise starve a sync
+    # probe handler and trigger spurious liveness-kill restarts of http-lb.
     """Execute healthcheck."""
     return "OK"
 

--- a/src/nv_config_manager/ztp/api/main.py
+++ b/src/nv_config_manager/ztp/api/main.py
@@ -30,6 +30,11 @@ from nv_config_manager.common.log import configure_logging
 from nv_config_manager.ztp.api import device_v1, files_v1, firmware_v1
 from nv_config_manager.ztp.api.clients import close_nautobot_client, get_nautobot_client
 from nv_config_manager.ztp.api.metrics import device_http_requests
+from nv_config_manager.ztp.api.storage_clients import (
+    StorageUnavailableError,
+    close_storage_clients,
+    warm_storage_clients,
+)
 from nv_config_manager.ztp.nautobot import NautobotUnavailableError
 
 configure_logging(service="ztp")
@@ -58,12 +63,19 @@ def main() -> None:
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
-    """Create the shared Nautobot client on startup, close it on shutdown."""
+    """Create shared backend clients on startup, close them on shutdown.
+
+    The Nautobot, object storage, and Config Store clients are process-wide
+    singletons so their connection pools / keepalive / backpressure are shared
+    across requests instead of rebuilt per request.
+    """
     get_nautobot_client()
+    await warm_storage_clients()
     try:
         yield
     finally:
         await close_nautobot_client()
+        await close_storage_clients()
 
 
 app = FastAPI(lifespan=lifespan)
@@ -80,6 +92,22 @@ async def _nautobot_unavailable_handler(
     """
     return PlainTextResponse(
         str(exc) or "Nautobot temporarily unavailable.",
+        status_code=503,
+        headers={"Retry-After": "5"},
+    )
+
+
+@app.exception_handler(StorageUnavailableError)
+async def _storage_unavailable_handler(
+    _request: Request, exc: StorageUnavailableError
+) -> PlainTextResponse:
+    """Surface object-storage / Config Store backpressure as a retryable 503.
+
+    Sheds load fast (rather than letting per-request S3/Config Store I/O pile up
+    on the event loop) so a device/ONIE backs off and retries its boot.
+    """
+    return PlainTextResponse(
+        str(exc) or "Storage temporarily unavailable.",
         status_code=503,
         headers={"Retry-After": "5"},
     )

--- a/src/nv_config_manager/ztp/api/main.py
+++ b/src/nv_config_manager/ztp/api/main.py
@@ -17,15 +17,20 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import PlainTextResponse
 from prometheus_fastapi_instrumentator import Instrumentator, metrics
 
 from nv_config_manager.common.auth import install_identity_probe
 from nv_config_manager.common.log import configure_logging
 from nv_config_manager.ztp.api import device_v1, files_v1, firmware_v1
+from nv_config_manager.ztp.api.clients import close_nautobot_client, get_nautobot_client
 from nv_config_manager.ztp.api.metrics import device_http_requests
+from nv_config_manager.ztp.nautobot import NautobotUnavailableError
 
 configure_logging(service="ztp")
 
@@ -51,7 +56,34 @@ def main() -> None:
     )
 
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Create the shared Nautobot client on startup, close it on shutdown."""
+    get_nautobot_client()
+    try:
+        yield
+    finally:
+        await close_nautobot_client()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.exception_handler(NautobotUnavailableError)
+async def _nautobot_unavailable_handler(
+    _request: Request, exc: NautobotUnavailableError
+) -> PlainTextResponse:
+    """Surface Nautobot backpressure/circuit-breaker as a retryable 503.
+
+    Devices (and ONIE) retry on transient failures, so shedding load here is
+    far better than letting requests pile up on a struggling Nautobot.
+    """
+    return PlainTextResponse(
+        str(exc) or "Nautobot temporarily unavailable.",
+        status_code=503,
+        headers={"Retry-After": "5"},
+    )
+
 
 # Include routers
 app.include_router(device_v1.router, prefix="/v1")

--- a/src/nv_config_manager/ztp/api/storage_clients.py
+++ b/src/nv_config_manager/ztp/api/storage_clients.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared, process-wide storage + Config Store clients for the ZTP API.
+
+Mirrors the shared Nautobot client (``ztp/api/clients.py``) for the two other
+backends a device hits during a boot storm: object storage (S3/PVC) and the
+Config Store.
+
+Why this exists
+---------------
+The device-facing handlers used to build a fresh client *per request*:
+
+* ``get_storage_client()`` created a new :class:`S3Client` each call — a new
+  ``aioboto3.Session`` plus a ``connect()`` that resolves credentials (IRSA →
+  STS on first use) and opens a brand-new connection pool.
+* ``DeviceData.config_store_client()`` created a new
+  :class:`ConfigStoreClient` each call — and its ``__init__`` builds a new
+  ``aiohttp.TCPConnector`` + SSL context every time, so nothing is reused.
+
+Under a boot storm (100+ concurrent devices) that per-request setup piles
+unbounded coroutines + handshakes + credential lookups onto the single event
+loop, saturating it — which is what tipped ``http-lb`` into liveness-kill
+restarts and 500s even though the backends themselves were fine.
+
+What this provides
+------------------
+* A single, pre-connected object-storage client reused across requests
+  (keepalive + a real pool cap instead of one pool per request).
+* Config Store clients cached per endpoint (connector/pool reuse).
+* A bounded concurrency semaphore + short per-op timeout so a saturated or
+  stuck storage/Config Store call sheds load fast as a retryable
+  :class:`StorageUnavailableError` (surfaced as HTTP 503 ``Retry-After``)
+  instead of accumulating on the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from nv_config_manager.common.client import ConfigStoreClient
+from nv_config_manager.common.config import get_storage_client as _build_storage_client
+from nv_config_manager.common.config import load_config
+from nv_config_manager.common.log import LogCategory, get_logger
+
+if TYPE_CHECKING:
+    from nv_config_manager.ztp.device import DeviceData
+    from nv_config_manager.ztp.storage import ObjectStorageClient
+
+logger = get_logger(__name__, category=LogCategory.ZTP_API)
+
+# Bound the number of in-flight storage/Config Store operations so ZTP applies
+# backpressure instead of opening unbounded I/O during a boot storm. Callers
+# that cannot get a slot within the acquire timeout, or whose op exceeds the op
+# timeout, get a fast StorageUnavailableError (HTTP 503) rather than piling up.
+_MAX_CONCURRENCY = 40
+_ACQUIRE_TIMEOUT = 3.0
+_OP_TIMEOUT = 8.0
+
+_semaphore = asyncio.Semaphore(_MAX_CONCURRENCY)
+
+_object_storage_client: ObjectStorageClient | None = None
+_object_storage_lock = asyncio.Lock()
+_config_store_clients: dict[str, ConfigStoreClient] = {}
+
+
+class StorageUnavailableError(Exception):
+    """Object storage / Config Store is saturated or too slow; retry shortly."""
+
+
+async def guarded_storage[T](
+    factory: Callable[[], Awaitable[T]],
+    *,
+    op_timeout: float = _OP_TIMEOUT,
+) -> T:
+    """Run a storage/Config Store coroutine under backpressure + a short timeout.
+
+    Takes a factory (not a coroutine) so the underlying request is only created
+    once a slot is admitted. Semaphore saturation or a timeout is translated
+    into a retryable :class:`StorageUnavailableError` (HTTP 503); every other
+    exception (e.g. NotFound) propagates unchanged so real 404s stay 404s.
+    """
+    try:
+        await asyncio.wait_for(_semaphore.acquire(), timeout=_ACQUIRE_TIMEOUT)
+    except TimeoutError as exc:
+        raise StorageUnavailableError(
+            "Storage backend busy (backpressure); retry shortly."
+        ) from exc
+    try:
+        async with asyncio.timeout(op_timeout):
+            return await factory()
+    except TimeoutError as exc:
+        raise StorageUnavailableError(
+            "Storage backend slow or unavailable; retry shortly."
+        ) from exc
+    finally:
+        _semaphore.release()
+
+
+async def get_object_storage_client() -> ObjectStorageClient:
+    """Return the process-wide, pre-connected object storage client.
+
+    Created and connected lazily behind a lock so concurrent first requests
+    don't each build (and leak) their own client. Safe to share: the underlying
+    aiobotocore client multiplexes concurrent calls over its connection pool.
+    """
+    global _object_storage_client
+    if _object_storage_client is not None:
+        return _object_storage_client
+    async with _object_storage_lock:
+        if _object_storage_client is None:
+            client = _build_storage_client()
+            await client.connect()
+            _object_storage_client = client
+    return _object_storage_client
+
+
+def _config_store_key(device_data: DeviceData) -> str:
+    """Cache key for a device's Config Store client.
+
+    Internal-endpoint deployments (all devices share one service URL) collapse
+    to a single client; external mTLS deployments key by per-device endpoint so
+    each distinct Config Store instance gets its own pooled client.
+    """
+    cfg = load_config()
+    if cfg.getboolean("config_store.client", "use_internal_endpoint", fallback=False):
+        return "internal"
+    return device_data.config_store_instance or "default"
+
+
+def get_config_store_client(device_data: DeviceData) -> ConfigStoreClient:
+    """Return a shared Config Store client for this device's endpoint.
+
+    Reuses one client (and its connection pool) per distinct endpoint instead
+    of building a new connector + SSL context on every ``load_file`` call.
+    """
+    key = _config_store_key(device_data)
+    client = _config_store_clients.get(key)
+    if client is None:
+        client = device_data.config_store_client()
+        _config_store_clients[key] = client
+    return client
+
+
+async def warm_storage_clients() -> None:
+    """Best-effort pre-connect of the object storage client on app startup.
+
+    Failures are logged and swallowed so the app still starts (e.g. in envs
+    without S3 credentials); the client will be built lazily on first request.
+    """
+    try:
+        await get_object_storage_client()
+    except Exception as exc:  # noqa: BLE001 - startup warming must never crash boot
+        logger.warning("Could not pre-connect object storage client at startup: %s", exc)
+
+
+async def close_storage_clients() -> None:
+    """Close all shared storage + Config Store clients (called on app shutdown)."""
+    global _object_storage_client
+    if _object_storage_client is not None:
+        try:
+            await _object_storage_client.close()
+        finally:
+            _object_storage_client = None
+    for client in _config_store_clients.values():
+        try:
+            await client.close()
+        except Exception as exc:  # noqa: BLE001 - shutdown cleanup is best-effort
+            logger.warning("Error closing Config Store client: %s", exc)
+    _config_store_clients.clear()
+
+
+def reset_storage_clients() -> None:
+    """Drop shared clients without awaiting (test isolation helper)."""
+    global _object_storage_client
+    _object_storage_client = None
+    _config_store_clients.clear()

--- a/src/nv_config_manager/ztp/device.py
+++ b/src/nv_config_manager/ztp/device.py
@@ -25,6 +25,7 @@ from nv_config_manager.common.client import (
     ConfigStoreFileNotFound,
 )
 from nv_config_manager.common.config import get_internal_auth_headers, load_config
+from nv_config_manager.ztp.api.storage_clients import get_config_store_client, guarded_storage
 
 
 @dataclass
@@ -98,9 +99,11 @@ class DeviceData:  # pylint: disable=too-many-instance-attributes
         if self.config_store_instance is None:
             raise ConfigStoreFileNotFound(f"No config store file found for device {self.name}")
 
-        client = self.config_store_client()
-        async with client:
-            config_file = await client.load_file(self.id, filename)
+        # Use the process-wide shared Config Store client (pooled connector +
+        # backpressure) rather than building/closing a fresh client per call,
+        # which under load piles TCP+TLS handshakes and coroutines onto the loop.
+        client = get_config_store_client(self)
+        config_file = await guarded_storage(lambda: client.load_file(self.id, filename))
         return config_file.content
 
     @staticmethod

--- a/src/nv_config_manager/ztp/nautobot.py
+++ b/src/nv_config_manager/ztp/nautobot.py
@@ -23,6 +23,12 @@ defaults so no config change is required):
 
 * Short request timeout so a stuck call releases its slot quickly
   (``request_timeout``, default 8s).
+* A bounded retry on transient failures (timeout, connection error, 5xx): each
+  guarded call is attempted up to ``request_max_attempts`` times (default 2) so
+  a fresh attempt can land on a healthy pod/connection. If every attempt fails,
+  the caller gets a fast :class:`NautobotUnavailableError` (surfaced as HTTP 503
+  ``Retry-After``) instead of a raw timeout leaking as a 500 — so a device (or
+  ONIE) backs off and retries rather than failing its boot.
 * A bounded concurrency semaphore so ZTP applies backpressure toward Nautobot
   instead of opening unbounded connections during a boot storm. Callers that
   cannot get a slot within ``acquire_timeout`` (default 3s) get a fast
@@ -126,6 +132,10 @@ class NautobotClient(BaseNautobotClient):
         nb_config: SectionProxy = config["nautobot"]
 
         self._request_timeout = nb_config.getint("request_timeout", fallback=8)
+        # Retry a transient failure a bounded number of times before giving up;
+        # a fresh attempt usually lands on a healthy pod / connection.
+        self._max_attempts = max(1, nb_config.getint("request_max_attempts", fallback=2))
+        self._retry_backoff = nb_config.getfloat("request_retry_backoff", fallback=0.1)
         self._acquire_timeout = nb_config.getfloat("acquire_timeout", fallback=3.0)
         self._cache_ttl = nb_config.getfloat("cache_ttl", fallback=5.0)
         self._breaker_threshold = nb_config.getint("breaker_failure_threshold", fallback=8)
@@ -202,30 +212,50 @@ class NautobotClient(BaseNautobotClient):
             ) from exc
 
     async def _guarded(self, make_coro: Callable[[], Awaitable[_T]]) -> _T:
-        """Run a coroutine behind the breaker + concurrency limiter.
+        """Run a coroutine behind the breaker + concurrency limiter, retrying
+        transient failures a bounded number of times.
 
         Takes a factory (not a coroutine) so the underlying request is only
-        created after the breaker and limiter admit it — no orphaned, never
-        awaited coroutines when we fail fast.
+        created after the breaker and limiter admit it, and so every retry gets
+        a fresh request — no orphaned, never-awaited coroutines when we fail
+        fast.
 
-        Only genuine Nautobot health failures (timeouts, connection errors,
-        5xx) count toward the breaker; logical errors (e.g. NotFoundError)
-        propagate without tripping it.
+        A transient Nautobot health failure (timeout, connection error, 5xx) is
+        retried up to ``request_max_attempts`` times; a fresh attempt usually
+        lands on a healthy pod / fresh connection (e.g. after a rollout churns
+        the endpoint list or a pod was momentarily cold). If every attempt
+        fails, we record a single breaker failure and surface a
+        :class:`NautobotUnavailableError` (HTTP 503 ``Retry-After``) rather than
+        letting the raw timeout leak out as a 500 — so a device backs off and
+        retries instead of failing its boot. Logical errors (e.g. NotFoundError)
+        mean a healthy Nautobot answered and propagate immediately without
+        tripping the breaker.
         """
         self._breaker_check()
         await self._acquire_slot()
         try:
-            result = await make_coro()
-        except _TRANSIENT_ERRORS:
+            last_exc: BaseException | None = None
+            for attempt in range(self._max_attempts):
+                try:
+                    result = await make_coro()
+                except _TRANSIENT_ERRORS as exc:
+                    last_exc = exc
+                    if attempt + 1 < self._max_attempts and self._retry_backoff > 0:
+                        await asyncio.sleep(self._retry_backoff)
+                    continue
+                except Exception:
+                    # Non-transient (e.g. NotFoundError): Nautobot answered.
+                    self._record_success()
+                    raise
+                else:
+                    self._record_success()
+                    return result
+            # Every attempt hit a transient failure: count one breaker failure
+            # and surface a retryable 503 instead of the raw timeout/conn error.
             self._record_failure()
-            raise
-        except Exception:
-            # Non-transient (e.g. NotFoundError): a healthy Nautobot answered.
-            self._record_success()
-            raise
-        else:
-            self._record_success()
-            return result
+            raise NautobotUnavailableError(
+                "Nautobot is slow or unavailable after retries; retry shortly."
+            ) from last_exc
         finally:
             self._semaphore.release()
 

--- a/src/nv_config_manager/ztp/nautobot.py
+++ b/src/nv_config_manager/ztp/nautobot.py
@@ -14,18 +14,52 @@
 # limitations under the License.
 """Nautobot Client for ZTP service.
 
-Extends the base NautobotClient with ZTP-specific methods for
-device bootstrapping and provisioning.
+Extends the base NautobotClient with ZTP-specific methods for device
+bootstrapping and provisioning, plus resilience so a slow or flapping Nautobot
+degrades gracefully instead of taking ZTP down with it.
+
+Resilience features (all tunable via the ``[nautobot]`` INI section, with safe
+defaults so no config change is required):
+
+* Short request timeout so a stuck call releases its slot quickly
+  (``request_timeout``, default 8s).
+* A bounded concurrency semaphore so ZTP applies backpressure toward Nautobot
+  instead of opening unbounded connections during a boot storm. Callers that
+  cannot get a slot within ``acquire_timeout`` (default 3s) get a fast
+  :class:`NautobotUnavailableError` (surfaced as HTTP 503) rather than piling
+  up (``max_concurrency``, default 40).
+* A short-TTL device-data cache with single-flight coalescing so a burst of
+  requests for the same device collapses to a single GraphQL query
+  (``cache_ttl``, default 5s).
+* A circuit breaker that fails fast for a cooldown once Nautobot starts
+  erroring/timing out, protecting both ZTP's event loop and a struggling
+  Nautobot (``breaker_failure_threshold`` default 8, ``breaker_cooldown``
+  default 10s).
+
+Because these features carry per-instance state (semaphore, cache, breaker),
+the client is meant to be created once and shared across requests — see
+``nv_config_manager.ztp.api.clients.get_nautobot_client``.
 """
 
 from __future__ import annotations
 
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from configparser import SectionProxy
+from typing import Any, TypeVar
+
+import aiohttp
+
 from nv_config_manager.common.client import NautobotClient as BaseNautobotClient
-from nv_config_manager.common.config import load_config
+from nv_config_manager.common.client import NautobotException
+from nv_config_manager.common.config import load_config, parse_verify_param
 from nv_config_manager.common.log import LogCategory, get_logger
 from nv_config_manager.ztp.device import DeviceData
 
 logger = get_logger(__name__, category=LogCategory.NAUTOBOT)
+
+_T = TypeVar("_T")
 
 DEVICE_QUERY = """
 query ($id: ID!) {
@@ -56,11 +90,30 @@ class NotFoundError(Exception):
     """No device data found in GraphQL."""
 
 
-class NautobotClient(BaseNautobotClient):
-    """Async Nautobot Client for ZTP service.
+class NautobotUnavailableError(Exception):
+    """Nautobot is overloaded or unhealthy; the caller should back off.
 
-    Extends the base NautobotClient with methods specific to ZTP,
-    including device data retrieval and provisioning status updates.
+    Raised when the concurrency limiter is saturated or the circuit breaker is
+    open. Surfaced to clients as HTTP 503 so devices retry rather than the
+    request piling up on a struggling Nautobot.
+    """
+
+
+# Errors that indicate Nautobot itself is unhealthy (slow/down) and should count
+# toward the circuit breaker. Logical/not-found errors are intentionally excluded.
+_TRANSIENT_ERRORS = (
+    TimeoutError,
+    aiohttp.ClientError,
+    NautobotException,
+)
+
+
+class NautobotClient(BaseNautobotClient):
+    """Async, resilient Nautobot client for the ZTP service.
+
+    Extends the base client with a bounded-concurrency limiter, a short-TTL
+    device-data cache with single-flight coalescing, and a circuit breaker.
+    Designed to be instantiated once and shared across requests.
     """
 
     def __init__(
@@ -68,23 +121,166 @@ class NautobotClient(BaseNautobotClient):
         nautobot_url: str | None = None,
         token: str | None = None,
     ) -> None:
-        """Initialize ZTP NB Client."""
-        # Lazy import to avoid circular dependency with nv_config_manager.common.config
-        from nv_config_manager.common.config import parse_verify_param
-
+        """Initialize the ZTP Nautobot client from the unified INI config."""
         config = load_config()
+        nb_config: SectionProxy = config["nautobot"]
+
+        self._request_timeout = nb_config.getint("request_timeout", fallback=8)
+        self._acquire_timeout = nb_config.getfloat("acquire_timeout", fallback=3.0)
+        self._cache_ttl = nb_config.getfloat("cache_ttl", fallback=5.0)
+        self._breaker_threshold = nb_config.getint("breaker_failure_threshold", fallback=8)
+        self._breaker_cooldown = nb_config.getfloat("breaker_cooldown", fallback=10.0)
+        max_concurrency = nb_config.getint("max_concurrency", fallback=40)
+
         super().__init__(
-            nautobot_url=nautobot_url or config["nautobot"]["server"],
-            token=token or config["nautobot"]["token"],
-            verify=parse_verify_param(config["nautobot"]),
+            nautobot_url=nautobot_url or nb_config["server"],
+            token=token or nb_config["token"],
+            verify=parse_verify_param(nb_config),
+            timeout=self._request_timeout,
+            # Give the pool a little headroom over the in-flight cap.
+            connection_limit=nb_config.getint("connection_limit", fallback=max_concurrency + 10),
         )
 
+        self._semaphore = asyncio.Semaphore(max_concurrency)
+
+        # Device-data cache: device_id -> (expiry_monotonic, DeviceData).
+        self._cache: dict[str, tuple[float, DeviceData]] = {}
+        # In-flight single-flight tasks: device_id -> Task, so concurrent
+        # requests for the same device share one GraphQL round-trip.
+        self._inflight: dict[str, asyncio.Task[DeviceData]] = {}
+
+        # Circuit breaker state.
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    # ------------------------------------------------------------------
+    # Test / lifecycle helpers
+    # ------------------------------------------------------------------
+    def reset_resilience_state(self) -> None:
+        """Clear cache, in-flight tasks, and breaker state.
+
+        Intended for test isolation between cases that share a singleton client.
+        """
+        self._cache.clear()
+        self._inflight.clear()
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    # ------------------------------------------------------------------
+    # Circuit breaker
+    # ------------------------------------------------------------------
+    def _breaker_check(self) -> None:
+        if self._breaker_open_until and time.monotonic() < self._breaker_open_until:
+            raise NautobotUnavailableError(
+                "Nautobot circuit breaker is open; refusing request to allow recovery."
+            )
+
+    def _record_success(self) -> None:
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self._breaker_threshold:
+            self._breaker_open_until = time.monotonic() + self._breaker_cooldown
+            logger.warning(
+                "Nautobot circuit breaker opened after %d consecutive failures; "
+                "failing fast for %.0fs.",
+                self._consecutive_failures,
+                self._breaker_cooldown,
+            )
+
+    # ------------------------------------------------------------------
+    # Concurrency limiter
+    # ------------------------------------------------------------------
+    async def _acquire_slot(self) -> None:
+        try:
+            await asyncio.wait_for(self._semaphore.acquire(), timeout=self._acquire_timeout)
+        except TimeoutError as exc:
+            raise NautobotUnavailableError(
+                "Nautobot concurrency limit reached; try again shortly."
+            ) from exc
+
+    async def _guarded(self, make_coro: Callable[[], Awaitable[_T]]) -> _T:
+        """Run a coroutine behind the breaker + concurrency limiter.
+
+        Takes a factory (not a coroutine) so the underlying request is only
+        created after the breaker and limiter admit it — no orphaned, never
+        awaited coroutines when we fail fast.
+
+        Only genuine Nautobot health failures (timeouts, connection errors,
+        5xx) count toward the breaker; logical errors (e.g. NotFoundError)
+        propagate without tripping it.
+        """
+        self._breaker_check()
+        await self._acquire_slot()
+        try:
+            result = await make_coro()
+        except _TRANSIENT_ERRORS:
+            self._record_failure()
+            raise
+        except Exception:
+            # Non-transient (e.g. NotFoundError): a healthy Nautobot answered.
+            self._record_success()
+            raise
+        else:
+            self._record_success()
+            return result
+        finally:
+            self._semaphore.release()
+
+    # ------------------------------------------------------------------
+    # Cache
+    # ------------------------------------------------------------------
+    def _cache_get(self, device_id: str) -> DeviceData | None:
+        entry = self._cache.get(device_id)
+        if entry is None:
+            return None
+        expiry, data = entry
+        if time.monotonic() >= expiry:
+            self._cache.pop(device_id, None)
+            return None
+        return data
+
+    def _cache_put(self, device_id: str, data: DeviceData) -> None:
+        if self._cache_ttl > 0:
+            self._cache[device_id] = (time.monotonic() + self._cache_ttl, data)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     async def get_device_data(self, device_id: str) -> DeviceData:
-        """Load device data from GraphQL."""
-        data = await self.graphql_query(DEVICE_QUERY, variables={"id": device_id})
+        """Load device data from GraphQL, with caching + single-flight.
+
+        Concurrent requests for the same device share a single GraphQL query,
+        and successful results are cached for a short TTL. This collapses the
+        read amplification of a boot storm (many configlet fetches per device,
+        plus the authorization lookup) down to roughly one query per device per
+        TTL window.
+        """
+        cached = self._cache_get(device_id)
+        if cached is not None:
+            return cached
+
+        task = self._inflight.get(device_id)
+        if task is None:
+            task = asyncio.ensure_future(self._load_device_data(device_id))
+            self._inflight[device_id] = task
+
+            def _discard(_task: asyncio.Task[DeviceData], key: str = device_id) -> None:
+                self._inflight.pop(key, None)
+
+            task.add_done_callback(_discard)
+        return await task
+
+    async def _load_device_data(self, device_id: str) -> DeviceData:
+        data = await self._guarded(
+            lambda: self.graphql_query(DEVICE_QUERY, variables={"id": device_id})
+        )
         device_data = DeviceData.from_graphql(data)
         if not device_data:
             raise NotFoundError(f"No data found in NB for {device_id}.")
+        self._cache_put(device_id, device_data)
         return device_data
 
     async def get_device_serial(self, device_id: str) -> str:
@@ -96,7 +292,9 @@ query ($id: ID!) {
     }
 }
 """
-        data = await self.graphql_query(query, variables={"id": device_id})
+        data: dict[str, Any] = await self._guarded(
+            lambda: self.graphql_query(query, variables={"id": device_id})
+        )
         if "errors" in data:
             raise NotFoundError(f"No serial found in NB for {device_id}.")
         serial: str = data["data"]["device"]["serial"]
@@ -104,4 +302,8 @@ query ($id: ID!) {
 
     async def set_status_provisioned(self, device_id: str) -> None:
         """Update the device status to Provisioned."""
-        await self.patch(f"dcim/devices/{device_id}/", {"status": "Provisioned"})
+        await self._guarded(
+            lambda: self.patch(f"dcim/devices/{device_id}/", {"status": "Provisioned"})
+        )
+        # Provisioning mutates device state; drop any stale cached copy.
+        self._cache.pop(device_id, None)

--- a/src/tests/ztp/api/test_main.py
+++ b/src/tests/ztp/api/test_main.py
@@ -26,6 +26,7 @@ from nv_config_manager.common.client import (
     ConfigStoreFileNotFound,
 )
 from nv_config_manager.ztp.api.main import app
+from nv_config_manager.ztp.api.storage_clients import StorageUnavailableError
 from nv_config_manager.ztp.nautobot import NautobotUnavailableError
 from nv_config_manager.ztp.s3 import (
     S3ExistsException,
@@ -283,7 +284,8 @@ def test_device_v1_firmware_checksum(mock_device_data, mock_not_found_data, clie
         mock_s3_class.return_value = mock_s3_instance
 
         with patch(
-            "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
+            "nv_config_manager.ztp.api.device_v1.get_object_storage_client",
+            new=AsyncMock(return_value=mock_s3_instance),
         ):
             rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
             assert rsp.status_code == 200
@@ -293,7 +295,8 @@ def test_device_v1_firmware_checksum(mock_device_data, mock_not_found_data, clie
         mock_s3_instance.get_firmware_checksum = AsyncMock(side_effect=S3NotFoundException())
 
         with patch(
-            "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
+            "nv_config_manager.ztp.api.device_v1.get_object_storage_client",
+            new=AsyncMock(return_value=mock_s3_instance),
         ):
             rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
             assert rsp.status_code == 404
@@ -304,6 +307,25 @@ def test_device_v1_firmware_checksum(mock_device_data, mock_not_found_data, clie
     ):
         rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 404
+
+
+def test_device_v1_firmware_checksum_returns_503_when_storage_unavailable(mock_device_data, client):
+    """Storage backpressure/timeout surfaces to devices as a retryable 503."""
+    mock_s3_instance = MagicMock()
+    mock_s3_instance.get_firmware_checksum = AsyncMock(
+        side_effect=StorageUnavailableError("storage busy")
+    )
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        return_value=mock_device_data,
+    ):
+        with patch(
+            "nv_config_manager.ztp.api.device_v1.get_object_storage_client",
+            new=AsyncMock(return_value=mock_s3_instance),
+        ):
+            rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
+            assert rsp.status_code == 503
+            assert rsp.headers["retry-after"] == "5"
 
 
 @patch("nv_config_manager.ztp.api.device_v1.Request.client")
@@ -502,7 +524,8 @@ def test_v1_firmware_checksum(client):
     mock_s3_class.return_value = mock_s3_instance
 
     with patch(
-        "nv_config_manager.ztp.api.firmware_v1.get_storage_client", return_value=mock_s3_instance
+        "nv_config_manager.ztp.api.firmware_v1.get_object_storage_client",
+        new=AsyncMock(return_value=mock_s3_instance),
     ):
         rsp = client.get("/v1/firmware/arista_eos/4.29.3M/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 200
@@ -512,7 +535,8 @@ def test_v1_firmware_checksum(client):
     mock_s3_instance.get_firmware_checksum = AsyncMock(side_effect=S3NotFoundException())
 
     with patch(
-        "nv_config_manager.ztp.api.firmware_v1.get_storage_client", return_value=mock_s3_instance
+        "nv_config_manager.ztp.api.firmware_v1.get_object_storage_client",
+        new=AsyncMock(return_value=mock_s3_instance),
     ):
         rsp = client.get("/v1/firmware/arista_eos/4.29.3M/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 404

--- a/src/tests/ztp/api/test_main.py
+++ b/src/tests/ztp/api/test_main.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import aiohttp
 import pytest
 from fastapi.testclient import TestClient
 
@@ -354,6 +355,57 @@ def test_device_v1_config_store_exceptions(mock_request_client, mock_device_data
             rsp = client.get(f"/v1/device/{uuid4()}/boot-script")
             assert rsp.json() == {"detail": "config store query error"}
             assert rsp.status_code == 500
+
+
+@patch("nv_config_manager.ztp.api.device_v1.Request.client")
+def test_device_v1_config_store_transient_error_returns_503(
+    mock_request_client, mock_device_data, client
+):
+    """A transient Config Store blip sheds as a retryable 503, not a hard 500.
+
+    The Config Store client re-wraps connection resets / retryable 5xx as a
+    generic ConfigStoreException with the original error as __cause__; those must
+    surface as 503 so a device retries, while a genuine 4xx stays a hard 500.
+    """
+    mock_request_client.host = "testclient"
+    mock_device_data["data"]["config_manager_device"]["device"]["interfaces"] = [
+        {"ip_addresses": [{"host": "testclient"}]}
+    ]
+
+    def _wrapped(cause: Exception | None) -> ConfigStoreException:
+        exc = ConfigStoreException("transient config store failure")
+        exc.__cause__ = cause
+        return exc
+
+    transient_causes = [
+        aiohttp.ClientConnectionError("connection reset"),
+        aiohttp.ClientResponseError(MagicMock(), (), status=503),
+    ]
+    permanent_causes: list[Exception | None] = [
+        aiohttp.ClientResponseError(MagicMock(), (), status=400),
+        None,
+    ]
+
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        return_value=mock_device_data,
+    ):
+        for cause in transient_causes:
+            with patch(
+                "nv_config_manager.ztp.device.DeviceData.load_file",
+                side_effect=_wrapped(cause),
+            ):
+                rsp = client.get(f"/v1/device/{uuid4()}/config/startup.yaml")
+                assert rsp.status_code == 503
+                assert rsp.headers["retry-after"] == "5"
+
+        for cause in permanent_causes:
+            with patch(
+                "nv_config_manager.ztp.device.DeviceData.load_file",
+                side_effect=_wrapped(cause),
+            ):
+                rsp = client.get(f"/v1/device/{uuid4()}/config/startup.yaml")
+                assert rsp.status_code == 500
 
 
 @patch("nv_config_manager.ztp.api.device_v1.Request.client")

--- a/src/tests/ztp/api/test_main.py
+++ b/src/tests/ztp/api/test_main.py
@@ -26,6 +26,7 @@ from nv_config_manager.common.client import (
     ConfigStoreFileNotFound,
 )
 from nv_config_manager.ztp.api.main import app
+from nv_config_manager.ztp.nautobot import NautobotUnavailableError
 from nv_config_manager.ztp.s3 import (
     S3ExistsException,
     S3NotFoundException,
@@ -98,6 +99,22 @@ def test_device_v1_bootscript(
     ):
         rsp = client.get(f"/v1/device/{uuid4()}/boot-script")
         assert rsp.status_code == 404
+
+
+@patch("nv_config_manager.ztp.api.device_v1.Request.client")
+def test_device_v1_returns_503_when_nautobot_unavailable(mock_request_client, client):
+    """Backpressure / circuit-breaker surfaces to devices as a retryable 503."""
+    mock_request_client.host = "testclient"
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.get_device_data",
+        new_callable=AsyncMock,
+        side_effect=NautobotUnavailableError(
+            "Nautobot concurrency limit reached; try again shortly."
+        ),
+    ):
+        rsp = client.get(f"/v1/device/{uuid4()}/boot-script")
+        assert rsp.status_code == 503
+        assert rsp.headers["retry-after"] == "5"
 
 
 @patch("nv_config_manager.ztp.api.device_v1.Request.client")

--- a/src/tests/ztp/api/test_storage_clients.py
+++ b/src/tests/ztp/api/test_storage_clients.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the shared ZTP storage / Config Store clients + backpressure."""
+
+import asyncio
+
+import pytest
+
+from nv_config_manager.ztp.api import storage_clients
+from nv_config_manager.ztp.api.storage_clients import (
+    StorageUnavailableError,
+    guarded_storage,
+)
+from nv_config_manager.ztp.s3 import S3NotFoundException
+
+
+async def test_guarded_storage_returns_value():
+    """A fast op returns its value unchanged through the guard."""
+
+    async def factory() -> str:
+        return "ok"
+
+    assert await guarded_storage(factory) == "ok"
+
+
+async def test_guarded_storage_timeout_raises_unavailable():
+    """An op that exceeds the op timeout is shed as a retryable 503-mapped error."""
+
+    async def slow() -> str:
+        await asyncio.sleep(0.2)
+        return "never"
+
+    with pytest.raises(StorageUnavailableError):
+        await guarded_storage(slow, op_timeout=0.01)
+
+
+async def test_guarded_storage_propagates_logical_errors():
+    """NotFound (a real answer) propagates unchanged — it must stay a 404, not 503."""
+
+    async def missing() -> str:
+        raise S3NotFoundException("nope")
+
+    with pytest.raises(S3NotFoundException):
+        await guarded_storage(missing)
+
+
+async def test_guarded_storage_backpressure_sheds_when_saturated(monkeypatch):
+    """When all concurrency slots are held, a new op fails fast as unavailable."""
+    # Drain the semaphore to 0 permits and use a tiny acquire timeout so the
+    # test is fast and deterministic.
+    monkeypatch.setattr(storage_clients, "_ACQUIRE_TIMEOUT", 0.01)
+    sem = asyncio.Semaphore(1)
+    await sem.acquire()  # now 0 permits available
+    monkeypatch.setattr(storage_clients, "_semaphore", sem)
+
+    async def factory() -> str:
+        return "ok"
+
+    with pytest.raises(StorageUnavailableError):
+        await guarded_storage(factory)

--- a/src/tests/ztp/conftest.py
+++ b/src/tests/ztp/conftest.py
@@ -19,22 +19,25 @@ import os
 
 import pytest
 
-from nv_config_manager.ztp.api import clients
+from nv_config_manager.ztp.api import clients, storage_clients
 
 # Get the directory containing this conftest.py
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture(autouse=True)
-def _reset_shared_nautobot_client():
-    """Drop the process-wide ZTP Nautobot client between tests.
+def _reset_shared_ztp_clients():
+    """Drop the process-wide ZTP backend clients between tests.
 
-    The shared client carries a cache, circuit-breaker, and concurrency limiter;
+    The shared Nautobot client carries a cache, circuit-breaker, and concurrency
+    limiter, and the shared storage/Config Store clients carry connection pools;
     resetting keeps those from leaking state across test cases.
     """
     clients.reset_nautobot_client()
+    storage_clients.reset_storage_clients()
     yield
     clients.reset_nautobot_client()
+    storage_clients.reset_storage_clients()
 
 
 @pytest.fixture

--- a/src/tests/ztp/conftest.py
+++ b/src/tests/ztp/conftest.py
@@ -19,8 +19,22 @@ import os
 
 import pytest
 
+from nv_config_manager.ztp.api import clients
+
 # Get the directory containing this conftest.py
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_nautobot_client():
+    """Drop the process-wide ZTP Nautobot client between tests.
+
+    The shared client carries a cache, circuit-breaker, and concurrency limiter;
+    resetting keeps those from leaking state across test cases.
+    """
+    clients.reset_nautobot_client()
+    yield
+    clients.reset_nautobot_client()
 
 
 @pytest.fixture

--- a/src/tests/ztp/test_nautobot.py
+++ b/src/tests/ztp/test_nautobot.py
@@ -12,12 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
+import aiohttp
 import pytest
 
-from nv_config_manager.ztp.nautobot import DeviceData, NautobotClient
+from nv_config_manager.ztp.nautobot import (
+    DeviceData,
+    NautobotClient,
+    NautobotUnavailableError,
+    NotFoundError,
+)
 
 
 @pytest.mark.asyncio
@@ -40,3 +47,106 @@ async def test_device_data(mock_device_data):
         )
 
         assert device_data == expected
+
+
+@pytest.mark.asyncio
+async def test_get_device_data_caches_within_ttl(mock_device_data):
+    """A second lookup within the TTL is served from cache (no extra query)."""
+    device_id = str(uuid4())
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        new_callable=AsyncMock,
+        return_value=mock_device_data,
+    ) as mock_query:
+        nb = NautobotClient()
+        first = await nb.get_device_data(device_id)
+        second = await nb.get_device_data(device_id)
+
+        assert first == second
+        mock_query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_device_data_single_flight(mock_device_data):
+    """Concurrent lookups for the same device coalesce into one query."""
+    device_id = str(uuid4())
+
+    async def slow_query(*_args, **_kwargs):
+        await asyncio.sleep(0.05)
+        return mock_device_data
+
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        side_effect=slow_query,
+    ) as mock_query:
+        nb = NautobotClient()
+        results = await asyncio.gather(*(nb.get_device_data(device_id) for _ in range(10)))
+
+        assert all(r == results[0] for r in results)
+        mock_query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_not_found_does_not_trip_breaker(mock_not_found_data):
+    """A device that legitimately has no data is not a Nautobot health failure."""
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        new_callable=AsyncMock,
+        return_value=mock_not_found_data,
+    ):
+        nb = NautobotClient()
+        nb._breaker_threshold = 3
+        for _ in range(5):
+            with pytest.raises(NotFoundError):
+                await nb.get_device_data(str(uuid4()))
+        assert nb._consecutive_failures == 0
+        assert nb._breaker_open_until == 0.0
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_opens_on_transient_failures():
+    """Repeated Nautobot errors open the breaker, then it fails fast."""
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        new_callable=AsyncMock,
+        side_effect=aiohttp.ClientError("boom"),
+    ) as mock_query:
+        nb = NautobotClient()
+        nb._breaker_threshold = 3
+
+        for _ in range(3):
+            with pytest.raises(aiohttp.ClientError):
+                await nb.get_device_data(str(uuid4()))
+
+        assert mock_query.await_count == 3
+
+        # Breaker now open: fails fast without hitting Nautobot again.
+        with pytest.raises(NautobotUnavailableError):
+            await nb.get_device_data(str(uuid4()))
+        assert mock_query.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_concurrency_limit_sheds_load(mock_device_data):
+    """When all slots are held, a new caller fails fast with 503-worthy error."""
+
+    async def never_returns(*_args, **_kwargs):
+        await asyncio.sleep(10)
+        return mock_device_data
+
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        side_effect=never_returns,
+    ):
+        nb = NautobotClient()
+        # Saturate the single slot and make acquisition give up immediately.
+        nb._semaphore = asyncio.Semaphore(1)
+        nb._acquire_timeout = 0.05
+
+        holder = asyncio.ensure_future(nb.get_device_data(str(uuid4())))
+        await asyncio.sleep(0.01)  # let the holder grab the only slot
+        try:
+            with pytest.raises(NautobotUnavailableError):
+                await nb.get_device_data(str(uuid4()))
+        finally:
+            holder.cancel()

--- a/src/tests/ztp/test_nautobot.py
+++ b/src/tests/ztp/test_nautobot.py
@@ -104,6 +104,45 @@ async def test_not_found_does_not_trip_breaker(mock_not_found_data):
 
 
 @pytest.mark.asyncio
+async def test_transient_error_retried_then_succeeds(mock_device_data):
+    """A transient failure is retried; a healthy second attempt succeeds."""
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        new_callable=AsyncMock,
+        side_effect=[aiohttp.ClientError("blip"), mock_device_data],
+    ) as mock_query:
+        nb = NautobotClient()
+        nb._retry_backoff = 0.0
+
+        data = await nb.get_device_data(str(uuid4()))
+
+        assert data.id == "80ce0a9a-d3c8-5b8e-b755-e9c16d92237b"
+        assert mock_query.await_count == 2
+        # A retried-then-successful call must not count against the breaker.
+        assert nb._consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_transient_exhaustion_raises_503_not_500():
+    """When every attempt is transient, the caller gets a 503-worthy error
+    (NautobotUnavailableError), not the raw timeout that would become a 500."""
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        new_callable=AsyncMock,
+        side_effect=TimeoutError("stuck"),
+    ) as mock_query:
+        nb = NautobotClient()
+        nb._retry_backoff = 0.0
+
+        with pytest.raises(NautobotUnavailableError):
+            await nb.get_device_data(str(uuid4()))
+
+        # Attempted request_max_attempts times, then gave up as one failure.
+        assert mock_query.await_count == nb._max_attempts
+        assert nb._consecutive_failures == 1
+
+
+@pytest.mark.asyncio
 async def test_circuit_breaker_opens_on_transient_failures():
     """Repeated Nautobot errors open the breaker, then it fails fast."""
     with patch(
@@ -113,17 +152,20 @@ async def test_circuit_breaker_opens_on_transient_failures():
     ) as mock_query:
         nb = NautobotClient()
         nb._breaker_threshold = 3
+        nb._retry_backoff = 0.0
 
+        # Each call retries internally, then surfaces a 503-worthy error and
+        # records exactly one breaker failure.
         for _ in range(3):
-            with pytest.raises(aiohttp.ClientError):
+            with pytest.raises(NautobotUnavailableError):
                 await nb.get_device_data(str(uuid4()))
 
-        assert mock_query.await_count == 3
+        assert mock_query.await_count == 3 * nb._max_attempts
 
         # Breaker now open: fails fast without hitting Nautobot again.
         with pytest.raises(NautobotUnavailableError):
             await nb.get_device_data(str(uuid4()))
-        assert mock_query.await_count == 3
+        assert mock_query.await_count == 3 * nb._max_attempts
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Makes the ZTP service degrade gracefully when Nautobot is slow or flapping (e.g. during a boot storm or a Nautobot rolling update) instead of crashlooping and amplifying load on a struggling Nautobot.

Motivated by load-testing in a QA environment, where sustained ZTP load / a Nautobot rollout drove the ZTP pods into `CrashLoopBackOff`. Root causes:
- **1s-default liveness probe** killed pods whenever the event loop stalled — a slow *dependency* became a *process* death.
- **A fresh Nautobot client per request** meant no keepalive reuse and, because the connection cap is per-session, **no global bound** on concurrent connections to Nautobot.
- **30s timeout + unbounded in-flight** requests let the loop pile up thousands of parked coroutines.
- **Read amplification**: each boot re-ran the heavy `config_manager_device` query ~2N times (authorize + handler + N configlets).

## Changes

- **Helm (`deploy/helm/templates/ztp.yaml`)**: split liveness/readiness and add a `startupProbe` for the `http-api`/`http-lb` containers. Liveness is now lenient (`timeoutSeconds: 5`, `periodSeconds: 15`, `failureThreshold: 6`) so a slow downstream degrades instead of crashlooping; traffic shedding is handled in-app.
- **Shared Nautobot client** (`ztp/api/clients.py`, wired through `device_v1.py` + `main.py` lifespan): one process-wide client with a bounded connection pool → keepalive reuse and a real global connection cap.
- **Backpressure + fail fast** (`ztp/nautobot.py`): a concurrency semaphore and a shorter request timeout (8s vs 30s). When saturated (or when the breaker is open) it raises `NautobotUnavailableError`, surfaced as **HTTP 503 + `Retry-After`** so devices/ONIE retry.
- **Cache + single-flight** (`ztp/nautobot.py`): short-TTL device-data cache with request coalescing collapses the per-boot `config_manager_device` amplification to ~1 query/device/window.
- **Circuit breaker** (`ztp/nautobot.py`): fails fast for a cooldown after consecutive *transient* failures (timeouts/connection/5xx), excluding logical 404s.

All tunables read from the `[nautobot]` INI section with safe fallbacks — **no config change required** to deploy.

> Note: this is a single commit for now; happy to split the Helm probe change from the app-code change if reviewers prefer.

## Test plan

- [x] `uv run ruff check` + `uv run mypy` clean on touched files
- [x] `uv run pytest src/tests/ztp` — 90 passed
- [x] `helm template test . --values values-ci.yaml` renders the new probes
- [x] New unit tests: cache hit, single-flight coalescing, breaker open/fast-fail, 404 doesn't trip breaker, concurrency load-shedding, API 503 path
- [ ] Deploy to a QA environment and re-run the boot-storm sweep to confirm no ZTP crashloop and reduced Nautobot query volume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable API worker counts, defaulting to four workers.
  * Added startup, liveness, and readiness health checks for deployment components.
* **Reliability Improvements**
  * Improved handling of temporary backend outages with automatic retries and clearer service-unavailable responses.
  * Reused backend connections to improve performance and resource usage.
  * Added caching and concurrency controls for device information requests.
* **Configuration**
  * Added timeout, connection-limit, and worker-count settings for improved operational control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->