### PR TITLE
fix(dhcp): allow matching generated subnet config

### DIFF
--- a/src/nv_config_manager/dhcp/kea_dhcp_confgen.py
+++ b/src/nv_config_manager/dhcp/kea_dhcp_confgen.py
@@ -307,7 +307,7 @@ def _build_subnet_config(
         subnet_config["reservations-in-subnet"] = True
 
     for opt, value in config.items():
-        if opt in subnet_config:
+        if opt in subnet_config and subnet_config[opt] != value:
             raise DhcpConfigGenerationError(f"Cannot override subnet config {opt} with {value}")
         subnet_config[opt] = value
     return subnet_config

--- a/src/tests/dhcp/test_kea_dhcp_confgen.py
+++ b/src/tests/dhcp/test_kea_dhcp_confgen.py
@@ -596,6 +596,58 @@ class MockAdditionalAutoSubnetsClient(MockNautobotClient):
         ]
 
 
+class MockOptionCandidateSubnetConfigClient(MockNautobotClient):
+    """Mock an option candidate whose context repeats generated subnet config."""
+
+    def __init__(self, reservations_in_subnet: bool):
+        super().__init__("https://nautobot.example.com/", "dummy")
+        self.reservations_in_subnet = reservations_in_subnet
+
+    async def load_auto_dhcp_subnets(
+        self, family: int = 4, is_aggregate_managed: bool | None = None
+    ):
+        return [
+            {
+                "prefix": ipaddress.ip_network("10.26.160.0/26"),
+                "gateway": ipaddress.ip_address("10.26.160.1"),
+                "pool_ips": [ipaddress.ip_address("10.26.160.10")],
+                "option_candidates": [
+                    {
+                        "address": ipaddress.ip_address("10.26.160.10"),
+                        "mac_address": "00:11:22:33:44:99",
+                        "serial": "OPTION001",
+                        "device_id": "device-option-candidate",
+                        "device_name": "option-candidate-device",
+                        "interface_name": "eth0",
+                        "interface_role": "management",
+                        "platform": "Cumulus Linux",
+                    }
+                ],
+                "reservations": [],
+            }
+        ]
+
+    async def load_dhcp_contexts(self, is_aggregate_managed: bool | None = None):
+        return {
+            "device-option-candidate": {
+                "dhcp": {
+                    "options": {
+                        "interface_roles": {
+                            "management": {
+                                "reservation_options": {
+                                    "boot-file-name": "http://boot.example.com/boot"
+                                },
+                                "subnet_config": {
+                                    "reservations-in-subnet": self.reservations_in_subnet
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
 class MockMultiplePoolRangesClient(MockNautobotClient):
     """Mock Nautobot client that returns auto subnets with non-contiguous pool IPs."""
 
@@ -791,6 +843,40 @@ async def test_auto_dhcp_subnets_pool_generation():
     assert len(subnet_24["pools"]) == 1
     # Should generate range from 10.23.160.10 to 10.23.160.11
     assert subnet_24["pools"][0]["pool"] == "10.24.160.10-10.24.160.11"
+
+
+@pytest.mark.asyncio
+async def test_option_candidate_allows_matching_generated_subnet_config():
+    """Test context may repeat the generated reservations-in-subnet value."""
+    config = await generate_config(
+        MockOptionCandidateSubnetConfigClient(reservations_in_subnet=True),
+        version=4,
+    )
+
+    subnet = next(
+        subnet for subnet in config["Dhcp4"]["subnet4"] if subnet["subnet"] == "10.26.160.0/26"
+    )
+    assert subnet["reservations-in-subnet"] is True
+    assert subnet["reservations"] == [
+        {
+            "hostname": "option-candidate-device",
+            "option-data": [{"name": "boot-file-name", "data": "http://boot.example.com/boot"}],
+            "hw-address": "00:11:22:33:44:99",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_option_candidate_rejects_conflicting_generated_subnet_config():
+    """Test context cannot contradict generated reservations-in-subnet value."""
+    with pytest.raises(
+        DhcpConfigGenerationError,
+        match="Cannot override subnet config reservations-in-subnet with False",
+    ):
+        await generate_config(
+            MockOptionCandidateSubnetConfigClient(reservations_in_subnet=False),
+            version=4,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Allow duplicate keys in generated DHCP config if the values match.

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Integration doesn't cover this code path

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DHCP configuration generation now accepts matching subnet settings without reporting a conflict.
  * Conflicting settings continue to be rejected with a clear configuration error.
  * Improved handling of `reservations-in-subnet` settings ensures generated reservations are placed correctly within the subnet.

* **Tests**
  * Added coverage for matching and conflicting DHCP subnet reservation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->