### PR TITLE
fix(ui): update distroless Node runtime to address CVEs

### DIFF
--- a/build/ui.Dockerfile
+++ b/build/ui.Dockerfile
@@ -54,7 +54,7 @@ RUN npm run build
 # =============================================================================
 # Runtime stage - NVIDIA distroless Node.js
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/node:24-v4.0.9 AS runner
+FROM nvcr.io/nvidia/distroless/node:24-v4.0.10@sha256:43151afc5b44dc241551e1f816ba27b07d02424b529faa758374b45c44eb86e4 AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

Updates the UI runtime base image to `24-v4.0.10`. This addresses:
- CVE-2026-48930
- CVE-2026-48615
- CVE-2026-48933
- CVE-2026-48619

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
https://github.com/NVIDIA/nv-config-manager/actions/runs/29526034555
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s runtime environment to a newer, digest-pinned base image for improved consistency and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->