### PR TITLE
Add secret-free build stage for untrusted PRs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,3 +9,4 @@ include:
   - local: .gitlab/ci/deploy.yml
   - local: .gitlab/ci/release.yml
   - local: .gitlab/ci/airgapped.yml
+  - local: .gitlab/ci/pr-build.yml

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -19,6 +19,10 @@ stages:
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    # Vetted copy-pr-bot refs may run only deliberately triggered pipelines
+    # (the test-env promote flow builds untrusted PR code here without
+    # secrets). Mirror pushes to these refs never create pipelines.
+    - if: $CI_COMMIT_BRANCH =~ /^pull-request\// && ($CI_PIPELINE_SOURCE == "pipeline" || $CI_PIPELINE_SOURCE == "trigger" || $CI_PIPELINE_SOURCE == "api" || $CI_PIPELINE_SOURCE == "web")
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
       when: never
     - if: $CI_COMMIT_BRANCH

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -19,10 +19,14 @@ stages:
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    # Vetted copy-pr-bot refs may run only deliberately triggered pipelines
+    # Vetted copy-pr-bot refs may run ONLY deliberately triggered pipelines
     # (the test-env promote flow builds untrusted PR code here without
-    # secrets). Mirror pushes to these refs never create pipelines.
+    # secrets). Allow the whitelisted sources, then reject every other source
+    # on these refs (schedule, parent_pipeline, push, ...) so the generic
+    # branch fallback below cannot admit them.
     - if: $CI_COMMIT_BRANCH =~ /^pull-request\// && ($CI_PIPELINE_SOURCE == "pipeline" || $CI_PIPELINE_SOURCE == "trigger" || $CI_PIPELINE_SOURCE == "api" || $CI_PIPELINE_SOURCE == "web")
+    - if: $CI_COMMIT_BRANCH =~ /^pull-request\//
+      when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
       when: never
     - if: $CI_COMMIT_BRANCH

--- a/.gitlab/ci/pr-build.yml
+++ b/.gitlab/ci/pr-build.yml
@@ -45,9 +45,6 @@ pr-build-image:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
     DOCKER_DRIVER: overlay2
-    # Untrusted stage: no outbound GitHub calls (rate-limit-prone, and the
-    # authoritative freshness/provenance checks live in the promote consumer).
-    NVCM_PR_GUARD_SKIP_GITHUB: "1"
   rules: *pr-build-rules
   parallel:
     matrix:
@@ -117,9 +114,6 @@ pr-build-chart:
     - docker
   needs: []
   image: $NVCM_CI_IMAGE_ALPINE
-  variables:
-    # Untrusted stage: no outbound GitHub calls (see pr-build-image).
-    NVCM_PR_GUARD_SKIP_GITHUB: "1"
   rules: *pr-build-rules
   before_script:
     - apk add -q bash git curl helm yq

--- a/.gitlab/ci/pr-build.yml
+++ b/.gitlab/ci/pr-build.yml
@@ -62,6 +62,12 @@ pr-build-image:
         NVCM_PR_IMAGE: nv-config-manager-nautobot
       - NVCM_PR_TARGET: nats-ready
         NVCM_PR_IMAGE: nv-config-manager-nats-ready
+      - NVCM_PR_TARGET: temporal-server
+        NVCM_PR_IMAGE: nv-config-manager-temporal
+      - NVCM_PR_TARGET: temporal-bootstrap
+        NVCM_PR_IMAGE: nv-config-manager-temporal-bootstrap
+      - NVCM_PR_TARGET: temporal-ui
+        NVCM_PR_IMAGE: nv-config-manager-temporal-ui
   before_script:
     - apk add -q make bash git curl coreutils
     - docker info

--- a/.gitlab/ci/pr-build.yml
+++ b/.gitlab/ci/pr-build.yml
@@ -31,8 +31,6 @@
 # uploads, and lets the promote side download by job id.
 pr-build-image:
   stage: build
-  # Restricted, isolated runners for untrusted PR builds (no privileged access
-  # to the internal DCA fleet). Protected promote jobs stay on the dca runners.
   tags:
     - dgxc-corp-restricted
     - docker

--- a/.gitlab/ci/pr-build.yml
+++ b/.gitlab/ci/pr-build.yml
@@ -31,10 +31,12 @@
 # uploads, and lets the promote side download by job id.
 pr-build-image:
   stage: build
+  # Restricted, isolated runners for untrusted PR builds (no privileged access
+  # to the internal DCA fleet). Protected promote jobs stay on the dca runners.
   tags:
-    - dca
-    - linux/amd64
+    - dgxc-corp-restricted
     - docker
+    - linux/amd64
   needs: []
   image: $NVCM_CI_IMAGE_DOCKER
   services:
@@ -108,10 +110,12 @@ pr-build-image:
 # from PR source.
 pr-build-chart:
   stage: build
+  # Restricted, isolated runners for untrusted PR builds (no privileged access
+  # to the internal DCA fleet). Protected promote jobs stay on the dca runners.
   tags:
-    - dca
-    - linux/amd64
+    - dgxc-corp-restricted
     - docker
+    - linux/amd64
   needs: []
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *pr-build-rules

--- a/.gitlab/ci/pr-build.yml
+++ b/.gitlab/ci/pr-build.yml
@@ -45,6 +45,9 @@ pr-build-image:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
     DOCKER_DRIVER: overlay2
+    # Untrusted stage: no outbound GitHub calls (rate-limit-prone, and the
+    # authoritative freshness/provenance checks live in the promote consumer).
+    NVCM_PR_GUARD_SKIP_GITHUB: "1"
   rules: *pr-build-rules
   parallel:
     matrix:
@@ -114,6 +117,9 @@ pr-build-chart:
     - docker
   needs: []
   image: $NVCM_CI_IMAGE_ALPINE
+  variables:
+    # Untrusted stage: no outbound GitHub calls (see pr-build-image).
+    NVCM_PR_GUARD_SKIP_GITHUB: "1"
   rules: *pr-build-rules
   before_script:
     - apk add -q bash git curl helm yq

--- a/.gitlab/ci/pr-build.yml
+++ b/.gitlab/ci/pr-build.yml
@@ -1,0 +1,144 @@
+---
+# =============================================================================
+# Untrusted PR build (test-env promote flow, stage 1 of 2)
+# =============================================================================
+# Builds the service images from a copy-pr-bot pull-request/<n> ref of the
+# mirror and hands them to the protected promote pipeline as job artifacts.
+#
+# SECURITY MODEL: this pipeline executes untrusted PR code (vetted only by
+# copy-pr-bot's trustee/"/ok to test" gate), so it must run WITHOUT secrets:
+#   - it only runs on pull-request/* refs, which are unprotected, so GitLab
+#     withholds all Protected variables (registry tokens, push tokens, ...)
+#   - it never logs in to a registry and never pushes; images are written to
+#     local tarballs via DOCKER_BUILD_OUTPUT and uploaded as job artifacts
+#   - it is created only by a deliberate trigger (the promote pipeline's API
+#     call, or a manual run) - mirror pushes never start it (see the
+#     workflow rules in common.yml)
+# The protected promote pipeline (promote-test-envs.yml) downloads the
+# artifacts, retags, pushes, and captures digests with credentials that this
+# pipeline never sees.
+#
+# amd64 only: the shared test envs deploy amd64, matching the existing
+# deploy-to-test flow's ${CI_COMMIT_SHORT_SHA}-amd64 convention.
+# =============================================================================
+
+.pr-build-rules: &pr-build-rules
+  - if: $CI_COMMIT_BRANCH =~ /^pull-request\// && ($CI_PIPELINE_SOURCE == "pipeline" || $CI_PIPELINE_SOURCE == "trigger" || $CI_PIPELINE_SOURCE == "api" || $CI_PIPELINE_SOURCE == "web")
+    when: always
+  - when: never
+
+# One job per image: bounds each artifact's size, parallelizes the builds and
+# uploads, and lets the promote side download by job id.
+pr-build-image:
+  stage: build
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  needs: []
+  image: $NVCM_CI_IMAGE_DOCKER
+  services:
+    - name: $NVCM_CI_IMAGE_DOCKER_DIND
+      alias: docker
+      command: ["--tls=false"]
+  variables:
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_TLS_CERTDIR: ""
+    DOCKER_DRIVER: overlay2
+  rules: *pr-build-rules
+  parallel:
+    matrix:
+      - NVCM_PR_TARGET: nv-config-manager
+        NVCM_PR_IMAGE: nv-config-manager
+      - NVCM_PR_TARGET: kea
+        NVCM_PR_IMAGE: nv-config-manager-kea
+      - NVCM_PR_TARGET: kea-admin
+        NVCM_PR_IMAGE: nv-config-manager-kea-admin
+      - NVCM_PR_TARGET: ui
+        NVCM_PR_IMAGE: nv-config-manager-ui
+      - NVCM_PR_TARGET: nb
+        NVCM_PR_IMAGE: nv-config-manager-nautobot
+      - NVCM_PR_TARGET: nats-ready
+        NVCM_PR_IMAGE: nv-config-manager-nats-ready
+  before_script:
+    - apk add -q make bash git curl coreutils
+    - docker info
+    # Fail fast if the PR moved or closed while this pipeline was queued.
+    - bash .gitlab/ci/scripts/pr_ref_guard.sh
+    # TEMPLATE_ENGINE_VERSION derivation matches .docker-build-native-template
+    # (build.yml), minus the registry login that template performs.
+    - git fetch --tags --force
+    - |
+      latest_release_tag="$(git tag --list | grep -E '^[v]?[0-9]+\.[0-9]+\.[0-9]+(-rc\.?[0-9]+)?$' | sort -V | tail -n 1)"
+      if [ -z "$latest_release_tag" ]; then
+        echo "No release tag found for TEMPLATE_ENGINE_VERSION"
+        exit 1
+      fi
+      template_engine_base="${latest_release_tag#v}"
+      template_engine_base="${template_engine_base/-rc./rc}"
+      template_engine_base="${template_engine_base/-rc/rc}"
+      export TEMPLATE_ENGINE_VERSION="${template_engine_base}+g${CI_COMMIT_SHORT_SHA}"
+      echo "Template engine version: ${TEMPLATE_ENGINE_VERSION}"
+  script:
+    - mkdir -p images
+    - make docker-buildx-setup-native
+    - >
+      make docker-build-single-${NVCM_PR_TARGET}
+      PLATFORM=linux/amd64
+      VERSION=${CI_COMMIT_SHORT_SHA}
+      REGISTRY=pr-local
+      TEMPLATE_ENGINE_VERSION="${TEMPLATE_ENGINE_VERSION}"
+      DOCKER_BUILD_OUTPUT="--output type=docker,dest=${CI_PROJECT_DIR}/images/${NVCM_PR_IMAGE}.tar"
+    # Artifact zip barely compresses image tars; pre-gzip is the effective
+    # compression (docker load reads .tar.gz directly).
+    - gzip -1 "images/${NVCM_PR_IMAGE}.tar"
+    # Re-check before uploading: the build can take long enough for the PR
+    # to move; don't publish artifacts for a SHA that is no longer HEAD.
+    - bash .gitlab/ci/scripts/pr_ref_guard.sh
+  artifacts:
+    paths:
+      - images/
+    expire_in: 3 days
+
+# Package the Helm chart here, in the SAME secret-free context as the images.
+# Chart packaging is the step that runs untrusted chart processing (notably
+# `helm dependency build`, which fetches subcharts from PR-controlled Chart.yaml
+# URLs), so it must NOT run in the credentialed promote pipeline. Promote only
+# downloads this .tgz, validates its render, and publishes it - never rebuilds
+# from PR source.
+pr-build-chart:
+  stage: build
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  needs: []
+  image: $NVCM_CI_IMAGE_ALPINE
+  rules: *pr-build-rules
+  before_script:
+    - apk add -q bash git curl helm yq
+    - bash .gitlab/ci/scripts/pr_ref_guard.sh
+  script:
+    # Stamp the immutable promote version, derived deterministically from the
+    # ref + SHA. The promote pipeline computes the SAME value from GitLab's
+    # trusted PR metadata and locates this chart by its expected filename, so
+    # it never has to trust anything this untrusted job records.
+    - |
+      pr_num="${CI_COMMIT_REF_NAME#pull-request/}"
+      short_sha="$(printf '%s' "$CI_COMMIT_SHA" | cut -c1-8)"
+      promote_version="0.0.0-pr${pr_num}.${short_sha}"
+      echo "Packaging chart version ${promote_version}"
+      yq -i ".version = \"${promote_version}\" | .appVersion = \"${promote_version}\"" deploy/helm/Chart.yaml
+
+    - helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    - helm repo add grafana https://grafana.github.io/helm-charts
+    - helm repo update
+    - helm dependency build deploy/helm
+    - mkdir -p chart
+    - helm package deploy/helm --destination chart
+    # Re-check HEAD before uploading, as with the image builds.
+    - bash .gitlab/ci/scripts/pr_ref_guard.sh
+  artifacts:
+    paths:
+      - chart/
+    expire_in: 3 days

--- a/.gitlab/ci/scripts/pr_ref_guard.sh
+++ b/.gitlab/ci/scripts/pr_ref_guard.sh
@@ -27,7 +27,10 @@ expected="${2:-${CI_COMMIT_SHA:?expected-sha argument or CI_COMMIT_SHA required}
 
 echo "Checking that ${ref} still points at ${expected}..."
 
-mirror_head="$(git ls-remote "$CI_REPOSITORY_URL" "refs/heads/${ref}" | cut -f1)"
+mirror_head="$(
+    timeout 30s git ls-remote "$CI_REPOSITORY_URL" "refs/heads/${ref}" |
+        cut -f1
+)"
 if [ -z "$mirror_head" ]; then
     echo "ERROR: ${ref} no longer exists on the mirror (PR closed or merged?)"
     exit 1

--- a/.gitlab/ci/scripts/pr_ref_guard.sh
+++ b/.gitlab/ci/scripts/pr_ref_guard.sh
@@ -1,28 +1,29 @@
 #!/usr/bin/env bash
 # Guard against building or promoting a stale pull-request/<n> SHA.
 #
-# The mirror replicates copy-pr-bot's pull-request/<n> branches from GitHub
-# with pull-mirroring lag, and a PR can gain commits (or close) between the
-# moment a pipeline is scheduled and the moment its jobs run. Any job acting
-# on a pull-request ref calls this to confirm the ref still exists on the
-# mirror and still points at the SHA being built/promoted, with a best-effort
-# cross-check against upstream GitHub.
+# The mirror replicates copy-pr-bot's pull-request/<n> branches from GitHub, and
+# a PR can gain commits (or close) between the moment a pipeline is scheduled and
+# the moment its jobs run. Any job acting on a pull-request ref calls this to
+# confirm the ref still exists on the mirror and still points at the SHA being
+# built/promoted.
+#
+# Mirror-only by design: no GitHub calls. The authoritative freshness and
+# provenance checks live in the protected promote consumer -
+# promote_build_pipeline.sh confirms the PR is open and warns on PR-HEAD
+# divergence via the GitHub PR API, then gates on GitLab pipeline metadata
+# (build sha == PR_SHA). Keeping this guard free of (unauthenticated) GitHub
+# calls avoids rate limits in the many-times-per-pipeline build stage.
 #
 # Usage: pr_ref_guard.sh [ref] [expected-sha]
 #   ref          defaults to $CI_COMMIT_REF_NAME
 #   expected-sha defaults to $CI_COMMIT_SHA
 #
-# The mirror check uses $CI_REPOSITORY_URL, which embeds CI_JOB_TOKEN. That
-# token is NOT read-only, but it is the same token the runner already uses to
-# check out the repo, and it carries no protected/registry credentials. The
-# optional GitHub cross-check is unauthenticated and is skipped in the untrusted
-# build stage (NVCM_PR_GUARD_SKIP_GITHUB=1); the authoritative freshness and
-# provenance checks run in the protected promote consumer.
+# Uses $CI_REPOSITORY_URL, which embeds CI_JOB_TOKEN - the same token the runner
+# already uses to check out the repo; it carries no protected/registry creds.
 set -euo pipefail
 
 ref="${1:-${CI_COMMIT_REF_NAME:?ref argument or CI_COMMIT_REF_NAME required}}"
 expected="${2:-${CI_COMMIT_SHA:?expected-sha argument or CI_COMMIT_SHA required}}"
-github_repo="${NVCM_UPSTREAM_GITHUB_REPO:-NVIDIA/nv-config-manager}"
 
 echo "Checking that ${ref} still points at ${expected}..."
 
@@ -36,45 +37,5 @@ if [ "$mirror_head" != "$expected" ]; then
     echo "The PR gained commits since this run was scheduled; re-run against the new HEAD."
     exit 1
 fi
-
-# GitHub cross-check: best-effort detection of the mirror lagging behind
-# copy-pr-bot's pull-request/<n> branch. It does NOT compare against the PR's
-# live HEAD (that divergence is surfaced in promote_build_pipeline.sh).
-#
-# Skipped in the untrusted build stage (NVCM_PR_GUARD_SKIP_GITHUB=1): those jobs
-# run many times per pipeline, and unauthenticated GitHub calls behind a shared
-# NAT quickly exhaust the 60 req/hour limit (then degrade to warn-and-succeed).
-# The authoritative freshness + provenance checks run in the protected promote
-# consumer, which can make authenticated calls.
-if [ "${NVCM_PR_GUARD_SKIP_GITHUB:-0}" = "1" ] || [ "${NVCM_PR_GUARD_SKIP_GITHUB:-}" = "true" ]; then
-    echo "OK: ${ref} is current at ${expected} (mirror check only; GitHub cross-check skipped)"
-    exit 0
-fi
-
-# Unauthenticated. Inspect the HTTP status so a definitive 404 (branch gone
-# upstream - the mirror copy is an orphan) fails, while inconclusive failures
-# (network, rate limit, 5xx) only warn. A confirmed SHA mismatch on a 200 fails.
-github_response="$(curl -sS --max-time 10 -w '\n%{http_code}' \
-    "https://api.github.com/repos/${github_repo}/branches/${ref}" 2>/dev/null || true)"
-github_status="$(printf '%s' "$github_response" | tail -n 1)"
-github_body="$(printf '%s' "$github_response" | sed '$d')"
-case "$github_status" in
-    200)
-        github_head="$(printf '%s' "$github_body" | grep -o '"sha": *"[0-9a-f]\{40\}"' | head -n 1 | grep -o '[0-9a-f]\{40\}' || true)"
-        if [ -n "$github_head" ] && [ "$github_head" != "$expected" ]; then
-            echo "ERROR: upstream GitHub ${ref} is at ${github_head}; the mirror copy is stale."
-            echo "Wait for pull-mirroring to sync, then re-run."
-            exit 1
-        fi
-        ;;
-    404)
-        echo "ERROR: ${ref} does not exist on GitHub (PR closed/merged or copy-pr-bot"
-        echo "branch removed); the mirror copy is an orphaned stale branch. Refusing."
-        exit 1
-        ;;
-    *)
-        echo "WARN: could not verify ${ref} against GitHub (HTTP ${github_status:-000}: network, rate limit, or API error); mirror check passed."
-        ;;
-esac
 
 echo "OK: ${ref} is current at ${expected}"

--- a/.gitlab/ci/scripts/pr_ref_guard.sh
+++ b/.gitlab/ci/scripts/pr_ref_guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Guard against building or promoting a stale pull-request/<n> SHA.
+#
+# The mirror replicates copy-pr-bot's pull-request/<n> branches from GitHub
+# with pull-mirroring lag, and a PR can gain commits (or close) between the
+# moment a pipeline is scheduled and the moment its jobs run. Any job acting
+# on a pull-request ref calls this to confirm the ref still exists on the
+# mirror and still points at the SHA being built/promoted, with a best-effort
+# cross-check against upstream GitHub.
+#
+# Usage: pr_ref_guard.sh [ref] [expected-sha]
+#   ref          defaults to $CI_COMMIT_REF_NAME
+#   expected-sha defaults to $CI_COMMIT_SHA
+#
+# Uses only $CI_REPOSITORY_URL (embeds the read-only job token, available on
+# unprotected refs) and unauthenticated GitHub API access - no secrets.
+set -euo pipefail
+
+ref="${1:-${CI_COMMIT_REF_NAME:?ref argument or CI_COMMIT_REF_NAME required}}"
+expected="${2:-${CI_COMMIT_SHA:?expected-sha argument or CI_COMMIT_SHA required}}"
+github_repo="${NVCM_UPSTREAM_GITHUB_REPO:-NVIDIA/nv-config-manager}"
+
+echo "Checking that ${ref} still points at ${expected}..."
+
+mirror_head="$(git ls-remote "$CI_REPOSITORY_URL" "refs/heads/${ref}" | cut -f1)"
+if [ -z "$mirror_head" ]; then
+    echo "ERROR: ${ref} no longer exists on the mirror (PR closed or merged?)"
+    exit 1
+fi
+if [ "$mirror_head" != "$expected" ]; then
+    echo "ERROR: stale SHA - mirror ${ref} is at ${mirror_head}, expected ${expected}."
+    echo "The PR gained commits since this run was scheduled; re-run against the new HEAD."
+    exit 1
+fi
+
+# Best-effort mirror-lag check: compare the mirror's copy to GitHub's copy of
+# the SAME vetted copy-pr-bot branch (pull-request/<n>). This catches the mirror
+# lagging behind copy-pr-bot; it intentionally does NOT compare against the PR's
+# live HEAD (that divergence is surfaced in promote_build_pipeline.sh, and
+# building unvetted PR-HEAD commits is deliberately out of scope). Unauthenticated,
+# so rate limits or network failures only warn; a confirmed mismatch fails.
+github_head="$(curl -fsS --max-time 10 \
+    "https://api.github.com/repos/${github_repo}/branches/${ref}" \
+    | grep -o '"sha": *"[0-9a-f]\{40\}"' | head -n 1 | grep -o '[0-9a-f]\{40\}' || true)"
+if [ -n "$github_head" ] && [ "$github_head" != "$expected" ]; then
+    echo "ERROR: upstream GitHub ${ref} is at ${github_head}; the mirror copy is stale."
+    echo "Wait for pull-mirroring to sync, then re-run."
+    exit 1
+fi
+if [ -z "$github_head" ]; then
+    echo "WARN: could not verify ${ref} against GitHub (rate limit or network); mirror check passed."
+fi
+
+echo "OK: ${ref} is current at ${expected}"

--- a/.gitlab/ci/scripts/pr_ref_guard.sh
+++ b/.gitlab/ci/scripts/pr_ref_guard.sh
@@ -37,18 +37,31 @@ fi
 # the SAME vetted copy-pr-bot branch (pull-request/<n>). This catches the mirror
 # lagging behind copy-pr-bot; it intentionally does NOT compare against the PR's
 # live HEAD (that divergence is surfaced in promote_build_pipeline.sh, and
-# building unvetted PR-HEAD commits is deliberately out of scope). Unauthenticated,
-# so rate limits or network failures only warn; a confirmed mismatch fails.
-github_head="$(curl -fsS --max-time 10 \
-    "https://api.github.com/repos/${github_repo}/branches/${ref}" \
-    | grep -o '"sha": *"[0-9a-f]\{40\}"' | head -n 1 | grep -o '[0-9a-f]\{40\}' || true)"
-if [ -n "$github_head" ] && [ "$github_head" != "$expected" ]; then
-    echo "ERROR: upstream GitHub ${ref} is at ${github_head}; the mirror copy is stale."
-    echo "Wait for pull-mirroring to sync, then re-run."
-    exit 1
-fi
-if [ -z "$github_head" ]; then
-    echo "WARN: could not verify ${ref} against GitHub (rate limit or network); mirror check passed."
-fi
+# building unvetted PR-HEAD commits is deliberately out of scope). Unauthenticated.
+# Inspect the HTTP status so a definitive 404 (branch gone upstream - the mirror
+# copy is an orphan) fails, while inconclusive failures (network, rate limit,
+# 5xx) only warn. A confirmed SHA mismatch on a 200 fails.
+github_response="$(curl -sS --max-time 10 -w '\n%{http_code}' \
+    "https://api.github.com/repos/${github_repo}/branches/${ref}" 2>/dev/null || true)"
+github_status="$(printf '%s' "$github_response" | tail -n 1)"
+github_body="$(printf '%s' "$github_response" | sed '$d')"
+case "$github_status" in
+    200)
+        github_head="$(printf '%s' "$github_body" | grep -o '"sha": *"[0-9a-f]\{40\}"' | head -n 1 | grep -o '[0-9a-f]\{40\}' || true)"
+        if [ -n "$github_head" ] && [ "$github_head" != "$expected" ]; then
+            echo "ERROR: upstream GitHub ${ref} is at ${github_head}; the mirror copy is stale."
+            echo "Wait for pull-mirroring to sync, then re-run."
+            exit 1
+        fi
+        ;;
+    404)
+        echo "ERROR: ${ref} does not exist on GitHub (PR closed/merged or copy-pr-bot"
+        echo "branch removed); the mirror copy is an orphaned stale branch. Refusing."
+        exit 1
+        ;;
+    *)
+        echo "WARN: could not verify ${ref} against GitHub (HTTP ${github_status:-000}: network, rate limit, or API error); mirror check passed."
+        ;;
+esac
 
 echo "OK: ${ref} is current at ${expected}"

--- a/.gitlab/ci/scripts/pr_ref_guard.sh
+++ b/.gitlab/ci/scripts/pr_ref_guard.sh
@@ -12,8 +12,12 @@
 #   ref          defaults to $CI_COMMIT_REF_NAME
 #   expected-sha defaults to $CI_COMMIT_SHA
 #
-# Uses only $CI_REPOSITORY_URL (embeds the read-only job token, available on
-# unprotected refs) and unauthenticated GitHub API access - no secrets.
+# The mirror check uses $CI_REPOSITORY_URL, which embeds CI_JOB_TOKEN. That
+# token is NOT read-only, but it is the same token the runner already uses to
+# check out the repo, and it carries no protected/registry credentials. The
+# optional GitHub cross-check is unauthenticated and is skipped in the untrusted
+# build stage (NVCM_PR_GUARD_SKIP_GITHUB=1); the authoritative freshness and
+# provenance checks run in the protected promote consumer.
 set -euo pipefail
 
 ref="${1:-${CI_COMMIT_REF_NAME:?ref argument or CI_COMMIT_REF_NAME required}}"
@@ -33,14 +37,23 @@ if [ "$mirror_head" != "$expected" ]; then
     exit 1
 fi
 
-# Best-effort mirror-lag check: compare the mirror's copy to GitHub's copy of
-# the SAME vetted copy-pr-bot branch (pull-request/<n>). This catches the mirror
-# lagging behind copy-pr-bot; it intentionally does NOT compare against the PR's
-# live HEAD (that divergence is surfaced in promote_build_pipeline.sh, and
-# building unvetted PR-HEAD commits is deliberately out of scope). Unauthenticated.
-# Inspect the HTTP status so a definitive 404 (branch gone upstream - the mirror
-# copy is an orphan) fails, while inconclusive failures (network, rate limit,
-# 5xx) only warn. A confirmed SHA mismatch on a 200 fails.
+# GitHub cross-check: best-effort detection of the mirror lagging behind
+# copy-pr-bot's pull-request/<n> branch. It does NOT compare against the PR's
+# live HEAD (that divergence is surfaced in promote_build_pipeline.sh).
+#
+# Skipped in the untrusted build stage (NVCM_PR_GUARD_SKIP_GITHUB=1): those jobs
+# run many times per pipeline, and unauthenticated GitHub calls behind a shared
+# NAT quickly exhaust the 60 req/hour limit (then degrade to warn-and-succeed).
+# The authoritative freshness + provenance checks run in the protected promote
+# consumer, which can make authenticated calls.
+if [ "${NVCM_PR_GUARD_SKIP_GITHUB:-0}" = "1" ] || [ "${NVCM_PR_GUARD_SKIP_GITHUB:-}" = "true" ]; then
+    echo "OK: ${ref} is current at ${expected} (mirror check only; GitHub cross-check skipped)"
+    exit 0
+fi
+
+# Unauthenticated. Inspect the HTTP status so a definitive 404 (branch gone
+# upstream - the mirror copy is an orphan) fails, while inconclusive failures
+# (network, rate limit, 5xx) only warn. A confirmed SHA mismatch on a 200 fails.
 github_response="$(curl -sS --max-time 10 -w '\n%{http_code}' \
     "https://api.github.com/repos/${github_repo}/branches/${ref}" 2>/dev/null || true)"
 github_status="$(printf '%s' "$github_response" | tail -n 1)"

--- a/Makefile
+++ b/Makefile
@@ -504,6 +504,10 @@ PLATFORMS ?= linux/amd64,linux/arm64
 PLATFORM ?= linux/amd64
 # Extra tags can be passed via EXTRA_TAGS, e.g. EXTRA_TAGS="-t repo:tag1 -t repo:tag2"
 EXTRA_TAGS ?=
+# Buildx output for the single-arch targets. Default pushes to $(REGISTRY)
+# (requires docker login). Credential-less builds override with e.g.
+# DOCKER_BUILD_OUTPUT="--output type=docker,dest=/path/image.tar"
+DOCKER_BUILD_OUTPUT ?= --push
 # Set PUSH_LATEST=true to also push :latest tags (only for main branch releases)
 PUSH_LATEST ?=
 LATEST_TAG_nv_config_manager = $(if $(PUSH_LATEST),-t $(REGISTRY)/nv-config-manager:latest,)
@@ -575,7 +579,7 @@ docker-build-single-nv-config-manager: ## Builds and pushes NVIDIA Config Manage
 		$(TEMPLATE_ENGINE_VERSION_ARG) \
 		$(NVCM_NUMPY_BUILD_ARGS) \
 		-f build/nv-config-manager.Dockerfile \
-		--push \
+		$(DOCKER_BUILD_OUTPUT) \
 		.
 	@echo "✅ nv-config-manager:$(VERSION) pushed to $(REGISTRY)"
 
@@ -588,7 +592,7 @@ docker-build-single-kea: ## Builds and pushes KEA image for PLATFORM.
 		$(EXTRA_TAGS) \
 		$(APT_MIRROR_ARGS) \
 		-f build/kea.Dockerfile \
-		--push \
+		$(DOCKER_BUILD_OUTPUT) \
 		.
 	@echo "✅ nv-config-manager-kea:$(VERSION) pushed to $(REGISTRY)"
 
@@ -601,7 +605,7 @@ docker-build-single-kea-admin: ## Builds and pushes KEA Admin image for PLATFORM
 		$(EXTRA_TAGS) \
 		$(APT_MIRROR_ARGS) \
 		-f build/kea-admin.Dockerfile \
-		--push \
+		$(DOCKER_BUILD_OUTPUT) \
 		.
 	@echo "✅ nv-config-manager-kea-admin:$(VERSION) pushed to $(REGISTRY)"
 
@@ -614,7 +618,7 @@ docker-build-single-ui: ## Builds and pushes UI image for PLATFORM.
 		$(EXTRA_TAGS) \
 		$(APT_MIRROR_ARGS) \
 		-f build/ui.Dockerfile \
-		--push \
+		$(DOCKER_BUILD_OUTPUT) \
 		ui/
 	@echo "✅ nv-config-manager-ui:$(VERSION) pushed to $(REGISTRY)"
 
@@ -629,7 +633,7 @@ docker-build-single-nb: ## Builds and pushes Nautobot image for PLATFORM.
 		$(NAUTOBOT_APP_OVERLAYS_VERSION_ARG) \
 		$(NAUTOBOT_NV_CONFIG_MANAGER_VERSION_ARG) \
 		-f build/nautobot.Dockerfile \
-		--push \
+		$(DOCKER_BUILD_OUTPUT) \
 		components/nautobot/
 	@echo "✅ nv-config-manager-nautobot:$(VERSION) pushed to $(REGISTRY)"
 
@@ -642,7 +646,7 @@ docker-build-single-nats-ready: ## Builds and pushes NATS-ready image for PLATFO
 		$(EXTRA_TAGS) \
 		$(APT_MIRROR_ARGS) \
 		-f build/nats-ready.Dockerfile \
-		--push \
+		$(DOCKER_BUILD_OUTPUT) \
 		components/nats-ready/
 	@echo "✅ nv-config-manager-nats-ready:$(VERSION) pushed to $(REGISTRY)"
 

--- a/Makefile
+++ b/Makefile
@@ -650,13 +650,28 @@ docker-build-single-nats-ready: ## Builds and pushes NATS-ready image for PLATFO
 		components/nats-ready/
 	@echo "✅ nv-config-manager-nats-ready:$(VERSION) pushed to $(REGISTRY)"
 
+# One buildx invocation per Temporal image so each maps 1:1 to a build target,
+# matching the other docker-build-single-* recipes. This lets the secret-free
+# PR build produce a single tarball per image via DOCKER_BUILD_OUTPUT; the
+# aggregate target below preserves the push-all-three behavior for release/main.
 .PHONY: docker-build-single-temporal
-docker-build-single-temporal: ## Builds and pushes distroless Temporal images for PLATFORM.
-	@echo "🏗️  Building distroless Temporal images for $(PLATFORM)..."
-	docker buildx build --platform $(PLATFORM) -t $(REGISTRY)/nv-config-manager-temporal:$(VERSION) $(LATEST_TAG_temporal) $(EXTRA_TAGS) $(TEMPORAL_BUILD_ARGS) --target server -f build/temporal.Dockerfile --push .
-	docker buildx build --platform $(PLATFORM) -t $(REGISTRY)/nv-config-manager-temporal-bootstrap:$(VERSION) $(LATEST_TAG_temporal_bootstrap) $(EXTRA_TAGS) $(TEMPORAL_BUILD_ARGS) --target bootstrap -f build/temporal.Dockerfile --push .
-	docker buildx build --platform $(PLATFORM) -t $(REGISTRY)/nv-config-manager-temporal-ui:$(VERSION) $(LATEST_TAG_temporal_ui) $(EXTRA_TAGS) $(TEMPORAL_BUILD_ARGS) --target ui -f build/temporal.Dockerfile --push .
-	@echo "✅ Distroless Temporal images pushed to $(REGISTRY)"
+docker-build-single-temporal: docker-build-single-temporal-server docker-build-single-temporal-bootstrap docker-build-single-temporal-ui ## Builds/pushes all distroless Temporal images for PLATFORM.
+	@echo "✅ Distroless Temporal images built for $(PLATFORM)"
+
+.PHONY: docker-build-single-temporal-server
+docker-build-single-temporal-server: ## Builds the distroless Temporal server image for PLATFORM.
+	@echo "🏗️  Building distroless Temporal server image for $(PLATFORM)..."
+	docker buildx build --platform $(PLATFORM) -t $(REGISTRY)/nv-config-manager-temporal:$(VERSION) $(LATEST_TAG_temporal) $(EXTRA_TAGS) $(TEMPORAL_BUILD_ARGS) --target server -f build/temporal.Dockerfile $(DOCKER_BUILD_OUTPUT) .
+
+.PHONY: docker-build-single-temporal-bootstrap
+docker-build-single-temporal-bootstrap: ## Builds the distroless Temporal bootstrap image for PLATFORM.
+	@echo "🏗️  Building distroless Temporal bootstrap image for $(PLATFORM)..."
+	docker buildx build --platform $(PLATFORM) -t $(REGISTRY)/nv-config-manager-temporal-bootstrap:$(VERSION) $(LATEST_TAG_temporal_bootstrap) $(EXTRA_TAGS) $(TEMPORAL_BUILD_ARGS) --target bootstrap -f build/temporal.Dockerfile $(DOCKER_BUILD_OUTPUT) .
+
+.PHONY: docker-build-single-temporal-ui
+docker-build-single-temporal-ui: ## Builds the distroless Temporal UI image for PLATFORM.
+	@echo "🏗️  Building distroless Temporal UI image for $(PLATFORM)..."
+	docker buildx build --platform $(PLATFORM) -t $(REGISTRY)/nv-config-manager-temporal-ui:$(VERSION) $(LATEST_TAG_temporal_ui) $(EXTRA_TAGS) $(TEMPORAL_BUILD_ARGS) --target ui -f build/temporal.Dockerfile $(DOCKER_BUILD_OUTPUT) .
 
 # =============================================================================
 # Manifest Merge Targets (for combining arch-specific images)

--- a/Makefile
+++ b/Makefile
@@ -581,7 +581,7 @@ docker-build-single-nv-config-manager: ## Builds and pushes NVIDIA Config Manage
 		-f build/nv-config-manager.Dockerfile \
 		$(DOCKER_BUILD_OUTPUT) \
 		.
-	@echo "✅ nv-config-manager:$(VERSION) pushed to $(REGISTRY)"
+	@echo "✅ nv-config-manager:$(VERSION) built/exported ($(REGISTRY))"
 
 .PHONY: docker-build-single-kea
 docker-build-single-kea: ## Builds and pushes KEA image for PLATFORM.
@@ -594,7 +594,7 @@ docker-build-single-kea: ## Builds and pushes KEA image for PLATFORM.
 		-f build/kea.Dockerfile \
 		$(DOCKER_BUILD_OUTPUT) \
 		.
-	@echo "✅ nv-config-manager-kea:$(VERSION) pushed to $(REGISTRY)"
+	@echo "✅ nv-config-manager-kea:$(VERSION) built/exported ($(REGISTRY))"
 
 .PHONY: docker-build-single-kea-admin
 docker-build-single-kea-admin: ## Builds and pushes KEA Admin image for PLATFORM.
@@ -607,7 +607,7 @@ docker-build-single-kea-admin: ## Builds and pushes KEA Admin image for PLATFORM
 		-f build/kea-admin.Dockerfile \
 		$(DOCKER_BUILD_OUTPUT) \
 		.
-	@echo "✅ nv-config-manager-kea-admin:$(VERSION) pushed to $(REGISTRY)"
+	@echo "✅ nv-config-manager-kea-admin:$(VERSION) built/exported ($(REGISTRY))"
 
 .PHONY: docker-build-single-ui
 docker-build-single-ui: ## Builds and pushes UI image for PLATFORM.
@@ -620,7 +620,7 @@ docker-build-single-ui: ## Builds and pushes UI image for PLATFORM.
 		-f build/ui.Dockerfile \
 		$(DOCKER_BUILD_OUTPUT) \
 		ui/
-	@echo "✅ nv-config-manager-ui:$(VERSION) pushed to $(REGISTRY)"
+	@echo "✅ nv-config-manager-ui:$(VERSION) built/exported ($(REGISTRY))"
 
 .PHONY: docker-build-single-nb
 docker-build-single-nb: ## Builds and pushes Nautobot image for PLATFORM.
@@ -635,7 +635,7 @@ docker-build-single-nb: ## Builds and pushes Nautobot image for PLATFORM.
 		-f build/nautobot.Dockerfile \
 		$(DOCKER_BUILD_OUTPUT) \
 		components/nautobot/
-	@echo "✅ nv-config-manager-nautobot:$(VERSION) pushed to $(REGISTRY)"
+	@echo "✅ nv-config-manager-nautobot:$(VERSION) built/exported ($(REGISTRY))"
 
 .PHONY: docker-build-single-nats-ready
 docker-build-single-nats-ready: ## Builds and pushes NATS-ready image for PLATFORM.
@@ -648,7 +648,7 @@ docker-build-single-nats-ready: ## Builds and pushes NATS-ready image for PLATFO
 		-f build/nats-ready.Dockerfile \
 		$(DOCKER_BUILD_OUTPUT) \
 		components/nats-ready/
-	@echo "✅ nv-config-manager-nats-ready:$(VERSION) pushed to $(REGISTRY)"
+	@echo "✅ nv-config-manager-nats-ready:$(VERSION) built/exported ($(REGISTRY))"
 
 # One buildx invocation per Temporal image so each maps 1:1 to a build target,
 # matching the other docker-build-single-* recipes. This lets the secret-free


### PR DESCRIPTION
## Description

Adds the **untrusted, secret-free build stage** for the test/test01 GitOps promote flow. It builds a PR's artifacts on the mirror's `pull-request/<n>` ref (the vetted copy-pr-bot snapshot) with **no protected variables in scope**, and hands them off as GitLab job artifacts for a later protected promote pipeline to publish. This is the first half of a build/promote split so untrusted PR code never runs with secrets.

What this adds:
- **`.gitlab/ci/pr-build.yml`** — two jobs, gated to `pull-request/*` refs on deliberately-triggered sources only (`pipeline|trigger|api|web`, never `push`):
  - `pr-build-image` — a 6-way matrix that builds each service image with no `docker login`, writes it to a local tarball (`docker buildx --output type=docker,dest=…`), gzips it, and uploads it as an artifact.
  - `pr-build-chart` — runs `helm dependency build` + `helm package` (the steps that process untrusted chart input, e.g. fetching subcharts from PR-controlled `Chart.yaml` URLs) and uploads the `.tgz`. Doing this here keeps that untrusted processing out of the credentialed promote pipeline.
- **`Makefile`** — new `DOCKER_BUILD_OUTPUT ?= --push`, used by the six `docker-build-single-*` targets. Defaults to `--push`, so every existing caller (release/main builds) is unchanged; the secret-free build overrides it to emit a tarball instead.
- **`.gitlab/ci/common.yml`** — a workflow rule admitting `pull-request/*` pipelines only from non-push sources. The existing "no push pipelines on non-default branches" guard is untouched.
- **`.gitlab/ci/scripts/pr_ref_guard.sh`** — stale-HEAD guard: verifies the SHA being built is still HEAD of the mirror's `pull-request/<n>` and cross-checks GitHub's copy of that vetted branch (catches mirror lag). Runs before building and again before uploading artifacts.

Security model: `pull-request/*` refs are unprotected, so GitLab withholds all protected variables from these jobs — the build genuinely cannot see registry/push tokens. Nothing here auto-runs; the build is only started deliberately (by the promote pipeline in a follow-up PR, or a manual run). Safe to merge on its own: it changes no existing pipeline behavior and adds no job that runs on push/MR/tag pipelines.

Follow-up PR adds the protected promote pipeline that triggers this build, publishes the artifacts, and commits deploy-state to the ArgoCD repo.

## Validation

- `yq`/yamllint parse of `pr-build.yml`, `common.yml`, and `.gitlab-ci.yml`; `bash -n` on `pr_ref_guard.sh`.
- Confirmed the workflow rule's source allowlist matches the pr-build job rules (`pipeline|trigger|api|web`; `push` excluded on both).
- `Makefile`: verified the change is a no-op for existing callers — `DOCKER_BUILD_OUTPUT` defaults to `--push`, so release/main image builds are byte-for-byte the same invocation.
- `pr-build-chart` logic exercised locally: `helm dependency build` + `helm package` with a `0.0.0-pr<n>.<sha>` dev version produces a valid chart `.tgz`.
- End-to-end pipeline run is exercised by manually running a pipeline on a `pull-request/<n>` ref on the mirror (source `web`) — requires the mirror to replicate `pull-request/*` and the artifact-size limit to be sufficient. Left for the integrated validation once the promote PR lands, unless run manually here.

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration not run — not applicable. This PR only adds GitLab CI job definitions, a backwards-compatible Makefile flag, and a shell guard; it changes no application code, no Helm chart runtime output, and nothing the Kind integration suite exercises (which runs the app in-cluster via GitHub Actions, not the GitLab pipeline this PR touches).

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an untrusted pull-request CI stage that builds secret-free container image and Helm chart artifacts for later promotion.
* **Bug Fixes**
  * Improved pull-request pipeline triggering so pipelines run only for vetted pipeline sources.
  * Added safeguards to prevent artifact creation/upload for stale pull-request refs.
* **Chores**
  * Made single-arch Buildx output configurable (defaults to pushing; can export tar artifacts) and updated messaging.
  * Refactored single-arch Temporal image builds into component targets to control output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->