### PR TITLE
feature(secrets): Add cache invalidation to ensure INI secrets reload when changed

### DIFF
--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -230,6 +230,8 @@ ANONYMOUS_IDENTITY = SSOIdentity(
 
 _auth_config: AuthConfig | None = None
 _auth_config_lock = threading.Lock()
+_auth_config_source: ConfigParser | None = None
+_auth_config_tracks_file = False
 
 _JWT_SECTION_PREFIX = "auth.jwt."
 
@@ -298,24 +300,31 @@ def _load_spiffe_from_ini(config: ConfigParser) -> SpiffeConfig | None:
 def load_auth_config(config: ConfigParser | None = None) -> AuthConfig:
     """Load auth configuration from ``nv-config-manager.ini``.
 
-    The result is cached for the lifetime of the process.  Call
-    :func:`reload_auth_config` to force a re-read.
+    File-backed configuration is rebuilt automatically when ``load_config``
+    observes a new INI version. Explicitly supplied configuration remains
+    pinned until :func:`reload_auth_config` is called.
     """
-    global _auth_config
-    if _auth_config is not None:
+    global _auth_config, _auth_config_source, _auth_config_tracks_file
+    tracks_file = config is None
+
+    if config is None:
+        if _auth_config is not None and not _auth_config_tracks_file:
+            return _auth_config
+        try:
+            from nv_config_manager.common.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = ConfigParser()
+    elif _auth_config is not None:
+        return _auth_config
+
+    if _auth_config is not None and _auth_config_source is config:
         return _auth_config
 
     with _auth_config_lock:
-        if _auth_config is not None:
+        if _auth_config is not None and (not tracks_file or _auth_config_source is config):
             return _auth_config
-
-        if config is None:
-            try:
-                from nv_config_manager.common.config import load_config
-
-                config = load_config()
-            except Exception:
-                config = ConfigParser()
 
         auth_section = "auth"
 
@@ -342,13 +351,17 @@ def load_auth_config(config: ConfigParser | None = None) -> AuthConfig:
             spiffe=_load_spiffe_from_ini(config),
             allowed_groups=allowed_groups,
         )
+        _auth_config_source = config
+        _auth_config_tracks_file = tracks_file
         return _auth_config
 
 
 def reload_auth_config() -> AuthConfig:
     """Force-reload the auth configuration (clears cache)."""
-    global _auth_config
+    global _auth_config, _auth_config_source, _auth_config_tracks_file
     _auth_config = None
+    _auth_config_source = None
+    _auth_config_tracks_file = False
     return load_auth_config()
 
 

--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -103,6 +103,7 @@ from fastapi.responses import JSONResponse
 from jwt.types import Options as JWTDecodeOptions
 from pydantic import BaseModel
 
+from nv_config_manager.common.config import load_config
 from nv_config_manager.common.log import LogCategory, get_logger
 
 logger = get_logger(__name__, category=LogCategory.AUTH)
@@ -311,8 +312,6 @@ def load_auth_config(config: ConfigParser | None = None) -> AuthConfig:
         if _auth_config is not None and not _auth_config_tracks_file:
             return _auth_config
         try:
-            from nv_config_manager.common.config import load_config
-
             config = load_config()
         except Exception:
             config = ConfigParser()

--- a/src/nv_config_manager/common/config.py
+++ b/src/nv_config_manager/common/config.py
@@ -52,6 +52,7 @@ from nv_config_manager.common.client import (
 # =============================================================================
 # LOGGING (re-exported from nv_config_manager.common.log to avoid circular imports)
 # =============================================================================
+from nv_config_manager.common.ini import FileFingerprint, file_fingerprint
 from nv_config_manager.common.log import (  # noqa: F401, E402
     LogCategory,
     configure_logging,
@@ -83,6 +84,16 @@ class ConfigStoreType(Enum):
 
 
 @lru_cache(maxsize=1)
+def _load_config(
+    config_path: str,
+    _fingerprint: FileFingerprint | None,
+) -> ConfigParser:
+    """Parse one version of the unified INI file."""
+    config = ConfigParser(interpolation=None, delimiters=("=",))
+    config.read(config_path)
+    return config
+
+
 def load_config() -> ConfigParser:
     """Load the unified nv-config-manager.ini configuration.
 
@@ -90,18 +101,24 @@ def load_config() -> ConfigParser:
     1. NV_CONFIG_MANAGER_INI environment variable
     2. Default: /etc/vault/nv-config-manager.ini
 
+    The parsed result is reused while the file is unchanged. Direct writes and
+    Kubernetes Secret-volume symlink swaps invalidate the cache automatically.
+
     Returns:
-        Loaded ConfigParser instance (cached)
+        Loaded ConfigParser instance for the current file version
     """
-    config = ConfigParser(interpolation=None, delimiters=("=",))
     config_path = os.getenv("NV_CONFIG_MANAGER_INI", "/etc/vault/nv-config-manager.ini")
-    config.read(config_path)
-    return config
+    return _load_config(config_path, file_fingerprint(config_path))
+
+
+def clear_config_cache() -> None:
+    """Clear the parsed INI cache without reading the file again."""
+    _load_config.cache_clear()
 
 
 def reload_config() -> ConfigParser:
     """Force reload the configuration (clears cache)."""
-    load_config.cache_clear()
+    clear_config_cache()
     return load_config()
 
 

--- a/src/nv_config_manager/common/ini.py
+++ b/src/nv_config_manager/common/ini.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for detecting changes to mounted INI files."""
+
+from __future__ import annotations
+
+import os
+
+type FileFingerprint = tuple[int, int, int, int, int]
+
+
+def file_fingerprint(path: str | None) -> FileFingerprint | None:
+    """Return metadata that changes for direct writes and atomic symlink swaps.
+
+    Kubernetes updates Secret volumes by atomically changing the symlink target.
+    Following the symlink and including the target inode detects that update even
+    when the replacement has the same size and timestamps as the previous file.
+    """
+    if not path:
+        return None
+
+    try:
+        stat_result = os.stat(path)
+    except OSError:
+        return None
+
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+    )

--- a/src/nv_config_manager/temporal/common/secrets.py
+++ b/src/nv_config_manager/temporal/common/secrets.py
@@ -30,43 +30,45 @@ from __future__ import annotations
 
 import os
 from configparser import ConfigParser
+from functools import lru_cache
 from typing import Any
 
+from nv_config_manager.common.ini import FileFingerprint, file_fingerprint
 from nv_config_manager.common.log import LogCategory, get_logger
 
 logger = get_logger(__name__, category=LogCategory.AUTH)
 
-# Module-level cache for secrets config to avoid repeated file reads
-_secrets_config_cache: tuple[ConfigParser, bool] | None = None
+
+@lru_cache(maxsize=1)
+def _load_secrets_config(
+    secrets_path: str | None,
+    fingerprint: FileFingerprint | None,
+) -> tuple[ConfigParser, bool]:
+    """Parse one version of the site-specific secrets INI file."""
+    secrets_config = ConfigParser(interpolation=None)
+
+    if secrets_path and fingerprint is not None:
+        secrets_config.read(secrets_path)
+        logger.debug("Loaded secrets config from: %s", secrets_path)
+        return secrets_config, True
+
+    if secrets_path:
+        logger.debug("Secrets config path set but file not found: %s", secrets_path)
+    return secrets_config, False
 
 
 def load_secrets_config() -> tuple[ConfigParser, bool]:
     """Load the secrets config file if available.
 
     Reads from the path specified by NV_CONFIG_MANAGER_CONFIG_SECRET_PATH environment variable.
-    Results are cached at the module level to avoid repeated file reads.
+    The parsed result is reused while the file is unchanged and invalidated
+    automatically after direct writes or Kubernetes Secret-volume updates.
 
     Returns:
         Tuple of (ConfigParser, found) where found indicates if the file exists
     """
-    global _secrets_config_cache
-
-    if _secrets_config_cache is not None:
-        return _secrets_config_cache
-
     secrets_path = os.environ.get("NV_CONFIG_MANAGER_CONFIG_SECRET_PATH")
-    secrets_config = ConfigParser(interpolation=None)
-
-    if secrets_path and os.path.exists(secrets_path):
-        secrets_config.read(secrets_path)
-        logger.debug("Loaded secrets config from: %s", secrets_path)
-        _secrets_config_cache = (secrets_config, True)
-    else:
-        if secrets_path:
-            logger.debug("Secrets config path set but file not found: %s", secrets_path)
-        _secrets_config_cache = (secrets_config, False)
-
-    return _secrets_config_cache
+    return _load_secrets_config(secrets_path, file_fingerprint(secrets_path))
 
 
 def clear_secrets_cache() -> None:
@@ -74,8 +76,7 @@ def clear_secrets_cache() -> None:
 
     Useful for testing or when the secrets file has been updated.
     """
-    global _secrets_config_cache
-    _secrets_config_cache = None
+    _load_secrets_config.cache_clear()
 
 
 def get_site_slug(site: str) -> str:

--- a/src/tests/common/test_auth.py
+++ b/src/tests/common/test_auth.py
@@ -41,6 +41,7 @@ from nv_config_manager.common.auth import (
     require_authenticated_identity,
     require_group,
 )
+from nv_config_manager.common.config import clear_config_cache
 
 # ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -79,9 +80,13 @@ def _clear_caches():
     """Reset module-level caches between tests."""
     _jwks_clients.clear()
     auth_mod._auth_config = None
+    auth_mod._auth_config_source = None
+    auth_mod._auth_config_tracks_file = False
     yield
     _jwks_clients.clear()
     auth_mod._auth_config = None
+    auth_mod._auth_config_source = None
+    auth_mod._auth_config_tracks_file = False
 
 
 @pytest.fixture
@@ -238,6 +243,21 @@ class TestConfigLoading:
         )
         cfg = load_auth_config(cp)
         assert len(cfg.jwt_providers) == 0
+
+    def test_file_backed_auth_config_reloads_after_ini_update(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "nv-config-manager.ini"
+        config_file.write_text("[auth]\nrequired = true\n")
+        monkeypatch.setenv("NV_CONFIG_MANAGER_INI", str(config_file))
+        clear_config_cache()
+
+        first = load_auth_config()
+        assert first.required is True
+
+        config_file.write_text("[auth]\nrequired = false\n")
+        second = load_auth_config()
+
+        assert second is not first
+        assert second.required is False
 
 
 # ── install_identity_probe enforcement tests ─────────────────────────────

--- a/src/tests/common/test_config.py
+++ b/src/tests/common/test_config.py
@@ -18,7 +18,13 @@ import os
 from configparser import ConfigParser
 from unittest.mock import patch
 
-from nv_config_manager.common.config import _read_spiffe_jwt, get_internal_auth_headers
+from nv_config_manager.common.config import (
+    _read_spiffe_jwt,
+    clear_config_cache,
+    get_internal_auth_headers,
+    load_config,
+    reload_config,
+)
 
 
 def _config_with_spiffe_path(jwt_path: str) -> ConfigParser:
@@ -27,6 +33,90 @@ def _config_with_spiffe_path(jwt_path: str) -> ConfigParser:
     cp.add_section("auth.spiffe")
     cp.set("auth.spiffe", "jwt_svid_path", jwt_path)
     return cp
+
+
+class TestLoadConfig:
+    """Tests for automatic invalidation of the parsed INI cache."""
+
+    def test_reuses_config_while_file_is_unchanged(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "nv-config-manager.ini"
+        config_file.write_text("[dynamic]\nvalue = one\n")
+        monkeypatch.setenv("NV_CONFIG_MANAGER_INI", str(config_file))
+        clear_config_cache()
+
+        first = load_config()
+        second = load_config()
+
+        assert first is second
+        assert second["dynamic"]["value"] == "one"
+
+    def test_reloads_after_direct_file_update(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "nv-config-manager.ini"
+        config_file.write_text("[dynamic]\nvalue = one\n")
+        monkeypatch.setenv("NV_CONFIG_MANAGER_INI", str(config_file))
+        clear_config_cache()
+        first = load_config()
+
+        config_file.write_text("[dynamic]\nvalue = updated\n")
+        second = load_config()
+
+        assert second is not first
+        assert second["dynamic"]["value"] == "updated"
+
+    def test_reloads_after_kubernetes_style_symlink_swap(self, monkeypatch, tmp_path):
+        version_one = tmp_path / "..2026_01"
+        version_two = tmp_path / "..2026_02"
+        version_one.mkdir()
+        version_two.mkdir()
+        first_file = version_one / "nv-config-manager.ini"
+        second_file = version_two / "nv-config-manager.ini"
+        first_file.write_text("[dynamic]\nvalue = one\n")
+        second_file.write_text("[dynamic]\nvalue = two\n")
+
+        # Make size and timestamps identical so target inode replacement is
+        # what invalidates the cache, matching Kubernetes' atomic writer.
+        timestamp_ns = 1_700_000_000_000_000_000
+        os.utime(first_file, ns=(timestamp_ns, timestamp_ns))
+        os.utime(second_file, ns=(timestamp_ns, timestamp_ns))
+
+        data_link = tmp_path / "..data"
+        data_link.symlink_to(version_one.name, target_is_directory=True)
+        config_file = tmp_path / "nv-config-manager.ini"
+        config_file.symlink_to("..data/nv-config-manager.ini")
+        monkeypatch.setenv("NV_CONFIG_MANAGER_INI", str(config_file))
+        clear_config_cache()
+        first = load_config()
+
+        replacement_link = tmp_path / "..data-next"
+        replacement_link.symlink_to(version_two.name, target_is_directory=True)
+        replacement_link.replace(data_link)
+        second = load_config()
+
+        assert second is not first
+        assert second["dynamic"]["value"] == "two"
+
+    def test_loads_file_created_after_initial_miss(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "nv-config-manager.ini"
+        monkeypatch.setenv("NV_CONFIG_MANAGER_INI", str(config_file))
+        clear_config_cache()
+
+        assert not load_config().has_section("dynamic")
+
+        config_file.write_text("[dynamic]\nvalue = created\n")
+
+        assert load_config()["dynamic"]["value"] == "created"
+
+    def test_reload_config_forces_reparse(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "nv-config-manager.ini"
+        config_file.write_text("[dynamic]\nvalue = one\n")
+        monkeypatch.setenv("NV_CONFIG_MANAGER_INI", str(config_file))
+        clear_config_cache()
+        first = load_config()
+
+        second = reload_config()
+
+        assert second is not first
+        assert second["dynamic"]["value"] == "one"
 
 
 class TestGetInternalAuthHeaders:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -22,7 +22,7 @@ from unittest.mock import Mock, patch
 import pytest
 from aiohttp import ClientResponse
 
-from nv_config_manager.common.config import load_config
+from nv_config_manager.common.config import clear_config_cache
 
 _CLIENT_RESPONSE_INIT = ClientResponse.__init__
 
@@ -172,7 +172,7 @@ def mock_ini_config(mocker):
     _current_ini["content"] = DEFAULT_INI
 
     # Clear any cached config from previous tests
-    load_config.cache_clear()
+    clear_config_cache()
 
     read_func = configparser.ConfigParser.read
 
@@ -185,7 +185,7 @@ def mock_ini_config(mocker):
     yield
 
     # Clear cache after test to prevent leaking to next test
-    load_config.cache_clear()
+    clear_config_cache()
 
 
 @pytest.fixture()
@@ -208,6 +208,6 @@ def custom_ini():
         # Update the shared INI content
         _current_ini["content"] = ini_content
         # Clear the cached config so it will be reloaded with new settings
-        load_config.cache_clear()
+        clear_config_cache()
 
     return _set_ini

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -22,6 +22,7 @@ from unittest.mock import Mock, patch
 import pytest
 from aiohttp import ClientResponse
 
+from nv_config_manager.common import auth as auth_mod
 from nv_config_manager.common.config import clear_config_cache
 
 _CLIENT_RESPONSE_INIT = ClientResponse.__init__
@@ -160,6 +161,13 @@ channel_name = nv-config-manager-test
 _current_ini = {"content": DEFAULT_INI}
 
 
+def _clear_auth_config_cache() -> None:
+    """Clear derived auth state when the backing INI cache is reset."""
+    auth_mod._auth_config = None
+    auth_mod._auth_config_source = None
+    auth_mod._auth_config_tracks_file = False
+
+
 @pytest.fixture(autouse=True)
 def mock_ini_config(mocker):
     """
@@ -173,6 +181,7 @@ def mock_ini_config(mocker):
 
     # Clear any cached config from previous tests
     clear_config_cache()
+    _clear_auth_config_cache()
 
     read_func = configparser.ConfigParser.read
 
@@ -186,6 +195,7 @@ def mock_ini_config(mocker):
 
     # Clear cache after test to prevent leaking to next test
     clear_config_cache()
+    _clear_auth_config_cache()
 
 
 @pytest.fixture()

--- a/src/tests/temporal/common/test_secrets.py
+++ b/src/tests/temporal/common/test_secrets.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for site-specific secrets INI loading."""
+
+from nv_config_manager.temporal.common.secrets import (
+    clear_secrets_cache,
+    load_secrets_config,
+)
+
+
+def test_secrets_config_reloads_after_file_update(monkeypatch, tmp_path):
+    secrets_file = tmp_path / "config-secrets.ini"
+    secrets_file.write_text("[site.test]\napi_user_key_r1 = old-secret\n")
+    monkeypatch.setenv("NV_CONFIG_MANAGER_CONFIG_SECRET_PATH", str(secrets_file))
+    clear_secrets_cache()
+
+    first, first_found = load_secrets_config()
+    assert first_found is True
+    assert first["site.test"]["api_user_key_r1"] == "old-secret"
+
+    secrets_file.write_text("[site.test]\napi_user_key_r1 = new-secret\n")
+    second, second_found = load_secrets_config()
+
+    assert second_found is True
+    assert second is not first
+    assert second["site.test"]["api_user_key_r1"] == "new-secret"

--- a/src/tests/ztp/test_storage.py
+++ b/src/tests/ztp/test_storage.py
@@ -16,17 +16,20 @@
 
 import pytest
 
-from nv_config_manager.common.config import get_storage_client, load_config
+from nv_config_manager.common.config import (
+    clear_config_cache,
+    get_storage_client,
+)
 from nv_config_manager.ztp.filestore import FileStoreClient
 from nv_config_manager.ztp.s3 import S3Client
 
 
 @pytest.fixture(autouse=True)
-def clear_config_cache():
+def reset_config_cache():
     """Keep config loaded in one test from leaking into another."""
-    load_config.cache_clear()
+    clear_config_cache()
     yield
-    load_config.cache_clear()
+    clear_config_cache()
 
 
 def test_get_storage_client_default_s3(monkeypatch):


### PR DESCRIPTION
## Description

External Secrets Operator can update the Kubernetes Secret and projected INI files without restarting a pod, but the process-lifetime configuration caches continued returning the original parsed values. This left credentials and other file-backed settings stale until a manual rollout.

This change:

- fingerprints each INI using its path, device, inode, size, modification time, and change time;
- reuses the parsed `ConfigParser` while that fingerprint is unchanged;
- reparses after direct writes and Kubernetes atomic Secret-volume symlink swaps;
- applies the same invalidation behavior to the unified INI and site-specific secrets INI; and
- rebuilds derived auth configuration when the underlying parsed INI changes.

Consumers pick up changes on their next configuration access or client construction. Explicitly injected configuration remains pinned for tests and callers, and the manual cache-clear/reload APIs remain available. No rollout controller or additional Helm dependency is required.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`91b8dc4c232d`](https://github.com/NVIDIA/nv-config-manager/actions/runs/29601914036).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

No external configuration or API shape changed. Loader docstrings document the new behavior; generated artifacts are not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Configuration and secrets INI files now automatically reload when the underlying files change, including Kubernetes-style atomic symlink swaps.
  * Added explicit cache-clearing and improved forced-reload behavior for INI-based configuration.

* **Bug Fixes**
  * Auth configuration now reliably refreshes when file-backed settings change, while keeping explicitly provided auth inputs stable until a reload.

* **Tests**
  * Expanded automated coverage for config/auth/secrets cache invalidation, reloads, and file-missing/created scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->