### PR TITLE
Update helm chart to support image digests

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -289,6 +289,47 @@ jobs:
               if (sc == 0 || sc != ok) exit 1
             }
           ' /tmp/nvcm-probes.yaml
+      - name: Image digest pin render
+        run: |
+          # global.images.<name>.digest must pin built-service images by digest
+          # (repository@sha256:...) and win over the tag; an unset digest must
+          # fall back to repository:tag. Render-time check only (no cluster) so
+          # it stays out of the slow kind-integration path.
+          set -euo pipefail
+          names="nvConfigManager nvConfigManagerUi kea keaAdmin nautobot natsReady"
+          d_nvConfigManager=sha256:1111111111111111111111111111111111111111111111111111111111111111
+          d_nvConfigManagerUi=sha256:2222222222222222222222222222222222222222222222222222222222222222
+          d_kea=sha256:3333333333333333333333333333333333333333333333333333333333333333
+          d_keaAdmin=sha256:4444444444444444444444444444444444444444444444444444444444444444
+          d_nautobot=sha256:5555555555555555555555555555555555555555555555555555555555555555
+          d_natsReady=sha256:6666666666666666666666666666666666666666666666666666666666666666
+
+          # Default render (no digests set) must not pin any image by digest.
+          helm template test deploy/helm/ --values deploy/helm/values-ci.yaml >/tmp/nvcm-nodigest.yaml
+          if grep -Eq 'image:[[:space:]]*"?[^"[:space:]]+@sha256:' /tmp/nvcm-nodigest.yaml; then
+            echo "ERROR: an image rendered with a digest even though none was set"
+            exit 1
+          fi
+
+          # With a digest per built image, each must render as repository@<digest>.
+          set_args=""
+          for n in $names; do
+            eval "digest=\$d_$n"
+            set_args="$set_args --set-string global.images.$n.digest=$digest"
+          done
+          # shellcheck disable=SC2086
+          helm template test deploy/helm/ --values deploy/helm/values-ci.yaml $set_args >/tmp/nvcm-digest.yaml
+
+          fail=0
+          for n in $names; do
+            eval "digest=\$d_$n"
+            if ! grep -qF "@$digest" /tmp/nvcm-digest.yaml; then
+              echo "ERROR: $n not pinned by its digest ($digest) in the render"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
+          echo "All 6 built-service images pinned by digest; unset digests fall back to tag"
 
   openapi:
     name: OpenAPI And Go Bindings Check

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -297,6 +297,18 @@ jobs:
           # it stays out of the slow kind-integration path.
           set -euo pipefail
           names="nvConfigManager nvConfigManagerUi kea keaAdmin nautobot natsReady"
+          r_nvConfigManager=registry.ci.example/nvcm/main
+          r_nvConfigManagerUi=registry.ci.example/nvcm/ui
+          r_kea=registry.ci.example/nvcm/kea
+          r_keaAdmin=registry.ci.example/nvcm/kea-admin
+          r_nautobot=registry.ci.example/nvcm/nautobot
+          r_natsReady=registry.ci.example/nvcm/nats-ready
+          t_nvConfigManager=9.0.1-nvcm
+          t_nvConfigManagerUi=9.0.1-ui
+          t_kea=9.0.1-kea
+          t_keaAdmin=9.0.1-kea-admin
+          t_nautobot=9.0.1-nautobot
+          t_natsReady=9.0.1-nats-ready
           d_nvConfigManager=sha256:1111111111111111111111111111111111111111111111111111111111111111
           d_nvConfigManagerUi=sha256:2222222222222222222222222222222222222222222222222222222222222222
           d_kea=sha256:3333333333333333333333333333333333333333333333333333333333333333
@@ -304,32 +316,57 @@ jobs:
           d_nautobot=sha256:5555555555555555555555555555555555555555555555555555555555555555
           d_natsReady=sha256:6666666666666666666666666666666666666666666666666666666666666666
 
-          # Default render (no digests set) must not pin any image by digest.
-          helm template test deploy/helm/ --values deploy/helm/values-ci.yaml >/tmp/nvcm-nodigest.yaml
+          base_set_args=""
+          for n in $names; do
+            eval "repo=\$r_$n"
+            eval "tag=\$t_$n"
+            base_set_args="$base_set_args --set-string global.images.$n.repository=$repo"
+            base_set_args="$base_set_args --set-string global.images.$n.tag=$tag"
+          done
+
+          # Default render: each service must render its seeded repository:tag.
+          # shellcheck disable=SC2086
+          helm template test deploy/helm/ --values deploy/helm/values-ci.yaml $base_set_args >/tmp/nvcm-nodigest.yaml
           if grep -Eq 'image:[[:space:]]*"?[^"[:space:]]+@sha256:' /tmp/nvcm-nodigest.yaml; then
             echo "ERROR: an image rendered with a digest even though none was set"
             exit 1
           fi
-
-          # With a digest per built image, each must render as repository@<digest>.
-          set_args=""
-          for n in $names; do
-            eval "digest=\$d_$n"
-            set_args="$set_args --set-string global.images.$n.digest=$digest"
-          done
-          # shellcheck disable=SC2086
-          helm template test deploy/helm/ --values deploy/helm/values-ci.yaml $set_args >/tmp/nvcm-digest.yaml
-
           fail=0
           for n in $names; do
-            eval "digest=\$d_$n"
-            if ! grep -qF "@$digest" /tmp/nvcm-digest.yaml; then
-              echo "ERROR: $n not pinned by its digest ($digest) in the render"
+            eval "repo=\$r_$n"
+            eval "tag=\$t_$n"
+            expected="${repo}:${tag}"
+            if ! grep -qF "$expected" /tmp/nvcm-nodigest.yaml; then
+              echo "ERROR: $n missing expected tag reference $expected in default render"
               fail=1
             fi
           done
           [ "$fail" -eq 0 ] || exit 1
-          echo "All 6 built-service images pinned by digest; unset digests fall back to tag"
+
+          # Digest render: each service must render its seeded repository@digest.
+          digest_set_args="$base_set_args"
+          for n in $names; do
+            eval "digest=\$d_$n"
+            digest_set_args="$digest_set_args --set-string global.images.$n.digest=$digest"
+          done
+          # shellcheck disable=SC2086
+          helm template test deploy/helm/ --values deploy/helm/values-ci.yaml $digest_set_args >/tmp/nvcm-digest.yaml
+          for n in $names; do
+            eval "repo=\$r_$n"
+            eval "tag=\$t_$n"
+            eval "digest=\$d_$n"
+            expected="${repo}@${digest}"
+            if ! grep -qF "$expected" /tmp/nvcm-digest.yaml; then
+              echo "ERROR: $n missing expected digest reference $expected in digest render"
+              fail=1
+            fi
+            if grep -qF "${repo}:${tag}" /tmp/nvcm-digest.yaml; then
+              echo "ERROR: $n still renders tag reference ${repo}:${tag} when digest is set"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
+          echo "All 6 built-service images render exact repository:tag or repository@digest references"
 
   openapi:
     name: OpenAPI And Go Bindings Check

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -33,6 +33,21 @@ tree has only one version to maintain.
 {{- end }}
 
 {{/*
+Resolve a full NVIDIA Config Manager image reference. A digest pin
+(sha256:<hex>, set by deploy automation) takes precedence over any tag and
+renders repository@digest; otherwise fall back to repository:tag with the
+imageTag chart-version fallback. Takes the same dict as imageTag:
+(dict "root" . "image" .Values.global.images.<name>)
+*/}}
+{{- define "nv-config-manager.image" -}}
+{{- if .image.digest -}}
+{{- .image.repository }}@{{ .image.digest -}}
+{{- else -}}
+{{- .image.repository }}:{{ include "nv-config-manager.imageTag" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "nv-config-manager.selectorLabels" -}}

--- a/deploy/helm/templates/config-store.yaml
+++ b/deploy/helm/templates/config-store.yaml
@@ -50,7 +50,7 @@ spec:
       {{- include "nv-config-manager.waitForRedis" . | nindent 6 }}
       containers:
       - name: api
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-config-store-api"]
@@ -169,7 +169,7 @@ spec:
           echo "Config-store postgres is ready"
       containers:
       - name: db-init
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         workingDir: /code/nv-config-manager
@@ -233,7 +233,7 @@ spec:
       {{- include "nv-config-manager.waitForNautobot" . | nindent 6 }}
       containers:
       - name: cache-refresh
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-config-store-cache-refresh"]

--- a/deploy/helm/templates/dhcp.yaml
+++ b/deploy/helm/templates/dhcp.yaml
@@ -50,7 +50,7 @@ spec:
       #   3. If exists: checks for upgrades and exits
       #   4. If not exists: runs kea-admin db-init to create schema
       - name: init-schema
-        image: "{{ .Values.global.images.keaAdmin.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.keaAdmin) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.keaAdmin) }}"
         imagePullPolicy: {{ .Values.global.images.keaAdmin.pullPolicy }}
         env:
         - name: INI_FILE
@@ -67,7 +67,7 @@ spec:
       containers:
       # Kea DHCP server container
       - name: kea
-        image: "{{ .Values.global.images.kea.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.kea) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.kea) }}"
         imagePullPolicy: {{ .Values.global.images.kea.pullPolicy }}
         env:
         - name: NV_CONFIG_MANAGER_INI
@@ -101,7 +101,7 @@ spec:
         {{- include "nv-config-manager.vaultAgent.configManagerIniFileMountEtcVault" . | nindent 8 }}
       # Healthcheck container for external NLB
       - name: healthcheck
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-dhcp-api"]
@@ -135,7 +135,7 @@ spec:
         {{- include "nv-config-manager.vaultAgent.configManagerSecretsDirEtcVault" . | nindent 8 }}
       # API container
       - name: api
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-dhcp-api"]
@@ -174,7 +174,7 @@ spec:
         {{- include "nv-config-manager.authVolumeMounts" . | nindent 8 }}
       # Config sync container
       - name: config-sync-v4
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-dhcp-confgen", "sync-kea-configuration", "--ip-version", "4", "--refresh-interval", "10"]
@@ -263,7 +263,7 @@ spec:
       {{- include "nv-config-manager.waitForNautobot" . | nindent 6 }}
       containers:
       - name: config-refresh-v4
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-dhcp-confgen", "refresh-kea-configuration", "--ip-version", "4", "--refresh-interval", "300"]

--- a/deploy/helm/templates/mcp.yaml
+++ b/deploy/helm/templates/mcp.yaml
@@ -44,7 +44,7 @@ spec:
       {{- include "nv-config-manager.podSecurityContext" . | nindent 6 }}
       containers:
       - name: api
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nvidia-config-manager-mcp"]

--- a/deploy/helm/templates/nautobot.yaml
+++ b/deploy/helm/templates/nautobot.yaml
@@ -269,7 +269,7 @@ spec:
         # Use nats-ready binary for production (streams have 20GB max_bytes)
         # Note: Production nats-ready creates both streams using nv-config-manager account
         # For local dev, we use nats CLI which creates streams in each account
-        image: {{ .Values.global.images.natsReady.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.natsReady) }}
+        image: {{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.natsReady) }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.global.images.natsReady.pullPolicy }}
         command: ["/nats-ready"]
         args: ["--address", "nats://$(NATS_USER):$(NATS_PASSWORD)@{{ $natsName }}:4222"]
@@ -511,7 +511,7 @@ spec:
         # IMPORTANT: Lock is held by a single Python process for the entire duration
         # to prevent the session-level advisory lock from being released on disconnect.
         - name: run-migrations
-          image: {{ .Values.global.images.nautobot.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nautobot) }}
+          image: {{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nautobot) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.global.images.nautobot.pullPolicy }}
           # Use the migration runner script (distroless-compatible, no shell needed)
           command: ["python", "/opt/nautobot/jobs/nv_config_manager_jobs/migration_runner.py"]
@@ -586,7 +586,7 @@ spec:
             {{- toYaml $migrationResources | nindent 12 }}
       containers:
         - name: nautobot
-          image: {{ .Values.global.images.nautobot.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nautobot) }}
+          image: {{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nautobot) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.global.images.nautobot.pullPolicy }}
           command:
             - nautobot-server
@@ -866,7 +866,7 @@ spec:
         {{- include "nv-config-manager.waitForNautobot" . | nindent 8 }}
       containers:
         - name: celery
-          image: {{ .Values.global.images.nautobot.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nautobot) }}
+          image: {{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nautobot) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.global.images.nautobot.pullPolicy }}
           command:
             - nautobot-server
@@ -1001,7 +1001,7 @@ spec:
         {{- include "nv-config-manager.waitForNautobot" . | nindent 8 }}
       containers:
         - name: celery-beat
-          image: {{ .Values.global.images.nautobot.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nautobot) }}
+          image: {{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nautobot) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.global.images.nautobot.pullPolicy }}
           command: ["nautobot-server", "celery", "beat", "--loglevel", "INFO"]
           {{- include "nv-config-manager.containerSecurityContext" . | nindent 10 }}

--- a/deploy/helm/templates/render-service.yaml
+++ b/deploy/helm/templates/render-service.yaml
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       containers:
       - name: api
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-render-api"]
@@ -185,7 +185,7 @@ spec:
       {{- end }}
       containers:
       - name: consumer
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-render-consumer"]
@@ -292,7 +292,7 @@ spec:
       {{- end }}
       containers:
       - name: consumer
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-render-consumer"]
@@ -400,7 +400,7 @@ spec:
       {{- end }}
       containers:
       - name: template-updater
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         command: ["nv-config-manager-render-template-updater"]

--- a/deploy/helm/templates/temporal.yaml
+++ b/deploy/helm/templates/temporal.yaml
@@ -403,7 +403,7 @@ spec:
             memory: 64Mi
       containers:
       - name: worker
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         command: ["nv-config-manager-temporal-worker"]
         args: []
@@ -495,7 +495,7 @@ spec:
       {{- end }}
       containers:
       - name: api
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         command: ["nv-config-manager-temporal-api"]
         args: []
@@ -615,7 +615,7 @@ spec:
       {{- include "nv-config-manager.waitForTemporalNamespace" . | nindent 6 }}
       containers:
       - name: scheduler
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         command: ["nv-config-manager-temporal-scheduler"]
         env:
@@ -687,7 +687,7 @@ spec:
       {{- end }}
       containers:
       - name: archive
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         command: ["nv-config-manager-temporal-archive"]
         args: ["-v"]

--- a/deploy/helm/templates/ui.yaml
+++ b/deploy/helm/templates/ui.yaml
@@ -44,7 +44,7 @@ spec:
       {{- include "nv-config-manager.podSecurityContext" . | nindent 6 }}
       containers:
       - name: ui
-        image: "{{ .Values.global.images.nvConfigManagerUi.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManagerUi) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManagerUi) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManagerUi.pullPolicy }}
         command: ["node", "server.js"]
         env:

--- a/deploy/helm/templates/ztp.yaml
+++ b/deploy/helm/templates/ztp.yaml
@@ -51,7 +51,7 @@ spec:
       # ACCEPT_REQUEST_HEADERS=true allows SSO/mTLS header-based authorization
       # Mounts os-images read-write so uploads can write files and update manifest.json
       - name: http-api
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         {{- include "nv-config-manager.networkZtpEntrypoint" (dict "root" . "command" (list "nv-config-manager-ztp-api") "args" (list)) | nindent 8 }}
@@ -93,7 +93,7 @@ spec:
       # No ACCEPT_REQUEST_HEADERS - uses client IP validation against Nautobot device addresses
       {{- if or .Values.networkZtp.ingress.nlb .Values.networkZtp.ingress.cilium .Values.networkZtp.ingress.metallb }}
       - name: http-lb
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         {{- include "nv-config-manager.networkZtpEntrypoint" (dict "root" . "command" (list "nv-config-manager-ztp-api") "args" (list "--port" "8000")) | nindent 8 }}
@@ -130,7 +130,7 @@ spec:
 
       # SFTP server container
       - name: sftp
-        image: "{{ .Values.global.images.nvConfigManager.repository }}:{{ include "nv-config-manager.imageTag" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
+        image: "{{ include "nv-config-manager.image" (dict "root" . "image" .Values.global.images.nvConfigManager) }}"
         imagePullPolicy: {{ .Values.global.images.nvConfigManager.pullPolicy }}
         {{- include "nv-config-manager.containerSecurityContext" . | nindent 8 }}
         {{- include "nv-config-manager.networkZtpEntrypoint" (dict "root" . "command" (list "nv-config-manager-ztp-sftp" "--host" "0.0.0.0" "--port" "2222" "--level" "INFO")) | nindent 8 }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -82,32 +82,42 @@ global:
   # NVIDIA registry path when public publishing is enabled.
   # Service image tags are optional. When omitted, templates use appVersion if
   # a pipeline supplies it, otherwise the chart version.
+  # Service images also accept an optional content-addressed pin
+  # (digest: "sha256:<hex>"). When set it takes precedence over tag and the
+  # chart-version fallback (rendering repository@digest). Digests are written
+  # by deploy automation; leave empty in checked-in values.
   # ---------------------------------------------------------------------------
   images:
     # Main NVIDIA Config Manager Python services image (render, ztp, dhcp, temporal, config-store)
     nvConfigManager:
       repository: registry.example.com/nvidia/nv-config-manager
       pullPolicy: Always
+      digest: ""
     # NVIDIA Config Manager UI (React/Next.js - workflows + config-store)
     nvConfigManagerUi:
       repository: registry.example.com/nvidia/nv-config-manager-ui
       pullPolicy: Always
+      digest: ""
     # Kea DHCP server
     kea:
       repository: registry.example.com/nvidia/nv-config-manager-kea
       pullPolicy: Always
+      digest: ""
     # Kea database admin (for schema initialization)
     keaAdmin:
       repository: registry.example.com/nvidia/nv-config-manager-kea-admin
       pullPolicy: Always
+      digest: ""
     # Nautobot with NVIDIA Config Manager plugins
     nautobot:
       repository: registry.example.com/nvidia/nv-config-manager-nautobot
       pullPolicy: Always
+      digest: ""
     # NATS streams initializer
     natsReady:
       repository: registry.example.com/nvidia/nv-config-manager-nats-ready
       pullPolicy: Always
+      digest: ""
     httpEcho:
       repository: hashicorp/http-echo
       tag: "1.0"


### PR DESCRIPTION
## Description

Adds optional content-addressed image pinning to the Helm chart. Introduces a `nv-config-manager.image` template helper that renders `repository@sha256:...` when a `digest` is set on an image, and otherwise falls back to the existing `repository:tag` behavior (with the current `imageTag` chart-version fallback unchanged).

- New helper `nv-config-manager.image` in `templates/_helpers.tpl`; digest takes precedence over tag, and an empty `digest: ""` is falsy so it is a no-op.
- Converts the `image:` references for the **6 built service images** (`nvConfigManager`, `nvConfigManagerUi`, `kea`, `keaAdmin`, `nautobot`, `natsReady`) to use the helper. Third-party images (busybox, redis, nats, temporal*, kubectl, etc.), oauth2-proxy, the spiffe/nginx sidecars, and render template plugins are intentionally left as-is — they are version-pinned by hand, not by the release pipeline.
- Adds a commented `digest: ""` default to those 6 images in `values.yaml`.
- `ui.yaml`'s `APP_VERSION` env var intentionally stays on `imageTag` so the UI's `/api/config` and `/api/health` continue to report a human-readable version rather than a digest.
- Adds an `Image digest pin render` step to the existing `helm` job in `public-ci.yml` that exercises both paths (unset digest → tag; set digest → `@sha256:...`).

This is groundwork for a GitOps deploy flow that pins images by digest; it has no effect until a caller sets a digest (e.g. via `--set global.images.<name>.digest=...` or a values override), so it is safe to merge independently.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

Covered by CI: the `Image digest pin render` step in the `helm` job asserts (a) a default render pins no image by digest — the tag fallback still applies — and (b) setting a digest on each of the 6 built services renders it as `repository@sha256:...`. Reproduce locally:

```bash
# 1) Byte-identical render when no digest is set (adoption safety).
#    Rendered against real test values and diffed against the
#    pre-change chart — no differences.
helm template nv-config-manager deploy/helm -f <test values> > after.yaml
diff before.yaml after.yaml        # empty

# 2) Digest wins when set.
helm template nv-config-manager deploy/helm -f <test values> \
  --set global.images.nvConfigManager.digest=sha256:aaaa... \
  --set global.images.kea.digest=sha256:bbbb... \
  | grep 'image:'
#   -> registry.example.com/nvidia/nv-config-manager@sha256:aaaa...
#   -> registry.example.com/nvidia/nv-config-manager-kea@sha256:bbbb...

# 3) Lint clean.
helm lint deploy/helm -f <test values>
```
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`11b460eba1c5`](https://github.com/NVIDIA/nv-config-manager/actions/runs/29362683540).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added support for pinning container images by digest, improving deployment consistency.
  - Updated Config Store, DHCP, MCP, Nautobot, Render Service, Temporal, UI, and ZTP components to resolve images via a shared, consistent image reference helper.
  - When a digest is configured, it takes precedence over tag-based image selection; tag fallback remains available.
- **Tests / CI**
  - Enhanced public CI with a render-time check to verify digest pinning behavior and ensure tag references are not used when digests are set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->