### PR TITLE
fix(installer): use local images for TUI local operations

### DIFF
--- a/installer/src/nv_config_manager_installer/tui/screens/deploy.py
+++ b/installer/src/nv_config_manager_installer/tui/screens/deploy.py
@@ -687,6 +687,11 @@ class DeployScreen(Container):
             run_tests=self.query_one("#opt-run-tests", LabeledSwitch).value,
         )
 
+    def _sync_image_source_from_options(self, options: DeployOptions) -> None:
+        """Use locally built or loaded images for the deployment."""
+        if options.build_images or options.load_kind:
+            self._config.images.source = ImageSource.LOCAL
+
     def _start_deploy(self) -> None:
         from nv_config_manager_installer.tui.app import NVConfigManagerInstallerApp
 
@@ -706,6 +711,7 @@ class DeployScreen(Container):
         log_viewer.clear_deploy_log()
 
         options = self._collect_deploy_options()
+        self._sync_image_source_from_options(options)
         callback = _TuiCallback(self)
 
         try:

--- a/installer/tests/test_tui.py
+++ b/installer/tests/test_tui.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 
 from nv_config_manager_installer.deployer import DeployOptions
@@ -99,11 +101,25 @@ async def test_airgapped_collected_from_cluster():
     "options",
     [DeployOptions(build_images=True), DeployOptions(load_kind=True)],
 )
-def test_local_image_operations_select_local_image_source(options):
-    """Building or loading local images must also deploy those images."""
+@pytest.mark.asyncio
+async def test_deployment_start_selects_local_image_source(
+    monkeypatch: pytest.MonkeyPatch, options: DeployOptions
+):
+    """Deployment must use local images when building or loading them."""
     config = NVConfigManagerInstallConfig()
-    screen = DeployScreen(config)
+    app = NVConfigManagerInstallerApp(config=config)
+    deployer = Mock()
+    deployer.return_value.steps = []
+    monkeypatch.setattr("nv_config_manager_installer.tui.screens.deploy.Deployer", deployer)
+    monkeypatch.setattr(DeployScreen, "_collect_deploy_options", lambda self: options)
+    monkeypatch.setattr(DeployScreen, "_run_deploy", lambda self: None)
 
-    screen._sync_image_source_from_options(options)
+    async with app.run_test():
+        screen = app._screens["deploy"]
+        assert isinstance(screen, DeployScreen)
+        screen._start_deploy()
 
-    assert config.images.source == ImageSource.LOCAL
+    deployed_config, deployed_options, _ = deployer.call_args.args
+
+    assert deployed_config.images.source == ImageSource.LOCAL
+    assert deployed_options is options

--- a/installer/tests/test_tui.py
+++ b/installer/tests/test_tui.py
@@ -18,13 +18,16 @@ from __future__ import annotations
 
 import pytest
 
+from nv_config_manager_installer.deployer import DeployOptions
 from nv_config_manager_installer.schema import (
     ClusterConfig,
+    ImageSource,
     NVConfigManagerInstallConfig,
     SiteConfig,
 )
 from nv_config_manager_installer.tui.app import NVConfigManagerInstallerApp
 from nv_config_manager_installer.tui.screens.cluster import ClusterScreen
+from nv_config_manager_installer.tui.screens.deploy import DeployScreen
 
 
 @pytest.mark.asyncio
@@ -90,3 +93,17 @@ async def test_airgapped_collected_from_cluster():
     async with app.run_test():
         app.collect_config()
         assert app.config.cluster.airgapped is True
+
+
+@pytest.mark.parametrize(
+    "options",
+    [DeployOptions(build_images=True), DeployOptions(load_kind=True)],
+)
+def test_local_image_operations_select_local_image_source(options):
+    """Building or loading local images must also deploy those images."""
+    config = NVConfigManagerInstallConfig()
+    screen = DeployScreen(config)
+
+    screen._sync_image_source_from_options(options)
+
+    assert config.images.source == ImageSource.LOCAL


### PR DESCRIPTION
## Description

Fix the TUI deployment flow so enabling **Build images** or **Load to Kind** also selects the local image source before Helm values are generated.

Previously, those switches only controlled the build and load operations. A user could successfully build and load local images while Helm still rendered the default private registry images, leaving the installation stuck in `ImagePullBackOff`. Local TUI installs now deploy the same images they build or load.

Regression coverage verifies both local-image options select `ImageSource.LOCAL`.

## Validation

Confirmed when running installer with both options enabled, local images are built and deployed to kind
```
+ kubectl describe pods nv-config-manager-dhcp-cf97577c6-tg7hj --namespace nv-config-manager
    Image:          nv-config-manager-kea-admin:sha-5b9b035134c9
    Image ID:       sha256:5b9b035134c9b886269fad8887f0bec49c1e2490cf89440ac34752a30370f3cc
    Image:          nv-config-manager-kea:sha-0a8102c5d58d
    Image ID:       sha256:0a8102c5d58d2d7797f744c2a3cda00fc317027f010b57a1260968c31b008756
    Image:         nv-config-manager:sha-3c85d032da82
    Image ID:      sha256:3c85d032da82be6624d70c46292cdde7da38b776fe4b911f58faeef5ff6f0f45
    Image:         nv-config-manager:sha-3c85d032da82
    Image ID:      sha256:3c85d032da82be6624d70c46292cdde7da38b776fe4b911f58faeef5ff6f0f45
    Image:         nv-config-manager:sha-3c85d032da82
    Image ID:      sha256:3c85d032da82be6624d70c46292cdde7da38b776fe4b911f58faeef5ff6f0f45
  Normal  Pulled     65s   kubelet            Container image "nv-config-manager-kea-admin:sha-5b9b035134c9" already present on machine and can be accessed by the pod
  Normal  Pulled     9s    kubelet            Container image "nv-config-manager-kea:sha-0a8102c5d58d" already present on machine and can be accessed by the pod
  Normal  Pulled     9s    kubelet            Container image "nv-config-manager:sha-3c85d032da82" already present on machine and can be accessed by the pod
  Normal  Pulled     9s    kubelet            Container image "nv-config-manager:sha-3c85d032da82" already present on machine and can be accessed by the pod
  Normal  Pulled     9s    kubelet            Container image "nv-config-manager:sha-3c85d032da82" already present on machine and can be accessed by the pod
```

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Not running kind, installer only change.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test 850b413caec21c04c39798bf7f0965abb6b5f5ca
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/141` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`850b413caec2`](https://github.com/NVIDIA/nv-config-manager/actions/runs/29586445873).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. No documentation change is needed because the existing TUI options now behave as labeled.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs. No generated artifacts are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment settings now automatically use locally sourced images when building images or loading the local cluster image is enabled.
  * Ensures the selected image source is synchronized with the user’s deployment options before deployment starts.
* **Tests**
  * Added coverage to verify that deployment starts with the correct local image source for the relevant option combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
