### PR TITLE
Add protected test/test01 promote pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,3 +10,4 @@ include:
   - local: .gitlab/ci/release.yml
   - local: .gitlab/ci/airgapped.yml
   - local: .gitlab/ci/pr-build.yml
+  - local: .gitlab/ci/promote-test-envs.yml

--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -244,6 +244,12 @@ Project settings required (GitLab UI):
 - Maximum artifacts size ≥ 1.5 GB (the build hands images over as artifacts).
 - Pull mirroring must replicate `pull-request/*` branches.
 - Only `main` and release-tag patterns protected; `pull-request/*` unprotected.
+- The **values repo** (`NVCM_VALUES_REPO_PATH`) must allow this project in its
+  inbound **job token allowlist**. `test-promote-chart` reads the baseline and
+  overrides with `CI_JOB_TOKEN` rather than the push token, since it only reads;
+  without the allowlist entry that clone fails with an auth error. Only the
+  deploy-state / rollback / release jobs use
+  `NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN`, and only they write.
 
 ## Air-Gapped Bundles
 

--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -189,6 +189,62 @@ NVCM_TEST01_VALUES_BRANCH=kiwi-platform-test01
 NVCM_TEST01_CHART_BRANCH=kiwi-test01-deployment
 ```
 
+## Test-Environment Promote Pipeline (test / test01)
+
+The GitOps promote flow (`pr-build.yml` + `promote-test-envs.yml`) replaces the
+legacy `deploy-to-test*` jobs. It builds a PR once into immutable artifacts (a
+versioned OCI Helm chart plus images referenced by digest) and promotes them by
+committing a machine-written `deploy-state.yaml` to the environment's branch in
+the downstream ArgoCD values repository. It targets ONLY the shared test
+environments; production stays on the tag-driven release flow.
+
+Security model: the image build runs in a separate pipeline on the unprotected
+`pull-request/<n>` mirror ref with no secrets (no registry login; images are
+handed over as job artifacts). The promote pipeline runs on protected `main`,
+holds the protected variables, and only operates on the finished artifacts.
+Because of that split, **every secret CI/CD variable in this project and its
+groups must be flagged Protected** - unprotected variables are visible to the
+untrusted `pull-request/*` builds. Never protect `pull-request/*` refs.
+
+| Variable | Purpose |
+| -------- | ------- |
+| `NVCM_MIRROR_API_TOKEN` | Project access token (Reporter, `read_api`) used to poll build pipelines and list jobs; protected + masked |
+| `NVCM_TEST_ENV_TARGETS` | One record per env: `env\|env_branch\|namespace\|release_name\|baseline_values\|state_dir` (see `scripts/test_env_config.sh`) |
+| `NVCM_CHART_REPO` | Helm repo URL ArgoCD reads the promoted chart from, e.g. `https://helm.ngc.nvidia.com/nvidian/cfa` (must match the `ngc` target in `NVCM_CHART_TARGETS`); written into deploy-state as `chartRepo` |
+| `NVCM_UPSTREAM_GITHUB_REPO` | Optional override for the upstream GitHub repo checked by the stale-HEAD guard (default `NVIDIA/nv-config-manager`) |
+| `NVCM_BUILD_POLL_INTERVAL` / `NVCM_BUILD_POLL_TIMEOUT` | Optional build-pipeline poll tuning (seconds; defaults 30 / 5400) |
+
+Runbooks (run pipeline on the default branch):
+
+- **Deploy a PR**: set `NVCM_PROMOTE_PR=<PR number>` and
+  `NVCM_PROMOTE_ENV=test|test01`. The pipeline resolves the **vetted copy-pr-bot
+  snapshot** (`pull-request/<n>`) from the mirror, reuses or triggers the
+  no-secrets build, pushes images (capturing digests), publishes the chart as
+  `0.0.0-pr<n>.<sha>`, validates the render against the env's baseline +
+  overrides, and commits the deploy-state. Set `NVCM_PROMOTE_REUSE_BUILD=false`
+  to force a rebuild.
+  - What deploys is the *vetted snapshot*, which can lag the PR's live HEAD
+    (untrusted authors re-copy only on `/ok to test`). If they differ, the run
+    warns and proceeds; to deploy newer commits, re-vet them first. Set
+    `NVCM_PROMOTE_REQUIRE_PR_HEAD=true` to hard-fail instead when the snapshot
+    lags PR HEAD.
+  - The run refuses a closed PR, and **fails closed if GitHub can't be reached**
+    to confirm the PR is open. Set `NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE=true`
+    to override during a GitHub outage.
+- **Rollback**: set only `NVCM_PROMOTE_ENV`, start `test-rollback-env`. Without
+  `NVCM_ROLLBACK_TO` it lists recent deploy-states and fails; re-run with
+  `NVCM_ROLLBACK_TO=<env-branch commit sha>` to restore that exact snapshot
+  (chart version + digests + pinned baseline revision).
+- **Free a slot**: set only `NVCM_PROMOTE_ENV`, start `test-release-env`. It
+  resets the env's deploy-state and overrides to the canonicals on the values
+  repo's `main`.
+
+Project settings required (GitLab UI):
+
+- Maximum artifacts size ≥ 1.5 GB (the build hands images over as artifacts).
+- Pull mirroring must replicate `pull-request/*` branches.
+- Only `main` and release-tag patterns protected; `pull-request/*` unprotected.
+
 ## Air-Gapped Bundles
 
 | Variable | Purpose |

--- a/.gitlab/ci/build.yml
+++ b/.gitlab/ci/build.yml
@@ -212,6 +212,10 @@ docker-build-main-amd64:
     - linux/amd64
     - docker
   rules:
+    # Test-env promote pipelines run on the default branch with rules:changes
+    # evaluating true (non-push pipeline); don't rebuild main as a side effect.
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_COMMIT_TAG
       when: always
     - if: $GITLAB_USER_EMAIL == $CI_PUSH_EMAIL
@@ -236,6 +240,9 @@ docker-build-main-arm64:
     - linux/arm64
     - docker
   rules:
+    # See docker-build-main-amd64: skip during test-env promote pipelines.
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_COMMIT_TAG
       when: always
     - if: $GITLAB_USER_EMAIL == $CI_PUSH_EMAIL
@@ -268,6 +275,9 @@ docker-manifest-main:
       alias: docker
       command: ["--tls=false"]
   rules:
+    # See docker-build-main-amd64: skip during test-env promote pipelines.
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_COMMIT_TAG
       when: on_success
     - if: $GITLAB_USER_EMAIL == $CI_PUSH_EMAIL

--- a/.gitlab/ci/build.yml
+++ b/.gitlab/ci/build.yml
@@ -214,7 +214,7 @@ docker-build-main-amd64:
   rules:
     # Test-env promote pipelines run on the default branch with rules:changes
     # evaluating true (non-push pipeline); don't rebuild main as a side effect.
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_COMMIT_TAG
       when: always
@@ -241,7 +241,7 @@ docker-build-main-arm64:
     - docker
   rules:
     # See docker-build-main-amd64: skip during test-env promote pipelines.
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_COMMIT_TAG
       when: always
@@ -276,7 +276,7 @@ docker-manifest-main:
       command: ["--tls=false"]
   rules:
     # See docker-build-main-amd64: skip during test-env promote pipelines.
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_COMMIT_TAG
       when: on_success

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -62,6 +62,13 @@ test-promote-build:
   artifacts:
     reports:
       dotenv: promote.env
+    # Also a plain file: downstream jobs read the provenance-critical values
+    # (resolved PR ref/SHA, build job ids) from disk, since pipeline variables
+    # outrank dotenv and could otherwise redirect artifact downloads or defeat
+    # the stale-HEAD guard.
+    paths:
+      - promote.env
+    expire_in: 1 week
 
 # -----------------------------------------------------------------------------
 # 2) Download image tars by job id, load, retag, push, capture digests.
@@ -158,7 +165,10 @@ test-promote-chart:
       # promote_build_pipeline.sh). This job never checks out or packages PR
       # source, so no untrusted chart code (e.g. `helm dependency build`) runs
       # in this credentialed context.
-      : "${CHART_BUILD_JOB_ID:?missing dotenv from test-promote-build}"
+      # Read from the file artifact, not dotenv: an overriding pipeline variable
+      # could otherwise point this download at a different job's artifacts.
+      CHART_BUILD_JOB_ID="$(grep -m1 '^CHART_BUILD_JOB_ID=' "${CI_PROJECT_DIR}/promote.env" | cut -d= -f2-)"
+      [ -n "$CHART_BUILD_JOB_ID" ] || { echo "❌ CHART_BUILD_JOB_ID missing from promote.env"; exit 1; }
       # SECURITY: this archive is produced by the untrusted build stage - the PR
       # controls pr-build.yml, and therefore the artifact's paths and contents.
       # Extract into a throwaway directory, NEVER into CI_PROJECT_DIR: unzipping
@@ -173,7 +183,12 @@ test-promote-chart:
 
       # Provenance: require exactly the chart version this promote run computed
       # from trusted PR metadata. A chart stamped with any other version does
-      # not match and is rejected (fails closed).
+      # not match and is rejected (fails closed). Read the version from the
+      # build job's FILE artifact for the same reason as the job id above -
+      # push-images already tagged the images from that same source, so taking
+      # it from (overridable) dotenv here could desynchronise the two.
+      PROMOTE_VERSION="$(grep -m1 '^PROMOTE_VERSION=' "${CI_PROJECT_DIR}/promote.env" | cut -d= -f2-)"
+      [ -n "$PROMOTE_VERSION" ] || { echo "❌ PROMOTE_VERSION missing from promote.env"; exit 1; }
       CHART_NAME=nv-config-manager
       chart_file="${chart_dl}/x/chart/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
       if [ ! -f "$chart_file" ]; then
@@ -208,7 +223,7 @@ test-promote-chart:
       fi
       git clone "$values_repo_url" /tmp/values-repo
       # Capture the exact main SHA whose baseline values this render validates.
-      # write_deploy_state consumes it (via dotenv) instead of re-resolving
+      # write_deploy_state reads it from this file instead of re-resolving
       # origin/main, so the DEPLOYED baseline is the one that was validated even
       # if main moves before the deploy-state job runs.
       baseline_revision="$(git -C /tmp/values-repo rev-parse HEAD)"
@@ -229,6 +244,28 @@ test-promote-chart:
       echo "PROMOTE_VERSION=${PROMOTE_VERSION}" >> "${CI_PROJECT_DIR}/chart.env"
       overrides_file="/tmp/values-env/${NVCM_ENV_STATE_DIR}/values-aws-${NVCM_ENV}.overrides.yaml"
       test -f "$overrides_file" || (echo "❌ Missing overrides file ${overrides_file} on ${NVCM_ENV_BRANCH}" && exit 1)
+
+      # Digest pins come from the push job's FILE artifact, not its dotenv
+      # export. write_deploy_state.sh pins the file's values, so reading the
+      # same source here keeps "what we validated" and "what we deploy"
+      # identical even if a same-named pipeline variable is set.
+      digest_attest="${CI_PROJECT_DIR}/digests.env"
+      [ -f "$digest_attest" ] || { echo "❌ Missing ${digest_attest} (artifact from test-promote-push-images)"; exit 1; }
+      attest_digest() {
+        local key="$1" val
+        val="$(grep -m1 "^${key}=" "$digest_attest" | cut -d= -f2- || true)"
+        [ -n "$val" ] || { echo "❌ ${key} missing from digests.env"; exit 1; }
+        printf '%s' "$val"
+      }
+      DIGEST_NV_CONFIG_MANAGER="$(attest_digest DIGEST_NV_CONFIG_MANAGER)"
+      DIGEST_NV_CONFIG_MANAGER_UI="$(attest_digest DIGEST_NV_CONFIG_MANAGER_UI)"
+      DIGEST_NV_CONFIG_MANAGER_KEA="$(attest_digest DIGEST_NV_CONFIG_MANAGER_KEA)"
+      DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN="$(attest_digest DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN)"
+      DIGEST_NV_CONFIG_MANAGER_NAUTOBOT="$(attest_digest DIGEST_NV_CONFIG_MANAGER_NAUTOBOT)"
+      DIGEST_NV_CONFIG_MANAGER_NATS_READY="$(attest_digest DIGEST_NV_CONFIG_MANAGER_NATS_READY)"
+      DIGEST_NV_CONFIG_MANAGER_TEMPORAL="$(attest_digest DIGEST_NV_CONFIG_MANAGER_TEMPORAL)"
+      DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP="$(attest_digest DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP)"
+      DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI="$(attest_digest DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI)"
 
       # Render with identical inputs for any package, so the locally validated
       # one and the published one can be compared.
@@ -327,7 +364,14 @@ test-promote-deploy-state:
     - git config --global user.name "NVIDIA Config Manager CI"
   script:
     # Final stale-HEAD check before mutating the env branch.
-    - bash .gitlab/ci/scripts/pr_ref_guard.sh "$PR_REF" "$PR_SHA"
+    # Guard inputs come from the file artifact, not dotenv - an overriding
+    # pipeline variable could otherwise make this check compare against
+    # operator-chosen values and pass trivially.
+    - |
+      pr_ref="$(grep -m1 '^PR_REF=' "${CI_PROJECT_DIR}/promote.env" | cut -d= -f2-)"
+      pr_sha="$(grep -m1 '^PR_SHA=' "${CI_PROJECT_DIR}/promote.env" | cut -d= -f2-)"
+      [ -n "$pr_ref" ] && [ -n "$pr_sha" ] || { echo "❌ PR_REF/PR_SHA missing from promote.env"; exit 1; }
+      bash .gitlab/ci/scripts/pr_ref_guard.sh "$pr_ref" "$pr_sha"
     - |
       env_config="$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")" || exit $?
       eval "$env_config"

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -178,14 +178,20 @@ test-promote-chart:
       # Render gate against the env's real values layering (pinned baseline +
       # env-branch overrides + digest pins) BEFORE publishing or touching the
       # env branch. helm template is sandboxed (no env access), so rendering the
-      # untrusted chart with the values token present cannot leak secrets; the
-      # packaged .tgz already vendors its subcharts, so nothing is fetched.
+      # untrusted chart with this job's credentials present cannot leak them;
+      # the packaged .tgz already vendors its subcharts, so nothing is fetched.
       env_config="$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/test_env_config.sh" "$NVCM_PROMOTE_ENV")" || exit $?
       eval "$env_config"
+      # Read-only access: this job only reads the baseline values and the env
+      # branch's overrides, so it uses CI_JOB_TOKEN (short-lived, job-scoped,
+      # auto-revoked) rather than the values PUSH token. Requires the values
+      # repo's inbound job-token allowlist to include this project. Only the
+      # deploy-state / rollback / release jobs, which actually commit, use
+      # NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN.
       if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
         values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
       else
-        values_repo_url="https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${NVCM_VALUES_REPO_PATH}.git"
+        values_repo_url="https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${NVCM_VALUES_REPO_PATH}.git"
       fi
       git clone "$values_repo_url" /tmp/values-repo
       # Capture the exact main SHA whose baseline values this render validates.

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -139,9 +139,16 @@ test-promote-chart:
       wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
       echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum -c -
       chmod +x /usr/local/bin/yq
-    - wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.8.2/files/ngccli_linux.zip -O ngccli_linux.zip
-    - unzip ngccli_linux.zip
-    - chmod u+x ngc-cli/ngc
+    # Pinned + checksum-verified, as with yq above: this job holds registry and
+    # values-push credentials, so nothing unverified gets executed here.
+    - |
+      set -e
+      NGC_CLI_VERSION=4.8.2
+      NGC_CLI_SHA256=8f12ed29aaa49be96e059439f993a990b953a709b152550f062d5190e21afafa
+      wget --content-disposition "https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip" -O ngccli_linux.zip
+      echo "${NGC_CLI_SHA256}  ngccli_linux.zip" | sha256sum -c -
+      unzip ngccli_linux.zip
+      chmod u+x ngc-cli/ngc
   script:
     - |
       set -e
@@ -292,6 +299,25 @@ test-rollback-env:
         git log -n 15 --pretty='%h  %ad  %s' --date=iso -- "$state_file"
         echo ""
         echo "Re-run this pipeline with NVCM_ROLLBACK_TO=<commit sha> to roll back."
+        exit 1
+      fi
+
+      # The rollback target must be a commit on THIS env branch. Without this,
+      # a typo or a SHA from another branch/env would install an unrelated
+      # deploy-state (e.g. another environment's chart + digests).
+      if ! git rev-parse --verify --quiet "${NVCM_ROLLBACK_TO}^{commit}" >/dev/null; then
+        echo "ERROR: NVCM_ROLLBACK_TO='${NVCM_ROLLBACK_TO}' is not a commit in ${NVCM_VALUES_REPO_PATH}."
+        exit 1
+      fi
+      if ! git merge-base --is-ancestor "${NVCM_ROLLBACK_TO}" "origin/${NVCM_ENV_BRANCH}"; then
+        echo "ERROR: ${NVCM_ROLLBACK_TO} is not an ancestor of ${NVCM_ENV_BRANCH}."
+        echo "       Roll back only to a deploy-state committed on this env branch"
+        echo "       (re-run without NVCM_ROLLBACK_TO to list valid candidates)."
+        exit 1
+      fi
+      # And it must actually carry this env's deploy-state.
+      if ! git cat-file -e "${NVCM_ROLLBACK_TO}:${state_file}" 2>/dev/null; then
+        echo "ERROR: ${NVCM_ROLLBACK_TO} does not contain ${state_file}."
         exit 1
       fi
 

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -48,9 +48,9 @@
 test-promote-build:
   stage: deploy
   tags:
-    - dca
-    - linux/amd64
+    - dgxc-corp-restricted
     - docker
+    - linux/amd64
   needs: []
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *test-promote-rules
@@ -69,9 +69,9 @@ test-promote-build:
 test-promote-push-images:
   stage: deploy
   tags:
-    - dca
-    - linux/amd64
+    - dgxc-corp-restricted
     - docker
+    - linux/amd64
   image: $NVCM_CI_IMAGE_DOCKER
   services:
     - name: $NVCM_CI_IMAGE_DOCKER_DIND
@@ -111,9 +111,9 @@ test-promote-push-images:
 test-promote-chart:
   stage: deploy
   tags:
-    - dca
-    - linux/amd64
+    - dgxc-corp-restricted
     - docker
+    - linux/amd64
   image:
     name: $NVCM_CI_IMAGE_UBUNTU
     entrypoint: ['']
@@ -220,9 +220,9 @@ test-promote-chart:
 test-promote-deploy-state:
   stage: deploy
   tags:
-    - dca
-    - linux/amd64
+    - dgxc-corp-restricted
     - docker
+    - linux/amd64
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *test-promote-rules
   needs:
@@ -253,9 +253,9 @@ test-promote-deploy-state:
 test-rollback-env:
   stage: deploy
   tags:
-    - dca
-    - linux/amd64
+    - dgxc-corp-restricted
     - docker
+    - linux/amd64
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *test-env-ops-rules
   needs: []
@@ -316,9 +316,9 @@ test-rollback-env:
 test-release-env:
   stage: deploy
   tags:
-    - dca
-    - linux/amd64
+    - dgxc-corp-restricted
     - docker
+    - linux/amd64
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *test-env-ops-rules
   needs: []

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -196,6 +196,12 @@ test-promote-chart:
       echo "BASELINE_REVISION=${baseline_revision}" > "${CI_PROJECT_DIR}/chart.env"
       git -C /tmp/values-repo fetch origin "${NVCM_ENV_BRANCH}"
       git -C /tmp/values-repo worktree add /tmp/values-env "origin/${NVCM_ENV_BRANCH}"
+      # Capture the env-branch SHA whose overrides this render validates.
+      # resource_group serializes promote/rollback/release, but NOT human pushes
+      # to the env branch, so the overrides can move between this gate and the
+      # deploy-state commit. write_deploy_state refuses to write if they have.
+      env_branch_revision="$(git -C /tmp/values-repo rev-parse "origin/${NVCM_ENV_BRANCH}")"
+      echo "ENV_BRANCH_REVISION=${env_branch_revision}" >> "${CI_PROJECT_DIR}/chart.env"
       overrides_file="/tmp/values-env/${NVCM_ENV_STATE_DIR}/values-aws-${NVCM_ENV}.overrides.yaml"
       test -f "$overrides_file" || (echo "❌ Missing overrides file ${overrides_file} on ${NVCM_ENV_BRANCH}" && exit 1)
 

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -310,9 +310,24 @@ test-promote-chart:
       fi
       verify_dir="$(mktemp -d)"
       helm repo add nvcm-verify "$NVCM_CHART_REPO" --username '$oauthtoken' --password "$ngc_key" >/dev/null
-      helm repo update nvcm-verify >/dev/null
-      helm pull "nvcm-verify/${CHART_NAME}" --version "$PROMOTE_VERSION" --devel -d "$verify_dir"
       published_chart="${verify_dir}/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
+      # The NGC repo index is eventually consistent, so a chart published
+      # seconds ago is often not listed yet. Retry the refresh+pull for a
+      # bounded window before treating that as a publish failure.
+      pull_attempts="${NVCM_CHART_PULL_ATTEMPTS:-6}"
+      pull_delay="${NVCM_CHART_PULL_DELAY:-10}"
+      attempt=1
+      while :; do
+        if helm repo update nvcm-verify >/dev/null \
+          && helm pull "nvcm-verify/${CHART_NAME}" --version "$PROMOTE_VERSION" --devel -d "$verify_dir" \
+          && [ -f "$published_chart" ]; then
+          break
+        fi
+        [ "$attempt" -lt "$pull_attempts" ] || break
+        echo "   not in the index yet; retrying in ${pull_delay}s (attempt ${attempt}/${pull_attempts})"
+        attempt=$((attempt + 1))
+        sleep "$pull_delay"
+      done
       if [ ! -f "$published_chart" ]; then
         echo "❌ Could not pull ${CHART_NAME}:${PROMOTE_VERSION} back from ${NVCM_CHART_REPO}"
         exit 1

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -202,6 +202,12 @@ test-promote-chart:
       # deploy-state commit. write_deploy_state refuses to write if they have.
       env_branch_revision="$(git -C /tmp/values-repo rev-parse "origin/${NVCM_ENV_BRANCH}")"
       echo "ENV_BRANCH_REVISION=${env_branch_revision}" >> "${CI_PROJECT_DIR}/chart.env"
+      # Attest the chart version too, now that it has been cross-checked against
+      # the built artifact's filename above. chart.env is published as a FILE
+      # artifact (not only dotenv) because pipeline variables outrank dotenv in
+      # GitLab - an operator-supplied variable of the same name would otherwise
+      # override the values these provenance guards compare against.
+      echo "PROMOTE_VERSION=${PROMOTE_VERSION}" >> "${CI_PROJECT_DIR}/chart.env"
       overrides_file="/tmp/values-env/${NVCM_ENV_STATE_DIR}/values-aws-${NVCM_ENV}.overrides.yaml"
       test -f "$overrides_file" || (echo "❌ Missing overrides file ${overrides_file} on ${NVCM_ENV_BRANCH}" && exit 1)
 
@@ -230,6 +236,11 @@ test-promote-chart:
   artifacts:
     reports:
       dotenv: chart.env
+    # Also published as a plain file so downstream jobs can read the attested
+    # values from disk instead of trusting (overridable) dotenv variables.
+    paths:
+      - chart.env
+    expire_in: 1 week
 
 # -----------------------------------------------------------------------------
 # 4) Commit the deployment-state to the env branch. ArgoCD does the rest.

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -26,7 +26,7 @@
 # untrusted PR code never executes here.
 #
 # Required protected CI/CD variables (see .gitlab/ci/README.md):
-#   NVCM_MIRROR_API_TOKEN, NVCM_TEST_ENV_TARGETS, NVCM_CHART_OCI_REPO,
+#   NVCM_MIRROR_API_TOKEN, NVCM_TEST_ENV_TARGETS, NVCM_CHART_REPO,
 #   NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN, NVCM_VALUES_REPO_PATH,
 #   plus the existing image/chart target variables.
 # =============================================================================

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -1,0 +1,338 @@
+---
+# =============================================================================
+# Protected promote pipeline for the SHARED TEST ENVIRONMENTS ONLY
+# =============================================================================
+# Promotes a PR build to test / test01 by publishing immutable artifacts and
+# committing a deployment-state file to the env's branch in the downstream
+# ArgoCD values repository. This pipeline can NOT target production: every
+# rule requires NVCM_PROMOTE_ENV to be exactly "test" or "test01" (prod stays
+# on the tag-driven release flow in release.yml).
+#
+# How to deploy a PR (single action):
+#   Run pipeline on the default branch with:
+#     NVCM_PROMOTE_PR  = <GitHub PR number>
+#     NVCM_PROMOTE_ENV = test | test01
+#   Optional: NVCM_PROMOTE_REUSE_BUILD=false to force a fresh build.
+#
+# How to rollback / free a test env (manual jobs):
+#   Run pipeline on the default branch with only NVCM_PROMOTE_ENV set, then
+#   start test-rollback-env (optionally NVCM_ROLLBACK_TO=<env-branch sha>) or
+#   test-release-env from the pipeline view.
+#
+# Build/promote split (security model): the actual image build runs in a
+# SEPARATE pipeline on the unprotected pull-request/<n> ref with no secrets
+# (see pr-build.yml). This pipeline runs on protected main, holds the
+# protected variables, and only operates on the already-built artifacts -
+# untrusted PR code never executes here.
+#
+# Required protected CI/CD variables (see .gitlab/ci/README.md):
+#   NVCM_MIRROR_API_TOKEN, NVCM_TEST_ENV_TARGETS, NVCM_CHART_OCI_REPO,
+#   NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN, NVCM_VALUES_REPO_PATH,
+#   plus the existing image/chart target variables.
+# =============================================================================
+
+.test-promote-rules: &test-promote-rules
+  - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_PR && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
+    when: always
+  - when: never
+
+.test-env-ops-rules: &test-env-ops-rules
+  - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/ && $NVCM_PROMOTE_PR == null
+    when: manual
+    allow_failure: true
+  - when: never
+
+# -----------------------------------------------------------------------------
+# 1) Resolve PR HEAD; reuse or trigger the no-secrets build pipeline; wait.
+# -----------------------------------------------------------------------------
+test-promote-build:
+  stage: deploy
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  needs: []
+  image: $NVCM_CI_IMAGE_ALPINE
+  rules: *test-promote-rules
+  timeout: 2h
+  before_script:
+    - apk add --no-cache bash curl git jq coreutils
+  script:
+    - bash .gitlab/ci/scripts/promote_build_pipeline.sh
+  artifacts:
+    reports:
+      dotenv: promote.env
+
+# -----------------------------------------------------------------------------
+# 2) Download image tars by job id, load, retag, push, capture digests.
+# -----------------------------------------------------------------------------
+test-promote-push-images:
+  stage: deploy
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  image: $NVCM_CI_IMAGE_DOCKER
+  services:
+    - name: $NVCM_CI_IMAGE_DOCKER_DIND
+      alias: docker
+      command: ["--tls=false"]
+  variables:
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_TLS_CERTDIR: ""
+    DOCKER_DRIVER: overlay2
+  rules: *test-promote-rules
+  needs:
+    - job: test-promote-build
+      artifacts: true
+  before_script:
+    - apk add -q bash curl unzip coreutils
+    - docker info
+    - |
+      image_target_exports="$(bash .gitlab/ci/scripts/image_target_env.sh "${NVCM_VALUES_IMAGE_TARGET:-}")" || exit $?
+      eval "$image_target_exports"
+    - image_token="$(printenv "$NVCM_IMAGE_TOKEN_VAR" || true)"
+    - test -n "$image_token" || (echo "Image target ${NVCM_IMAGE_TARGET_NAME} references ${NVCM_IMAGE_TOKEN_VAR}, but it is empty or unset" && exit 1)
+    - printf '%s' "$image_token" | docker login -u "$NVCM_IMAGE_USERNAME" --password-stdin "$NVCM_IMAGE_REGISTRY"
+  script:
+    - bash .gitlab/ci/scripts/promote_push_images.sh
+  artifacts:
+    reports:
+      dotenv: digests.env
+    paths:
+      - digests.env
+    expire_in: 1 week
+
+# -----------------------------------------------------------------------------
+# 3) Download the chart .tgz packaged in the secret-free build stage, validate
+#    its render against the target env's actual values layering, and publish it.
+#    Does NOT check out or package PR source (that happens in pr-build-chart).
+# -----------------------------------------------------------------------------
+test-promote-chart:
+  stage: deploy
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  image:
+    name: $NVCM_CI_IMAGE_UBUNTU
+    entrypoint: ['']
+  rules: *test-promote-rules
+  needs:
+    - job: test-promote-build
+      artifacts: true
+    - job: test-promote-push-images
+      artifacts: true
+  before_script:
+    - |
+      set -e
+      apt update
+      apt install -y curl gpg apt-transport-https
+      curl --retry 3 --retry-delay 5 --retry-connrefused -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
+      echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
+      apt update
+      apt install -y helm git wget unzip
+      wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+      chmod +x /usr/local/bin/yq
+    - wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.8.2/files/ngccli_linux.zip -O ngccli_linux.zip
+    - unzip ngccli_linux.zip
+    - chmod u+x ngc-cli/ngc
+  script:
+    - |
+      set -e
+
+      # Download the chart .tgz packaged in the SECRET-FREE build stage on the
+      # PR ref (job id resolved from GitLab-trusted metadata by
+      # promote_build_pipeline.sh). This job never checks out or packages PR
+      # source, so no untrusted chart code (e.g. `helm dependency build`) runs
+      # in this credentialed context.
+      : "${CHART_BUILD_JOB_ID:?missing dotenv from test-promote-build}"
+      curl -fsS --retry 3 --retry-delay 5 -H "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+        -o chart-artifacts.zip \
+        "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/jobs/${CHART_BUILD_JOB_ID}/artifacts"
+      unzip -o -q chart-artifacts.zip
+
+      # Provenance: require exactly the chart version this promote run computed
+      # from trusted PR metadata. A chart stamped with any other version does
+      # not match and is rejected (fails closed).
+      CHART_NAME=nv-config-manager
+      chart_file="chart/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
+      if [ ! -f "$chart_file" ]; then
+        echo "❌ Expected ${chart_file} not found in build artifacts"
+        ls -laR chart || true
+        exit 1
+      fi
+
+      # Render gate against the env's real values layering (pinned baseline +
+      # env-branch overrides + digest pins) BEFORE publishing or touching the
+      # env branch. helm template is sandboxed (no env access), so rendering the
+      # untrusted chart with the values token present cannot leak secrets; the
+      # packaged .tgz already vendors its subcharts, so nothing is fetched.
+      eval "$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/test_env_config.sh" "$NVCM_PROMOTE_ENV")"
+      if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
+        values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+      else
+        values_repo="$NVCM_VALUES_REPO_PATH"
+      fi
+      git clone "https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git" /tmp/values-repo
+      git -C /tmp/values-repo fetch origin "${NVCM_ENV_BRANCH}"
+      git -C /tmp/values-repo worktree add /tmp/values-env "origin/${NVCM_ENV_BRANCH}"
+      overrides_file="/tmp/values-env/${NVCM_ENV_STATE_DIR}/values-aws-${NVCM_ENV}.overrides.yaml"
+      test -f "$overrides_file" || (echo "❌ Missing overrides file ${overrides_file} on ${NVCM_ENV_BRANCH}" && exit 1)
+
+      echo "🔍 Validating render for ${NVCM_ENV}..."
+      helm template "${NVCM_ENV_RELEASE_NAME}" "$chart_file" \
+        -f "/tmp/values-repo/${NVCM_ENV_BASELINE_VALUES}" \
+        -f "$overrides_file" \
+        --set "global.images.nvConfigManager.digest=${DIGEST_NV_CONFIG_MANAGER}" \
+        --set "global.images.nvConfigManagerUi.digest=${DIGEST_NV_CONFIG_MANAGER_UI}" \
+        --set "global.images.kea.digest=${DIGEST_NV_CONFIG_MANAGER_KEA}" \
+        --set "global.images.keaAdmin.digest=${DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN}" \
+        --set "global.images.nautobot.digest=${DIGEST_NV_CONFIG_MANAGER_NAUTOBOT}" \
+        --set "global.images.natsReady.digest=${DIGEST_NV_CONFIG_MANAGER_NATS_READY}" \
+        > /dev/null
+      echo "✅ Render OK"
+
+      echo "📤 Publishing chart to configured targets..."
+      # publish_chart_targets.sh resolves ngc-cli/ngc relative to the project
+      # root, so publish from there.
+      cp "$chart_file" "${CI_PROJECT_DIR}/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
+      cd "${CI_PROJECT_DIR}"
+      bash .gitlab/ci/scripts/publish_chart_targets.sh "${CHART_NAME}-${PROMOTE_VERSION}.tgz" "$PROMOTE_VERSION" "$CHART_NAME"
+
+# -----------------------------------------------------------------------------
+# 4) Commit the deployment-state to the env branch. ArgoCD does the rest.
+# -----------------------------------------------------------------------------
+test-promote-deploy-state:
+  stage: deploy
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  image: $NVCM_CI_IMAGE_ALPINE
+  rules: *test-promote-rules
+  needs:
+    - job: test-promote-build
+      artifacts: true
+    - job: test-promote-push-images
+      artifacts: true
+    - job: test-promote-chart
+  environment:
+    name: $NVCM_PROMOTE_ENV
+  before_script:
+    - apk add --no-cache bash git yq curl coreutils
+    - git config --global user.email "${CI_PUSH_EMAIL:-ci@nv-config-manager}"
+    - git config --global user.name "NVIDIA Config Manager CI"
+  script:
+    # Final stale-HEAD check before mutating the env branch.
+    - bash .gitlab/ci/scripts/pr_ref_guard.sh "$PR_REF" "$PR_SHA"
+    - eval "$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")"
+    - bash .gitlab/ci/scripts/write_deploy_state.sh
+
+# -----------------------------------------------------------------------------
+# Rollback: restore a prior known-good deploy-state from env-branch history.
+# -----------------------------------------------------------------------------
+test-rollback-env:
+  stage: deploy
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  image: $NVCM_CI_IMAGE_ALPINE
+  rules: *test-env-ops-rules
+  needs: []
+  environment:
+    name: $NVCM_PROMOTE_ENV
+  before_script:
+    - apk add --no-cache bash git yq coreutils
+    - git config --global user.email "${CI_PUSH_EMAIL:-ci@nv-config-manager}"
+    - git config --global user.name "NVIDIA Config Manager CI"
+  script:
+    - |
+      set -e
+      eval "$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")"
+      if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
+        values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+      else
+        values_repo="$NVCM_VALUES_REPO_PATH"
+      fi
+      git clone "https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git" values-repo
+      cd values-repo
+      git fetch origin "${NVCM_ENV_BRANCH}"
+      git checkout "${NVCM_ENV_BRANCH}"
+      state_file="${NVCM_ENV_STATE_DIR}/deploy-state.yaml"
+
+      if [ -z "${NVCM_ROLLBACK_TO:-}" ]; then
+        echo "Recent deploy-states on ${NVCM_ENV_BRANCH} (newest first):"
+        echo ""
+        git log -n 15 --pretty='%h  %ad  %s' --date=iso -- "$state_file"
+        echo ""
+        echo "Re-run this pipeline with NVCM_ROLLBACK_TO=<commit sha> to roll back."
+        exit 1
+      fi
+
+      echo "Rolling ${NVCM_PROMOTE_ENV} back to deploy-state @ ${NVCM_ROLLBACK_TO}"
+      git show "${NVCM_ROLLBACK_TO}:${state_file}" > "$state_file"
+      # Refresh audit fields only; the deployment pins are restored verbatim.
+      occupant="${GITLAB_USER_LOGIN:-${GITLAB_USER_NAME:-ci}}"
+      updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      export occupant updated_at
+      yq -i '.occupant = strenv(occupant) | .updatedAt = strenv(updated_at)' "$state_file"
+
+      git diff "$state_file"
+      git add "$state_file"
+      git commit -m "[nvcm CI] Rollback ${NVCM_PROMOTE_ENV} to deploy-state @ ${NVCM_ROLLBACK_TO}
+
+      Triggered by: ${occupant}
+      Pipeline: ${CI_PIPELINE_URL}"
+      git push origin "HEAD:refs/heads/${NVCM_ENV_BRANCH}"
+      echo "✅ Rolled back. ArgoCD will revert ${NVCM_PROMOTE_ENV} to that exact chart+image+baseline snapshot."
+
+# -----------------------------------------------------------------------------
+# Release: reset the env's deploy-state AND overrides to the canonicals on
+# main, freeing the slot immediately.
+# -----------------------------------------------------------------------------
+test-release-env:
+  stage: deploy
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  image: $NVCM_CI_IMAGE_ALPINE
+  rules: *test-env-ops-rules
+  needs: []
+  environment:
+    name: $NVCM_PROMOTE_ENV
+  before_script:
+    - apk add --no-cache bash git coreutils
+    - git config --global user.email "${CI_PUSH_EMAIL:-ci@nv-config-manager}"
+    - git config --global user.name "NVIDIA Config Manager CI"
+  script:
+    - |
+      set -e
+      eval "$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")"
+      if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
+        values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+      else
+        values_repo="$NVCM_VALUES_REPO_PATH"
+      fi
+      git clone "https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git" values-repo
+      cd values-repo
+      git fetch origin "${NVCM_ENV_BRANCH}" main
+      git checkout "${NVCM_ENV_BRANCH}"
+
+      echo "Resetting ${NVCM_ENV_STATE_DIR}/ to the canonicals on main..."
+      git checkout origin/main -- "${NVCM_ENV_STATE_DIR}/"
+
+      if git diff --cached --quiet && git diff --quiet; then
+        echo "✓ ${NVCM_PROMOTE_ENV} already matches the canonicals; nothing to release."
+        exit 0
+      fi
+
+      git add "${NVCM_ENV_STATE_DIR}/"
+      git commit -m "[nvcm CI] Release ${NVCM_PROMOTE_ENV}: reset deploy-state and overrides to canonicals
+
+      Triggered by: ${GITLAB_USER_LOGIN:-${GITLAB_USER_NAME:-ci}}
+      Pipeline: ${CI_PIPELINE_URL}"
+      git push origin "HEAD:refs/heads/${NVCM_ENV_BRANCH}"
+      echo "✅ ${NVCM_PROMOTE_ENV} released. ArgoCD will re-deploy the canonical baseline state."

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -201,6 +201,9 @@ test-promote-chart:
         --set "global.images.keaAdmin.digest=${DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN}" \
         --set "global.images.nautobot.digest=${DIGEST_NV_CONFIG_MANAGER_NAUTOBOT}" \
         --set "global.images.natsReady.digest=${DIGEST_NV_CONFIG_MANAGER_NATS_READY}" \
+        --set "global.images.temporalServer.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL}" \
+        --set "global.images.temporalBootstrap.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP}" \
+        --set "global.images.temporalUi.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI}" \
         > /dev/null
       echo "✅ Render OK"
 

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -132,7 +132,12 @@ test-promote-chart:
       echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
       apt update
       apt install -y helm git wget unzip
-      wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+      # Pinned yq + SHA-256 verification (this is a secret-bearing job; do not
+      # run an unverified binary from a floating 'latest' URL).
+      YQ_VERSION=v4.44.6
+      YQ_SHA256=0c2b24e645b57d8e7c0566d18643a6d4f5580feeea3878127354a46f2a1e4598
+      wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+      echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum -c -
       chmod +x /usr/local/bin/yq
     - wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.8.2/files/ngccli_linux.zip -O ngccli_linux.zip
     - unzip ngccli_linux.zip
@@ -170,11 +175,17 @@ test-promote-chart:
       # packaged .tgz already vendors its subcharts, so nothing is fetched.
       eval "$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/test_env_config.sh" "$NVCM_PROMOTE_ENV")"
       if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
-        values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+        values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
       else
-        values_repo="$NVCM_VALUES_REPO_PATH"
+        values_repo_url="https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${NVCM_VALUES_REPO_PATH}.git"
       fi
-      git clone "https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git" /tmp/values-repo
+      git clone "$values_repo_url" /tmp/values-repo
+      # Capture the exact main SHA whose baseline values this render validates.
+      # write_deploy_state consumes it (via dotenv) instead of re-resolving
+      # origin/main, so the DEPLOYED baseline is the one that was validated even
+      # if main moves before the deploy-state job runs.
+      baseline_revision="$(git -C /tmp/values-repo rev-parse HEAD)"
+      echo "BASELINE_REVISION=${baseline_revision}" > "${CI_PROJECT_DIR}/chart.env"
       git -C /tmp/values-repo fetch origin "${NVCM_ENV_BRANCH}"
       git -C /tmp/values-repo worktree add /tmp/values-env "origin/${NVCM_ENV_BRANCH}"
       overrides_file="/tmp/values-env/${NVCM_ENV_STATE_DIR}/values-aws-${NVCM_ENV}.overrides.yaml"
@@ -199,6 +210,9 @@ test-promote-chart:
       cp "$chart_file" "${CI_PROJECT_DIR}/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
       cd "${CI_PROJECT_DIR}"
       bash .gitlab/ci/scripts/publish_chart_targets.sh "${CHART_NAME}-${PROMOTE_VERSION}.tgz" "$PROMOTE_VERSION" "$CHART_NAME"
+  artifacts:
+    reports:
+      dotenv: chart.env
 
 # -----------------------------------------------------------------------------
 # 4) Commit the deployment-state to the env branch. ArgoCD does the rest.
@@ -217,8 +231,12 @@ test-promote-deploy-state:
     - job: test-promote-push-images
       artifacts: true
     - job: test-promote-chart
+      artifacts: true
   environment:
     name: $NVCM_PROMOTE_ENV
+  # Serialize env-branch mutations (promote / rollback / release) per env so
+  # concurrent runs can't race on the same nvcm-<env> branch.
+  resource_group: nvcm-env-$NVCM_PROMOTE_ENV
   before_script:
     - apk add --no-cache bash git yq curl coreutils
     - git config --global user.email "${CI_PUSH_EMAIL:-ci@nv-config-manager}"
@@ -243,6 +261,9 @@ test-rollback-env:
   needs: []
   environment:
     name: $NVCM_PROMOTE_ENV
+  # Serialize env-branch mutations (promote / rollback / release) per env so
+  # concurrent runs can't race on the same nvcm-<env> branch.
+  resource_group: nvcm-env-$NVCM_PROMOTE_ENV
   before_script:
     - apk add --no-cache bash git yq coreutils
     - git config --global user.email "${CI_PUSH_EMAIL:-ci@nv-config-manager}"
@@ -252,11 +273,11 @@ test-rollback-env:
       set -e
       eval "$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")"
       if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
-        values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+        values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
       else
-        values_repo="$NVCM_VALUES_REPO_PATH"
+        values_repo_url="https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${NVCM_VALUES_REPO_PATH}.git"
       fi
-      git clone "https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git" values-repo
+      git clone "$values_repo_url" values-repo
       cd values-repo
       git fetch origin "${NVCM_ENV_BRANCH}"
       git checkout "${NVCM_ENV_BRANCH}"
@@ -303,6 +324,9 @@ test-release-env:
   needs: []
   environment:
     name: $NVCM_PROMOTE_ENV
+  # Serialize env-branch mutations (promote / rollback / release) per env so
+  # concurrent runs can't race on the same nvcm-<env> branch.
+  resource_group: nvcm-env-$NVCM_PROMOTE_ENV
   before_script:
     - apk add --no-cache bash git coreutils
     - git config --global user.email "${CI_PUSH_EMAIL:-ci@nv-config-manager}"
@@ -312,11 +336,11 @@ test-release-env:
       set -e
       eval "$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")"
       if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
-        values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+        values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
       else
-        values_repo="$NVCM_VALUES_REPO_PATH"
+        values_repo_url="https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${NVCM_VALUES_REPO_PATH}.git"
       fi
-      git clone "https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git" values-repo
+      git clone "$values_repo_url" values-repo
       cd values-repo
       git fetch origin "${NVCM_ENV_BRANCH}" main
       git checkout "${NVCM_ENV_BRANCH}"

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -159,19 +159,32 @@ test-promote-chart:
       # source, so no untrusted chart code (e.g. `helm dependency build`) runs
       # in this credentialed context.
       : "${CHART_BUILD_JOB_ID:?missing dotenv from test-promote-build}"
+      # SECURITY: this archive is produced by the untrusted build stage - the PR
+      # controls pr-build.yml, and therefore the artifact's paths and contents.
+      # Extract into a throwaway directory, NEVER into CI_PROJECT_DIR: unzipping
+      # in place would let a crafted artifact overwrite the trusted scripts this
+      # job then executes (test_env_config.sh, publish_chart_targets.sh), giving
+      # arbitrary code execution with the registry and values-push credentials.
+      chart_dl="$(mktemp -d)"
       curl -fsS --retry 3 --retry-delay 5 -H "JOB-TOKEN: ${CI_JOB_TOKEN}" \
-        -o chart-artifacts.zip \
+        -o "${chart_dl}/chart-artifacts.zip" \
         "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/jobs/${CHART_BUILD_JOB_ID}/artifacts"
-      unzip -o -q chart-artifacts.zip
+      unzip -q "${chart_dl}/chart-artifacts.zip" -d "${chart_dl}/x"
 
       # Provenance: require exactly the chart version this promote run computed
       # from trusted PR metadata. A chart stamped with any other version does
       # not match and is rejected (fails closed).
       CHART_NAME=nv-config-manager
-      chart_file="chart/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
+      chart_file="${chart_dl}/x/chart/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
       if [ ! -f "$chart_file" ]; then
-        echo "❌ Expected ${chart_file} not found in build artifacts"
-        ls -laR chart || true
+        echo "❌ Expected chart/${CHART_NAME}-${PROMOTE_VERSION}.tgz not found in build artifacts"
+        ls -laR "${chart_dl}/x" || true
+        exit 1
+      fi
+      # Reject a symlink masquerading as the chart (it could point anywhere on
+      # the filesystem); only a regular file is acceptable.
+      if [ -L "$chart_file" ]; then
+        echo "❌ ${chart_file} is a symlink, not a regular file"
         exit 1
       fi
 
@@ -217,20 +230,26 @@ test-promote-chart:
       overrides_file="/tmp/values-env/${NVCM_ENV_STATE_DIR}/values-aws-${NVCM_ENV}.overrides.yaml"
       test -f "$overrides_file" || (echo "❌ Missing overrides file ${overrides_file} on ${NVCM_ENV_BRANCH}" && exit 1)
 
+      # Render with identical inputs for any package, so the locally validated
+      # one and the published one can be compared.
+      render_chart() {
+        helm template "${NVCM_ENV_RELEASE_NAME}" "$1" \
+          -f "/tmp/values-repo/${NVCM_ENV_BASELINE_VALUES}" \
+          -f "$overrides_file" \
+          --set "global.images.nvConfigManager.digest=${DIGEST_NV_CONFIG_MANAGER}" \
+          --set "global.images.nvConfigManagerUi.digest=${DIGEST_NV_CONFIG_MANAGER_UI}" \
+          --set "global.images.kea.digest=${DIGEST_NV_CONFIG_MANAGER_KEA}" \
+          --set "global.images.keaAdmin.digest=${DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN}" \
+          --set "global.images.nautobot.digest=${DIGEST_NV_CONFIG_MANAGER_NAUTOBOT}" \
+          --set "global.images.natsReady.digest=${DIGEST_NV_CONFIG_MANAGER_NATS_READY}" \
+          --set "global.images.temporalServer.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL}" \
+          --set "global.images.temporalBootstrap.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP}" \
+          --set "global.images.temporalUi.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI}" \
+          > "$2"
+      }
+
       echo "🔍 Validating render for ${NVCM_ENV}..."
-      helm template "${NVCM_ENV_RELEASE_NAME}" "$chart_file" \
-        -f "/tmp/values-repo/${NVCM_ENV_BASELINE_VALUES}" \
-        -f "$overrides_file" \
-        --set "global.images.nvConfigManager.digest=${DIGEST_NV_CONFIG_MANAGER}" \
-        --set "global.images.nvConfigManagerUi.digest=${DIGEST_NV_CONFIG_MANAGER_UI}" \
-        --set "global.images.kea.digest=${DIGEST_NV_CONFIG_MANAGER_KEA}" \
-        --set "global.images.keaAdmin.digest=${DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN}" \
-        --set "global.images.nautobot.digest=${DIGEST_NV_CONFIG_MANAGER_NAUTOBOT}" \
-        --set "global.images.natsReady.digest=${DIGEST_NV_CONFIG_MANAGER_NATS_READY}" \
-        --set "global.images.temporalServer.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL}" \
-        --set "global.images.temporalBootstrap.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP}" \
-        --set "global.images.temporalUi.digest=${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI}" \
-        > /dev/null
+      render_chart "$chart_file" /tmp/render-validated.yaml
       echo "✅ Render OK"
 
       echo "📤 Publishing chart to configured targets..."
@@ -239,6 +258,37 @@ test-promote-chart:
       cp "$chart_file" "${CI_PROJECT_DIR}/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
       cd "${CI_PROJECT_DIR}"
       bash .gitlab/ci/scripts/publish_chart_targets.sh "${CHART_NAME}-${PROMOTE_VERSION}.tgz" "$PROMOTE_VERSION" "$CHART_NAME"
+
+      # The publisher treats "already exists" as success, and PROMOTE_VERSION is
+      # a pure function of PR+SHA - so a concurrent or earlier run could already
+      # have published a DIFFERENT package at this version and ours was silently
+      # skipped. Verify the registry now serves what we validated; otherwise
+      # deploy-state would pin a package this run never rendered.
+      echo "🔎 Verifying the published chart matches the validated package..."
+      ngc_key="$(awk -F' = ' '/^apikey/{print $2}' ~/.ngc/config 2>/dev/null || true)"
+      if [ -z "$ngc_key" ]; then
+        echo "❌ No NGC credentials available to verify the published chart."
+        echo "   (Expected ~/.ngc/config from an 'ngc' entry in NVCM_CHART_TARGETS.)"
+        exit 1
+      fi
+      verify_dir="$(mktemp -d)"
+      helm repo add nvcm-verify "$NVCM_CHART_REPO" --username '$oauthtoken' --password "$ngc_key" >/dev/null
+      helm repo update nvcm-verify >/dev/null
+      helm pull "nvcm-verify/${CHART_NAME}" --version "$PROMOTE_VERSION" --devel -d "$verify_dir"
+      published_chart="${verify_dir}/${CHART_NAME}-${PROMOTE_VERSION}.tgz"
+      if [ ! -f "$published_chart" ]; then
+        echo "❌ Could not pull ${CHART_NAME}:${PROMOTE_VERSION} back from ${NVCM_CHART_REPO}"
+        exit 1
+      fi
+      render_chart "$published_chart" /tmp/render-published.yaml
+      if ! diff -q /tmp/render-validated.yaml /tmp/render-published.yaml >/dev/null; then
+        echo "❌ The chart published at ${PROMOTE_VERSION} does NOT match the package"
+        echo "   this run validated - a different package already existed at this"
+        echo "   version. Refusing to promote an unvalidated chart."
+        diff /tmp/render-validated.yaml /tmp/render-published.yaml | head -40
+        exit 1
+      fi
+      echo "✅ Published chart renders identically to the validated package"
   artifacts:
     reports:
       dotenv: chart.env

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -180,7 +180,8 @@ test-promote-chart:
       # env branch. helm template is sandboxed (no env access), so rendering the
       # untrusted chart with the values token present cannot leak secrets; the
       # packaged .tgz already vendors its subcharts, so nothing is fetched.
-      eval "$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/test_env_config.sh" "$NVCM_PROMOTE_ENV")"
+      env_config="$(bash "${CI_PROJECT_DIR}/.gitlab/ci/scripts/test_env_config.sh" "$NVCM_PROMOTE_ENV")" || exit $?
+      eval "$env_config"
       if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
         values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
       else
@@ -254,7 +255,9 @@ test-promote-deploy-state:
   script:
     # Final stale-HEAD check before mutating the env branch.
     - bash .gitlab/ci/scripts/pr_ref_guard.sh "$PR_REF" "$PR_SHA"
-    - eval "$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")"
+    - |
+      env_config="$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")" || exit $?
+      eval "$env_config"
     - bash .gitlab/ci/scripts/write_deploy_state.sh
 
 # -----------------------------------------------------------------------------
@@ -281,7 +284,8 @@ test-rollback-env:
   script:
     - |
       set -e
-      eval "$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")"
+      env_config="$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")" || exit $?
+      eval "$env_config"
       if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
         values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
       else
@@ -363,7 +367,8 @@ test-release-env:
   script:
     - |
       set -e
-      eval "$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")"
+      env_config="$(bash .gitlab/ci/scripts/test_env_config.sh "$NVCM_PROMOTE_ENV")" || exit $?
+      eval "$env_config"
       if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
         values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
       else
@@ -375,6 +380,10 @@ test-release-env:
       git checkout "${NVCM_ENV_BRANCH}"
 
       echo "Resetting ${NVCM_ENV_STATE_DIR}/ to the canonicals on main..."
+      # Clear the directory first: `git checkout <ref> -- <dir>` only overwrites
+      # paths that exist on main, so files added only on the env branch (scratch
+      # values, stray notes) would survive a release and leave the slot dirty.
+      git rm -r --quiet --ignore-unmatch "${NVCM_ENV_STATE_DIR}/"
       git checkout origin/main -- "${NVCM_ENV_STATE_DIR}/"
 
       if git diff --cached --quiet && git diff --quiet; then

--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -34,6 +34,10 @@
     - job: docker-manifest-main
       optional: true
   rules: &pulse-scan-rules
+    # Skip during test-env promote pipelines (web pipelines on the default
+    # branch with $NVCM_PROMOTE_ENV set).
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_COMMIT_TAG
       when: on_success
     - if: $FORCE_PULSE_SCAN == "true" && ($CI_PIPELINE_SOURCE == "merge_request_event" || $CI_COMMIT_BRANCH)

--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -36,7 +36,7 @@
   rules: &pulse-scan-rules
     # Skip during test-env promote pipelines (web pipelines on the default
     # branch with $NVCM_PROMOTE_ENV set).
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_COMMIT_TAG
       when: on_success

--- a/.gitlab/ci/scripts/promote_build_pipeline.sh
+++ b/.gitlab/ci/scripts/promote_build_pipeline.sh
@@ -17,8 +17,9 @@
 #             NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE (default false)
 # Requires: NVCM_MIRROR_API_TOKEN (read_api; polling/job-listing endpoints are
 #           not in the CI_JOB_TOKEN allowlist), CI_JOB_TOKEN (trigger + clone)
-# Output:   promote.env dotenv - PR_NUM, PR_REF, PR_SHA, PR_SHORT_SHA,
-#           PROMOTE_VERSION, BUILD_PIPELINE_ID, BUILD_JOB_ID_<IMAGE> x6,
+# Output:   promote.env (dotenv + file artifact) - PR_NUM, PR_REF, PR_SHA,
+#           PR_SHORT_SHA,
+#           PROMOTE_VERSION, BUILD_PIPELINE_ID, BUILD_JOB_ID_<IMAGE> x9,
 #           CHART_BUILD_JOB_ID
 set -euo pipefail
 
@@ -46,7 +47,7 @@ allowed_build_sources='["pipeline","trigger","api","web"]'
 PR_NUM="$NVCM_PROMOTE_PR"
 PR_REF="pull-request/${PR_NUM}"
 
-# The six pr-build-image matrix entries (target|image), matching pr-build.yml.
+# The nine pr-build-image matrix entries (target|image), matching pr-build.yml.
 matrix_entries="nv-config-manager|nv-config-manager
 kea|nv-config-manager-kea
 kea-admin|nv-config-manager-kea-admin

--- a/.gitlab/ci/scripts/promote_build_pipeline.sh
+++ b/.gitlab/ci/scripts/promote_build_pipeline.sh
@@ -45,7 +45,10 @@ kea|nv-config-manager-kea
 kea-admin|nv-config-manager-kea-admin
 ui|nv-config-manager-ui
 nb|nv-config-manager-nautobot
-nats-ready|nv-config-manager-nats-ready"
+nats-ready|nv-config-manager-nats-ready
+temporal-server|nv-config-manager-temporal
+temporal-bootstrap|nv-config-manager-temporal-bootstrap
+temporal-ui|nv-config-manager-temporal-ui"
 
 api_get() {
     curl -fsS --max-time 30 -H "PRIVATE-TOKEN: ${NVCM_MIRROR_API_TOKEN}" "$@"

--- a/.gitlab/ci/scripts/promote_build_pipeline.sh
+++ b/.gitlab/ci/scripts/promote_build_pipeline.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Stage 1 of the test-env promote flow: obtain a successful secret-free build
+# of the vetted copy-pr-bot snapshot (pull-request/<n>) on the mirror.
+#
+# Resolves the snapshot's HEAD SHA, confirms the PR is still open upstream and
+# warns if the snapshot lags the PR's live HEAD, then either reuses an existing
+# successful build pipeline for that exact ref+SHA (unexpired artifacts) or
+# API-triggers a new one on the pull-request ref and polls it to completion.
+# The build pipeline runs on an UNPROTECTED ref, so it executes the untrusted
+# PR code without any protected variables; no variables are passed on the
+# trigger call because trigger variables would be visible to those untrusted
+# jobs. Provenance is finally asserted from GitLab's own pipeline metadata.
+#
+# Inputs (pipeline variables): NVCM_PROMOTE_PR, NVCM_PROMOTE_ENV
+#   Optional: NVCM_PROMOTE_REUSE_BUILD (default true),
+#             NVCM_PROMOTE_REQUIRE_PR_HEAD (default false),
+#             NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE (default false)
+# Requires: NVCM_MIRROR_API_TOKEN (read_api; polling/job-listing endpoints are
+#           not in the CI_JOB_TOKEN allowlist), CI_JOB_TOKEN (trigger + clone)
+# Output:   promote.env dotenv - PR_NUM, PR_REF, PR_SHA, PR_SHORT_SHA,
+#           PROMOTE_VERSION, BUILD_PIPELINE_ID, BUILD_JOB_ID_<IMAGE> x6,
+#           CHART_BUILD_JOB_ID
+set -euo pipefail
+
+: "${NVCM_PROMOTE_PR:?Set NVCM_PROMOTE_PR to the GitHub PR number}"
+: "${NVCM_PROMOTE_ENV:?Set NVCM_PROMOTE_ENV to the target environment}"
+: "${NVCM_MIRROR_API_TOKEN:?NVCM_MIRROR_API_TOKEN (read_api) is required}"
+
+if ! printf '%s' "$NVCM_PROMOTE_PR" | grep -Eq '^[0-9]+$'; then
+    echo "ERROR: NVCM_PROMOTE_PR must be a PR number, got '${NVCM_PROMOTE_PR}'"
+    exit 1
+fi
+
+github_repo="${NVCM_UPSTREAM_GITHUB_REPO:-NVIDIA/nv-config-manager}"
+api="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}"
+poll_interval="${NVCM_BUILD_POLL_INTERVAL:-30}"
+poll_timeout="${NVCM_BUILD_POLL_TIMEOUT:-5400}"
+
+PR_NUM="$NVCM_PROMOTE_PR"
+PR_REF="pull-request/${PR_NUM}"
+
+# The six pr-build-image matrix entries (target|image), matching pr-build.yml.
+matrix_entries="nv-config-manager|nv-config-manager
+kea|nv-config-manager-kea
+kea-admin|nv-config-manager-kea-admin
+ui|nv-config-manager-ui
+nb|nv-config-manager-nautobot
+nats-ready|nv-config-manager-nats-ready"
+
+api_get() {
+    curl -fsS --max-time 30 -H "PRIVATE-TOKEN: ${NVCM_MIRROR_API_TOKEN}" "$@"
+}
+
+# -----------------------------------------------------------------------------
+# Resolve the current HEAD of the VETTED copy-pr-bot snapshot on the mirror
+# (pull-request/<n>). This is intentionally the vetted snapshot, not the PR's
+# live HEAD - the GitHub PR-HEAD comparison below surfaces any divergence.
+# -----------------------------------------------------------------------------
+PR_SHA="$(git ls-remote "$CI_REPOSITORY_URL" "refs/heads/${PR_REF}" | cut -f1)"
+if [ -z "$PR_SHA" ]; then
+    echo "ERROR: ${PR_REF} does not exist on the mirror."
+    echo "Either the PR is closed/merged, copy-pr-bot has not vetted it, or"
+    echo "pull-mirroring has not replicated the branch yet."
+    exit 1
+fi
+PR_SHORT_SHA="$(printf '%s' "$PR_SHA" | cut -c1-8)"
+PROMOTE_VERSION="0.0.0-pr${PR_NUM}.${PR_SHORT_SHA}"
+echo "PR #${PR_NUM}: ${PR_REF} @ ${PR_SHA}"
+echo "Promote version: ${PROMOTE_VERSION}"
+
+# Interactive-path upstream checks against GitHub's PR API. This API is
+# authoritative for PR *state* and the PR's *true* HEAD - unlike the copy-pr-bot
+# pull-request/<n> branch (PR_SHA above), which is a VETTED SNAPSHOT that may
+# lag the PR (untrusted authors only re-copy on /ok to test).
+pr_json="$(curl -fsS --max-time 10 "https://api.github.com/repos/${github_repo}/pulls/${PR_NUM}" || true)"
+if [ -n "$pr_json" ]; then
+    pr_state="$(printf '%s' "$pr_json" | jq -r '.state // empty')"
+    if [ "$pr_state" != "open" ]; then
+        echo "ERROR: upstream PR #${PR_NUM} is '${pr_state:-unknown}', not open. Refusing to promote."
+        exit 1
+    fi
+    # Surface (do NOT silently deploy) a vetted snapshot older than PR HEAD. We
+    # deliberately promote the vetted snapshot, not the live PR HEAD - newer
+    # commits are unvetted and must not run - but the operator must know when
+    # what deploys is not their latest push.
+    pr_head_sha="$(printf '%s' "$pr_json" | jq -r '.head.sha // empty')"
+    if [ -n "$pr_head_sha" ] && [ "$pr_head_sha" != "$PR_SHA" ]; then
+        echo "WARN: PR #${PR_NUM} HEAD is ${pr_head_sha}, but the vetted copy-pr-bot"
+        echo "      snapshot (pull-request/${PR_NUM}) is ${PR_SHA}. Promoting the VETTED"
+        echo "      snapshot; to deploy newer commits, have them re-vetted (/ok to test)."
+        if [ "${NVCM_PROMOTE_REQUIRE_PR_HEAD:-false}" = "true" ]; then
+            echo "ERROR: NVCM_PROMOTE_REQUIRE_PR_HEAD=true and the snapshot lags PR HEAD."
+            exit 1
+        fi
+    fi
+elif [ "${NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE:-false}" = "true" ]; then
+    echo "WARN: could not query GitHub PR state; NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE=true set, continuing."
+else
+    # Fail closed: don't promote a possibly-closed PR just because GitHub was
+    # unreachable. Operator can explicitly override for a GitHub outage.
+    echo "ERROR: could not confirm PR #${PR_NUM} is open (GitHub unreachable or rate-limited)."
+    echo "Re-run when GitHub is reachable, or set NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE=true to override."
+    exit 1
+fi
+bash "$(dirname "$0")/pr_ref_guard.sh" "$PR_REF" "$PR_SHA"
+
+# -----------------------------------------------------------------------------
+# Reuse an existing successful build for this exact ref+SHA, if allowed.
+# -----------------------------------------------------------------------------
+BUILD_PIPELINE_ID=""
+if [ "${NVCM_PROMOTE_REUSE_BUILD:-true}" != "false" ]; then
+    BUILD_PIPELINE_ID="$(api_get "${api}/pipelines?ref=$(printf '%s' "$PR_REF" | sed 's|/|%2F|g')&sha=${PR_SHA}&status=success&order_by=id&sort=desc&per_page=1" \
+        | jq -r '.[0].id // empty')"
+    if [ -n "$BUILD_PIPELINE_ID" ]; then
+        echo "Found existing successful build pipeline ${BUILD_PIPELINE_ID} for ${PR_SHA}; will verify its artifacts."
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Otherwise trigger a fresh build on the pull-request ref and poll it.
+# CI_JOB_TOKEN is a valid same-project trigger token. NO variables are passed.
+# -----------------------------------------------------------------------------
+if [ -z "$BUILD_PIPELINE_ID" ]; then
+    echo "Triggering build pipeline on ${PR_REF}..."
+    trigger_response="$(curl -fsS --max-time 30 -X POST \
+        -F "token=${CI_JOB_TOKEN}" \
+        -F "ref=${PR_REF}" \
+        "${api}/trigger/pipeline")"
+    BUILD_PIPELINE_ID="$(printf '%s' "$trigger_response" | jq -r '.id // empty')"
+    if [ -z "$BUILD_PIPELINE_ID" ]; then
+        echo "ERROR: failed to trigger build pipeline:"
+        printf '%s\n' "$trigger_response"
+        echo "Hint: if GitLab reports an empty pipeline, the PR branch predates"
+        echo "the pr-build CI definitions - ask the author to rebase onto main."
+        exit 1
+    fi
+    echo "Build pipeline: ${CI_PROJECT_URL}/-/pipelines/${BUILD_PIPELINE_ID}"
+
+    elapsed=0
+    while :; do
+        status="$(api_get "${api}/pipelines/${BUILD_PIPELINE_ID}" | jq -r '.status')"
+        case "$status" in
+            success)
+                echo "Build pipeline ${BUILD_PIPELINE_ID} succeeded."
+                break
+                ;;
+            failed|canceled|skipped)
+                echo "ERROR: build pipeline ${BUILD_PIPELINE_ID} ended with status '${status}'."
+                echo "See ${CI_PROJECT_URL}/-/pipelines/${BUILD_PIPELINE_ID}"
+                exit 1
+                ;;
+            *)
+                if [ "$elapsed" -ge "$poll_timeout" ]; then
+                    echo "ERROR: timed out after ${poll_timeout}s waiting for build pipeline ${BUILD_PIPELINE_ID} (status: ${status})."
+                    exit 1
+                fi
+                echo "Build pipeline ${BUILD_PIPELINE_ID} status: ${status} (${elapsed}s elapsed)"
+                sleep "$poll_interval"
+                elapsed=$((elapsed + poll_interval))
+                ;;
+        esac
+    done
+fi
+
+# -----------------------------------------------------------------------------
+# Trusted provenance gate. GitLab records the exact commit and ref a pipeline
+# ran on; assert the build pipeline ran on the PR HEAD we resolved and guarded.
+# This is the ONLY provenance check that matters: it uses GitLab metadata, not
+# any file the untrusted build produced (which the PR author fully controls).
+# -----------------------------------------------------------------------------
+build_pipeline_json="$(api_get "${api}/pipelines/${BUILD_PIPELINE_ID}")"
+build_sha="$(printf '%s' "$build_pipeline_json" | jq -r '.sha')"
+build_ref="$(printf '%s' "$build_pipeline_json" | jq -r '.ref')"
+build_status="$(printf '%s' "$build_pipeline_json" | jq -r '.status')"
+build_source="$(printf '%s' "$build_pipeline_json" | jq -r '.source')"
+if [ "$build_sha" != "$PR_SHA" ] || [ "$build_ref" != "$PR_REF" ] || [ "$build_status" != "success" ]; then
+    echo "ERROR: build pipeline ${BUILD_PIPELINE_ID} provenance mismatch."
+    echo "  got ref=${build_ref} sha=${build_sha} status=${build_status}"
+    echo "  expected ref=${PR_REF} sha=${PR_SHA} status=success"
+    echo "Re-run with NVCM_PROMOTE_REUSE_BUILD=false to force a fresh build."
+    exit 1
+fi
+case "$build_source" in
+    pipeline|trigger|api|web)
+        ;;
+    *)
+        echo "ERROR: build pipeline ${BUILD_PIPELINE_ID} has disallowed source '${build_source}'."
+        echo "Expected a deliberately triggered pipeline (pipeline, trigger, api, or web)."
+        exit 1
+        ;;
+esac
+echo "Provenance OK: successful ${build_source} pipeline ${BUILD_PIPELINE_ID} ran on ${PR_REF}@${PR_SHA}"
+
+# -----------------------------------------------------------------------------
+# Collect the six pr-build-image job ids and confirm artifacts are usable.
+# -----------------------------------------------------------------------------
+jobs_json="$(api_get "${api}/pipelines/${BUILD_PIPELINE_ID}/jobs?per_page=100")"
+
+{
+    echo "PR_NUM=${PR_NUM}"
+    echo "PR_REF=${PR_REF}"
+    echo "PR_SHA=${PR_SHA}"
+    echo "PR_SHORT_SHA=${PR_SHORT_SHA}"
+    echo "PROMOTE_VERSION=${PROMOTE_VERSION}"
+    echo "BUILD_PIPELINE_ID=${BUILD_PIPELINE_ID}"
+} > promote.env
+
+now_epoch="$(date -u +%s)"
+while IFS='|' read -r target image; do
+    job_name="pr-build-image: [${target}, ${image}]"
+    job_json="$(printf '%s' "$jobs_json" | jq -c --arg name "$job_name" '[.[] | select(.name == $name and .status == "success")] | sort_by(.id) | last // empty')"
+    if [ -z "$job_json" ] || [ "$job_json" = "null" ]; then
+        echo "ERROR: no successful '${job_name}' job in pipeline ${BUILD_PIPELINE_ID}."
+        exit 1
+    fi
+    job_id="$(printf '%s' "$job_json" | jq -r '.id')"
+    expires_at="$(printf '%s' "$job_json" | jq -r '.artifacts_expire_at // empty')"
+    if [ -n "$expires_at" ]; then
+        expire_epoch="$(date -u -d "$expires_at" +%s 2>/dev/null || date -u -D "%Y-%m-%dT%H:%M:%S" -d "${expires_at%%.*}" +%s 2>/dev/null || echo 0)"
+        if [ "$expire_epoch" != "0" ] && [ "$expire_epoch" -le "$now_epoch" ]; then
+            echo "ERROR: artifacts of job ${job_id} (${job_name}) have expired."
+            echo "Re-run with NVCM_PROMOTE_REUSE_BUILD=false to force a fresh build."
+            exit 1
+        fi
+    fi
+    key="$(printf '%s' "$image" | tr 'a-z-' 'A-Z_')"
+    echo "BUILD_JOB_ID_${key}=${job_id}" >> promote.env
+    echo "  ${job_name} -> job ${job_id}"
+done <<EOF
+${matrix_entries}
+EOF
+
+# The chart is packaged (secret-free) alongside the images; capture its job id
+# so the promote pipeline can download the .tgz and publish it without ever
+# rebuilding from PR source.
+chart_job_id="$(printf '%s' "$jobs_json" | jq -r '[.[] | select(.name == "pr-build-chart" and .status == "success")] | sort_by(.id) | last | .id // empty')"
+if [ -z "$chart_job_id" ]; then
+    echo "ERROR: no successful 'pr-build-chart' job in pipeline ${BUILD_PIPELINE_ID}."
+    exit 1
+fi
+echo "CHART_BUILD_JOB_ID=${chart_job_id}" >> promote.env
+echo "  pr-build-chart -> job ${chart_job_id}"
+
+echo "Build stage resolved:"
+cat promote.env

--- a/.gitlab/ci/scripts/promote_build_pipeline.sh
+++ b/.gitlab/ci/scripts/promote_build_pipeline.sh
@@ -36,6 +36,13 @@ api="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}"
 poll_interval="${NVCM_BUILD_POLL_INTERVAL:-30}"
 poll_timeout="${NVCM_BUILD_POLL_TIMEOUT:-5400}"
 
+# Pipeline sources that count as a deliberately triggered build. Anything else
+# (a mirror push, a schedule, ...) is refused by the pr-build workflow rules in
+# common.yml, so such a pipeline can be "successful" without having built
+# anything. Applied both when picking a build to reuse and at the provenance
+# gate below; keep the two in sync by keeping this the only copy.
+allowed_build_sources='["pipeline","trigger","api","web"]'
+
 PR_NUM="$NVCM_PROMOTE_PR"
 PR_REF="pull-request/${PR_NUM}"
 
@@ -112,8 +119,12 @@ bash "$(dirname "$0")/pr_ref_guard.sh" "$PR_REF" "$PR_SHA"
 # -----------------------------------------------------------------------------
 BUILD_PIPELINE_ID=""
 if [ "${NVCM_PROMOTE_REUSE_BUILD:-true}" != "false" ]; then
-    BUILD_PIPELINE_ID="$(api_get "${api}/pipelines?ref=$(printf '%s' "$PR_REF" | sed 's|/|%2F|g')&sha=${PR_SHA}&status=success&order_by=id&sort=desc&per_page=1" \
-        | jq -r '.[0].id // empty')"
+    # Consider several recent successes, not just the newest: a pipeline with a
+    # disallowed source would be rejected by the provenance gate below, which
+    # would dead-end the promote instead of falling through to a fresh trigger.
+    BUILD_PIPELINE_ID="$(api_get "${api}/pipelines?ref=$(printf '%s' "$PR_REF" | sed 's|/|%2F|g')&sha=${PR_SHA}&status=success&order_by=id&sort=desc&per_page=20" \
+        | jq -r --argjson allowed "$allowed_build_sources" \
+            '[.[] | select(.source as $s | $allowed | index($s))] | sort_by(.id) | last | .id // empty')"
     if [ -n "$BUILD_PIPELINE_ID" ]; then
         echo "Found existing successful build pipeline ${BUILD_PIPELINE_ID} for ${PR_SHA}; will verify its artifacts."
     fi
@@ -183,15 +194,12 @@ if [ "$build_sha" != "$PR_SHA" ] || [ "$build_ref" != "$PR_REF" ] || [ "$build_s
     echo "Re-run with NVCM_PROMOTE_REUSE_BUILD=false to force a fresh build."
     exit 1
 fi
-case "$build_source" in
-    pipeline|trigger|api|web)
-        ;;
-    *)
-        echo "ERROR: build pipeline ${BUILD_PIPELINE_ID} has disallowed source '${build_source}'."
-        echo "Expected a deliberately triggered pipeline (pipeline, trigger, api, or web)."
-        exit 1
-        ;;
-esac
+if ! printf '%s' "$allowed_build_sources" \
+    | jq -e --arg s "$build_source" 'index($s) != null' >/dev/null; then
+    echo "ERROR: build pipeline ${BUILD_PIPELINE_ID} has disallowed source '${build_source}'."
+    echo "Expected a deliberately triggered pipeline ($(printf '%s' "$allowed_build_sources" | jq -r 'join(", ")'))."
+    exit 1
+fi
 echo "Provenance OK: successful ${build_source} pipeline ${BUILD_PIPELINE_ID} ran on ${PR_REF}@${PR_SHA}"
 
 # -----------------------------------------------------------------------------

--- a/.gitlab/ci/scripts/promote_push_images.sh
+++ b/.gitlab/ci/scripts/promote_push_images.sh
@@ -77,9 +77,13 @@ for image in $images; do
 
     # Authoritative digest: ask the registry for the pushed manifest digest
     # (the local image id is NOT the registry manifest digest).
-    digest="$(docker buildx imagetools inspect "$dst" --format '{{json .Manifest}}' | grep -o '"digest": *"sha256:[0-9a-f]*"' | head -n 1 | cut -d'"' -f4)"
+    # The `|| true` is required: under `set -euo pipefail` a failing inspect or
+    # a non-matching grep would abort the script here, making the fallback (and
+    # the validation below) unreachable.
+    digest="$(docker buildx imagetools inspect "$dst" --format '{{json .Manifest}}' 2>/dev/null | grep -o '"digest": *"sha256:[0-9a-f]*"' | head -n 1 | cut -d'"' -f4 || true)"
     if [ -z "$digest" ]; then
-        digest="$(docker inspect --format '{{index .RepoDigests 0}}' "$dst" | cut -d@ -f2)"
+        echo "  imagetools inspect yielded no digest; falling back to docker inspect"
+        digest="$(docker inspect --format '{{index .RepoDigests 0}}' "$dst" 2>/dev/null | cut -d@ -f2 || true)"
     fi
     if ! printf '%s' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
         echo "ERROR: could not capture a valid digest for ${dst} (got '${digest}')"

--- a/.gitlab/ci/scripts/promote_push_images.sh
+++ b/.gitlab/ci/scripts/promote_push_images.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Stage 2 of the test-env promote flow: turn the untrusted build's artifacts
+# into immutable registry artifacts.
+#
+# For each of the six images: download the build job's artifact archive by job
+# id (race-free, CI_JOB_TOKEN allowlisted), docker load, retag to
+# ${NVCM_IMAGE_REPOSITORY}/<image>:${PROMOTE_VERSION}, push, and capture the
+# pushed manifest digest from the registry. Images and tars are deleted
+# between iterations to bound dind disk usage.
+#
+# Provenance is NOT checked here: that the artifacts came from the guarded PR
+# HEAD is established once, against GitLab's trusted pipeline metadata, in
+# promote_build_pipeline.sh. This job must never trust or execute anything the
+# untrusted build wrote.
+#
+# Requires (from test-promote-build's dotenv): PR_SHORT_SHA, PROMOTE_VERSION,
+#          BUILD_JOB_ID_<IMAGE> x6
+# Requires (from before_script): docker login already performed,
+#          NVCM_IMAGE_REPOSITORY exported by image_target_env.sh
+# Output:  digests.env dotenv - DIGEST_<IMAGE>=sha256:... x6
+set -euo pipefail
+
+: "${PROMOTE_VERSION:?missing dotenv from test-promote-build}"
+: "${NVCM_IMAGE_REPOSITORY:?image_target_env.sh exports required}"
+
+api="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}"
+short_sha="${PR_SHORT_SHA:?missing dotenv from test-promote-build}"
+
+images="nv-config-manager
+nv-config-manager-kea
+nv-config-manager-kea-admin
+nv-config-manager-ui
+nv-config-manager-nautobot
+nv-config-manager-nats-ready"
+
+: > digests.env
+
+for image in $images; do
+    key="$(printf '%s' "$image" | tr 'a-z-' 'A-Z_')"
+    job_id_var="BUILD_JOB_ID_${key}"
+    job_id="${!job_id_var:?missing ${job_id_var} from test-promote-build dotenv}"
+
+    echo ""
+    echo "=== ${image} (build job ${job_id}) ==="
+    workdir="$(mktemp -d)"
+
+    echo "Downloading artifacts..."
+    curl -fsS --retry 3 --retry-delay 5 -H "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+        -o "${workdir}/artifacts.zip" \
+        "${api}/jobs/${job_id}/artifacts"
+    unzip -q "${workdir}/artifacts.zip" -d "$workdir"
+
+    # The artifact contents (image tarball) are attacker-controlled by design -
+    # they are the PR's own build. Provenance (that this came from the guarded
+    # PR HEAD) is established in promote_build_pipeline.sh against GitLab's
+    # trusted pipeline metadata, NOT from any file the build wrote. Never
+    # source or eval anything under $workdir here: this job holds registry
+    # credentials, so executing untrusted build output would leak them.
+    tar_file="${workdir}/images/${image}.tar.gz"
+    if [ ! -f "$tar_file" ]; then
+        echo "ERROR: job ${job_id} artifacts do not contain ${image}.tar.gz"
+        ls -laR "$workdir" || true
+        exit 1
+    fi
+
+    echo "Loading ${image}..."
+    docker load -i "$tar_file"
+
+    src="pr-local/${image}:${short_sha}"
+    dst="${NVCM_IMAGE_REPOSITORY}/${image}:${PROMOTE_VERSION}"
+    docker tag "$src" "$dst"
+    echo "Pushing ${dst}..."
+    docker push "$dst"
+
+    # Authoritative digest: ask the registry for the pushed manifest digest
+    # (the local image id is NOT the registry manifest digest).
+    digest="$(docker buildx imagetools inspect "$dst" --format '{{json .Manifest}}' | grep -o '"digest": *"sha256:[0-9a-f]*"' | head -n 1 | cut -d'"' -f4)"
+    if [ -z "$digest" ]; then
+        digest="$(docker inspect --format '{{index .RepoDigests 0}}' "$dst" | cut -d@ -f2)"
+    fi
+    if ! printf '%s' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+        echo "ERROR: could not capture a valid digest for ${dst} (got '${digest}')"
+        exit 1
+    fi
+    echo "DIGEST_${key}=${digest}" >> digests.env
+    echo "${dst}"
+    echo "  digest: ${digest}"
+
+    docker rmi "$src" "$dst" >/dev/null 2>&1 || true
+    rm -rf "$workdir"
+done
+
+echo ""
+echo "All images pushed:"
+cat digests.env

--- a/.gitlab/ci/scripts/promote_push_images.sh
+++ b/.gitlab/ci/scripts/promote_push_images.sh
@@ -31,7 +31,10 @@ nv-config-manager-kea
 nv-config-manager-kea-admin
 nv-config-manager-ui
 nv-config-manager-nautobot
-nv-config-manager-nats-ready"
+nv-config-manager-nats-ready
+nv-config-manager-temporal
+nv-config-manager-temporal-bootstrap
+nv-config-manager-temporal-ui"
 
 : > digests.env
 

--- a/.gitlab/ci/scripts/promote_push_images.sh
+++ b/.gitlab/ci/scripts/promote_push_images.sh
@@ -2,7 +2,7 @@
 # Stage 2 of the test-env promote flow: turn the untrusted build's artifacts
 # into immutable registry artifacts.
 #
-# For each of the six images: download the build job's artifact archive by job
+# For each of the nine built images: download the build job's artifact archive by job
 # id (race-free, CI_JOB_TOKEN allowlisted), docker load, retag to
 # ${NVCM_IMAGE_REPOSITORY}/<image>:${PROMOTE_VERSION}, push, and capture the
 # pushed manifest digest from the registry. Images and tars are deleted
@@ -13,18 +13,33 @@
 # promote_build_pipeline.sh. This job must never trust or execute anything the
 # untrusted build wrote.
 #
-# Requires (from test-promote-build's dotenv): PR_SHORT_SHA, PROMOTE_VERSION,
-#          BUILD_JOB_ID_<IMAGE> x6
+# Requires (from test-promote-build FILE artifact promote.env): PR_SHORT_SHA,
+#          PROMOTE_VERSION,
+#          BUILD_JOB_ID_<IMAGE> x9
 # Requires (from before_script): docker login already performed,
 #          NVCM_IMAGE_REPOSITORY exported by image_target_env.sh
-# Output:  digests.env dotenv - DIGEST_<IMAGE>=sha256:... x6
+# Output:  digests.env - DIGEST_<IMAGE>=sha256:... x9 (dotenv + file artifact)
 set -euo pipefail
 
-: "${PROMOTE_VERSION:?missing dotenv from test-promote-build}"
 : "${NVCM_IMAGE_REPOSITORY:?image_target_env.sh exports required}"
 
 api="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}"
-short_sha="${PR_SHORT_SHA:?missing dotenv from test-promote-build}"
+
+# Read the resolved build metadata from test-promote-build's FILE artifact
+# rather than its dotenv export: pipeline variables outrank dotenv, so a
+# same-named variable could otherwise redirect which job's artifacts are
+# downloaded (BUILD_JOB_ID_*) or change the tag images are pushed under.
+promote_attest="${CI_PROJECT_DIR}/promote.env"
+[ -f "$promote_attest" ] || { echo "ERROR: missing attestation artifact ${promote_attest}"; exit 1; }
+attest() {
+    local key="$1" val
+    val="$(grep -m1 "^${key}=" "$promote_attest" | cut -d= -f2- || true)"
+    [ -n "$val" ] || { echo "ERROR: ${key} missing from promote.env"; exit 1; }
+    printf '%s' "$val"
+}
+
+PROMOTE_VERSION="$(attest PROMOTE_VERSION)"
+short_sha="$(attest PR_SHORT_SHA)"
 
 images="nv-config-manager
 nv-config-manager-kea
@@ -40,8 +55,7 @@ nv-config-manager-temporal-ui"
 
 for image in $images; do
     key="$(printf '%s' "$image" | tr 'a-z-' 'A-Z_')"
-    job_id_var="BUILD_JOB_ID_${key}"
-    job_id="${!job_id_var:?missing ${job_id_var} from test-promote-build dotenv}"
+    job_id="$(attest "BUILD_JOB_ID_${key}")"
 
     echo ""
     echo "=== ${image} (build job ${job_id}) ==="

--- a/.gitlab/ci/scripts/test_env_config.sh
+++ b/.gitlab/ci/scripts/test_env_config.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Resolve a shared test environment's deployment configuration from the
+# NVCM_TEST_ENV_TARGETS CI variable (GHF: env branch/namespace/path names are
+# internal details, so they live in protected GitLab variables, not in this
+# public file). Prints shell exports; callers eval the output, mirroring
+# image_target_env.sh.
+#
+# Usage: eval "$(test_env_config.sh <env>)"
+#
+# NVCM_TEST_ENV_TARGETS holds one record per line:
+#   env|env_branch|namespace|release_name|baseline_values|state_dir
+# Example:
+#   test|nvcm-test|kiwi-test|kiwi-platform-test|cfa/values/nv-config-manager/values-aws-test.yaml|cfa/values/nv-config-manager/test
+#   test01|nvcm-test01|kiwi-test01|kiwi-platform-test01|cfa/values/nv-config-manager/values-aws-test01.yaml|cfa/values/nv-config-manager/test01
+#
+# Exports: NVCM_ENV, NVCM_ENV_BRANCH, NVCM_ENV_NAMESPACE,
+#          NVCM_ENV_RELEASE_NAME, NVCM_ENV_BASELINE_VALUES, NVCM_ENV_STATE_DIR
+set -euo pipefail
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+  return 0
+}
+
+shell_export() {
+  printf 'export %s=%q\n' "$1" "$2"
+  return 0
+}
+
+requested_env="$(trim "${1:?usage: test_env_config.sh <env>}")"
+records="${NVCM_TEST_ENV_TARGETS:-}"
+
+if [[ -z "$records" ]]; then
+  echo "NVCM_TEST_ENV_TARGETS is empty or unset (protected variable; only available on protected refs)." >&2
+  exit 1
+fi
+
+while IFS= read -r raw_record; do
+  record="$(trim "$raw_record")"
+  [[ -z "$record" || "$record" == \#* ]] && continue
+
+  IFS='|' read -r env env_branch namespace release_name baseline_values state_dir <<< "$record"
+  env="$(trim "$env")"
+  [[ "$env" == "$requested_env" ]] || continue
+
+  env_branch="$(trim "$env_branch")"
+  namespace="$(trim "$namespace")"
+  release_name="$(trim "$release_name")"
+  baseline_values="$(trim "$baseline_values")"
+  state_dir="$(trim "$state_dir")"
+  for field in env_branch namespace release_name baseline_values state_dir; do
+    if [[ -z "${!field}" ]]; then
+      echo "NVCM_TEST_ENV_TARGETS record for '${env}' is missing field '${field}'." >&2
+      exit 1
+    fi
+  done
+
+  shell_export NVCM_ENV "$env"
+  shell_export NVCM_ENV_BRANCH "$env_branch"
+  shell_export NVCM_ENV_NAMESPACE "$namespace"
+  shell_export NVCM_ENV_RELEASE_NAME "$release_name"
+  shell_export NVCM_ENV_BASELINE_VALUES "$baseline_values"
+  shell_export NVCM_ENV_STATE_DIR "$state_dir"
+  exit 0
+done <<< "$records"
+
+echo "No NVCM_TEST_ENV_TARGETS record found for environment '${requested_env}'." >&2
+exit 1

--- a/.gitlab/ci/scripts/test_env_config.sh
+++ b/.gitlab/ci/scripts/test_env_config.sh
@@ -31,6 +31,27 @@ shell_export() {
 }
 
 requested_env="$(trim "${1:?usage: test_env_config.sh <env>}")"
+
+# Defence in depth. The promote pipeline's rules already constrain
+# NVCM_PROMOTE_ENV to the shared test environments, but this script is the point
+# where an environment name becomes a concrete branch, namespace and release
+# name - so refuse anything outside that set here too. A mis-set variable, a
+# stray NVCM_TEST_ENV_TARGETS record, or a future caller that forgets the rule
+# then fails closed instead of resolving production.
+#
+# Deliberately hardcoded rather than configurable: making the allowlist itself
+# overridable would let the same variable injection this guards against widen
+# it. Adding an environment is a reviewed code change, by design.
+case "$requested_env" in
+  test|test01) ;;
+  *)
+    echo "Refusing to resolve environment '${requested_env}'." >&2
+    echo "Only the shared test environments (test, test01) may be resolved;" >&2
+    echo "production is deployed by the tag-driven release flow, not this one." >&2
+    exit 1
+    ;;
+esac
+
 records="${NVCM_TEST_ENV_TARGETS:-}"
 
 if [[ -z "$records" ]]; then

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -7,10 +7,11 @@
 # The deploy-state file is the ONLY file this script touches - human-owned
 # overrides on the env branch are never modified.
 #
-# Requires (dotenv from earlier stages): PROMOTE_VERSION, PR_NUM, PR_SHA,
-#          DIGEST_<IMAGE> x9, and from test-promote-chart: BASELINE_REVISION
-#          (main SHA whose baseline was validated) + ENV_BRANCH_REVISION
-#          (env-branch SHA whose overrides were validated)
+# Requires (dotenv from earlier stages): PR_NUM, PR_SHA
+# Requires (FILE artifacts, read as the source of truth - see "Attested inputs"
+#          below): chart.env from test-promote-chart (PROMOTE_VERSION,
+#          BASELINE_REVISION, ENV_BRANCH_REVISION) and digests.env from
+#          test-promote-push-images (DIGEST_<IMAGE> x9)
 # Requires (eval of test_env_config.sh): NVCM_ENV, NVCM_ENV_BRANCH,
 #          NVCM_ENV_NAMESPACE, NVCM_ENV_RELEASE_NAME, NVCM_ENV_STATE_DIR
 # Requires (protected variables): NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN,
@@ -19,7 +20,6 @@
 #          https://helm.ngc.nvidia.com/nvidian/cfa)
 set -euo pipefail
 
-: "${PROMOTE_VERSION:?missing dotenv from test-promote-build}"
 : "${PR_NUM:?missing dotenv from test-promote-build}"
 : "${PR_SHA:?missing dotenv from test-promote-build}"
 : "${NVCM_ENV:?eval test_env_config.sh first}"
@@ -28,16 +28,41 @@ set -euo pipefail
 : "${NVCM_ENV_RELEASE_NAME:?eval test_env_config.sh first}"
 : "${NVCM_ENV_STATE_DIR:?eval test_env_config.sh first}"
 : "${NVCM_CHART_REPO:?Set NVCM_CHART_REPO to the Helm repo URL ArgoCD reads the chart from}"
-: "${ENV_BRANCH_REVISION:?ENV_BRANCH_REVISION missing (dotenv from test-promote-chart)}"
-: "${DIGEST_NV_CONFIG_MANAGER:?missing dotenv from test-promote-push-images}"
-: "${DIGEST_NV_CONFIG_MANAGER_UI:?missing dotenv from test-promote-push-images}"
-: "${DIGEST_NV_CONFIG_MANAGER_KEA:?missing dotenv from test-promote-push-images}"
-: "${DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN:?missing dotenv from test-promote-push-images}"
-: "${DIGEST_NV_CONFIG_MANAGER_NAUTOBOT:?missing dotenv from test-promote-push-images}"
-: "${DIGEST_NV_CONFIG_MANAGER_NATS_READY:?missing dotenv from test-promote-push-images}"
-: "${DIGEST_NV_CONFIG_MANAGER_TEMPORAL:?missing dotenv from test-promote-push-images}"
-: "${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP:?missing dotenv from test-promote-push-images}"
-: "${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI:?missing dotenv from test-promote-push-images}"
+
+# ---------------------------------------------------------------------------
+# Attested inputs: read from the producing jobs' FILE artifacts, not from their
+# dotenv exports. GitLab ranks pipeline variables above dotenv report variables,
+# so an operator-supplied variable of the same name would silently override the
+# values these provenance guards compare against. Files cannot be overridden
+# that way, so the deployment-affecting inputs are taken from disk.
+#   chart.env   (test-promote-chart)       - revisions + verified chart version
+#   digests.env (test-promote-push-images) - registry digests as pushed
+# ---------------------------------------------------------------------------
+chart_attest="${CI_PROJECT_DIR}/chart.env"
+digest_attest="${CI_PROJECT_DIR}/digests.env"
+for f in "$chart_attest" "$digest_attest"; do
+    [ -f "$f" ] || { echo "ERROR: missing attestation artifact ${f}"; exit 1; }
+done
+
+attest() {
+    local key="$1" file="$2" val
+    val="$(grep -m1 "^${key}=" "$file" | cut -d= -f2- || true)"
+    [ -n "$val" ] || { echo "ERROR: ${key} missing from $(basename "$file")"; exit 1; }
+    printf '%s' "$val"
+}
+
+PROMOTE_VERSION="$(attest PROMOTE_VERSION "$chart_attest")"
+BASELINE_REVISION="$(attest BASELINE_REVISION "$chart_attest")"
+ENV_BRANCH_REVISION="$(attest ENV_BRANCH_REVISION "$chart_attest")"
+DIGEST_NV_CONFIG_MANAGER="$(attest DIGEST_NV_CONFIG_MANAGER "$digest_attest")"
+DIGEST_NV_CONFIG_MANAGER_UI="$(attest DIGEST_NV_CONFIG_MANAGER_UI "$digest_attest")"
+DIGEST_NV_CONFIG_MANAGER_KEA="$(attest DIGEST_NV_CONFIG_MANAGER_KEA "$digest_attest")"
+DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN="$(attest DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN "$digest_attest")"
+DIGEST_NV_CONFIG_MANAGER_NAUTOBOT="$(attest DIGEST_NV_CONFIG_MANAGER_NAUTOBOT "$digest_attest")"
+DIGEST_NV_CONFIG_MANAGER_NATS_READY="$(attest DIGEST_NV_CONFIG_MANAGER_NATS_READY "$digest_attest")"
+DIGEST_NV_CONFIG_MANAGER_TEMPORAL="$(attest DIGEST_NV_CONFIG_MANAGER_TEMPORAL "$digest_attest")"
+DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP="$(attest DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP "$digest_attest")"
+DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI="$(attest DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI "$digest_attest")"
 
 if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
     # A full URL override is used as-is (provide any auth it needs in the URL).

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -8,7 +8,7 @@
 # overrides on the env branch are never modified.
 #
 # Requires (dotenv from earlier stages): PROMOTE_VERSION, PR_NUM, PR_SHA,
-#          DIGEST_<IMAGE> x6
+#          DIGEST_<IMAGE> x6, BASELINE_REVISION (from test-promote-chart)
 # Requires (eval of test_env_config.sh): NVCM_ENV, NVCM_ENV_BRANCH,
 #          NVCM_ENV_NAMESPACE, NVCM_ENV_RELEASE_NAME, NVCM_ENV_STATE_DIR
 # Requires (protected variables): NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN,
@@ -34,9 +34,13 @@ set -euo pipefail
 : "${DIGEST_NV_CONFIG_MANAGER_NATS_READY:?missing dotenv from test-promote-push-images}"
 
 if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
+    # A full URL override is used as-is (provide any auth it needs in the URL).
     values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+    values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
 else
+    # A path builds the authenticated GitLab URL with the push token.
     values_repo="${NVCM_VALUES_REPO_PATH:?Set NVCM_VALUES_REPO_PATH or NV_CONFIG_MANAGER_VALUES_REPO_URL}"
+    values_repo_url="https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git"
 fi
 
 state_file="${NVCM_ENV_STATE_DIR}/deploy-state.yaml"
@@ -44,7 +48,7 @@ occupant="${GITLAB_USER_LOGIN:-${GITLAB_USER_NAME:-ci}}"
 
 echo "Committing deploy-state for env '${NVCM_ENV}' to ${values_repo}@${NVCM_ENV_BRANCH}:${state_file}"
 
-git clone "https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git" values-repo
+git clone "$values_repo_url" values-repo
 cd values-repo
 
 if git ls-remote --heads origin "${NVCM_ENV_BRANCH}" | grep -q "${NVCM_ENV_BRANCH}"; then
@@ -70,10 +74,12 @@ if [ "$current_hold" = "true" ] && [ "$current_occupant" != "$occupant" ]; then
     exit 1
 fi
 
-# Baseline pin: the kiwi-argocd main SHA whose baseline values this deployment
-# renders against. Pinning (instead of tracking main) makes rollback exact.
-git fetch origin main
-baseline_rev="$(git rev-parse origin/main)"
+# Baseline pin: the kiwi-argocd main SHA whose baseline values the render gate
+# validated against, captured in test-promote-chart and passed via dotenv.
+# Consuming that exact SHA - rather than re-resolving origin/main here - keeps
+# the deployed baseline identical to the one that was validated even if main
+# moved in between. Pinning (vs tracking main) also makes rollback exact.
+baseline_rev="${BASELINE_REVISION:?BASELINE_REVISION missing (dotenv from test-promote-chart)}"
 
 export NVCM_ENV NVCM_ENV_NAMESPACE NVCM_ENV_BRANCH NVCM_ENV_RELEASE_NAME \
     NVCM_CHART_REPO PROMOTE_VERSION PR_SHA PR_NUM occupant baseline_rev \

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Final stage of the test-env promote flow: commit the machine-written
+# deployment state for one environment to its env branch in the downstream
+# ArgoCD values repository. The ApplicationSet's git file generator reads this
+# file and deploys the pinned chart version + image digests.
+#
+# The deploy-state file is the ONLY file this script touches - human-owned
+# overrides on the env branch are never modified.
+#
+# Requires (dotenv from earlier stages): PROMOTE_VERSION, PR_NUM, PR_SHA,
+#          DIGEST_<IMAGE> x6
+# Requires (eval of test_env_config.sh): NVCM_ENV, NVCM_ENV_BRANCH,
+#          NVCM_ENV_NAMESPACE, NVCM_ENV_RELEASE_NAME, NVCM_ENV_STATE_DIR
+# Requires (protected variables): NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN,
+#          NVCM_VALUES_REPO_PATH (or NV_CONFIG_MANAGER_VALUES_REPO_URL),
+#          NVCM_CHART_REPO (Helm repo URL ArgoCD reads the chart from, e.g.
+#          https://helm.ngc.nvidia.com/nvidian/cfa)
+set -euo pipefail
+
+: "${PROMOTE_VERSION:?missing dotenv from test-promote-build}"
+: "${PR_NUM:?missing dotenv from test-promote-build}"
+: "${PR_SHA:?missing dotenv from test-promote-build}"
+: "${NVCM_ENV:?eval test_env_config.sh first}"
+: "${NVCM_ENV_BRANCH:?eval test_env_config.sh first}"
+: "${NVCM_ENV_NAMESPACE:?eval test_env_config.sh first}"
+: "${NVCM_ENV_RELEASE_NAME:?eval test_env_config.sh first}"
+: "${NVCM_ENV_STATE_DIR:?eval test_env_config.sh first}"
+: "${NVCM_CHART_REPO:?Set NVCM_CHART_REPO to the Helm repo URL ArgoCD reads the chart from}"
+: "${DIGEST_NV_CONFIG_MANAGER:?missing dotenv from test-promote-push-images}"
+: "${DIGEST_NV_CONFIG_MANAGER_UI:?missing dotenv from test-promote-push-images}"
+: "${DIGEST_NV_CONFIG_MANAGER_KEA:?missing dotenv from test-promote-push-images}"
+: "${DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN:?missing dotenv from test-promote-push-images}"
+: "${DIGEST_NV_CONFIG_MANAGER_NAUTOBOT:?missing dotenv from test-promote-push-images}"
+: "${DIGEST_NV_CONFIG_MANAGER_NATS_READY:?missing dotenv from test-promote-push-images}"
+
+if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
+    values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+else
+    values_repo="${NVCM_VALUES_REPO_PATH:?Set NVCM_VALUES_REPO_PATH or NV_CONFIG_MANAGER_VALUES_REPO_URL}"
+fi
+
+state_file="${NVCM_ENV_STATE_DIR}/deploy-state.yaml"
+occupant="${GITLAB_USER_LOGIN:-${GITLAB_USER_NAME:-ci}}"
+
+echo "Committing deploy-state for env '${NVCM_ENV}' to ${values_repo}@${NVCM_ENV_BRANCH}:${state_file}"
+
+git clone "https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git" values-repo
+cd values-repo
+
+if git ls-remote --heads origin "${NVCM_ENV_BRANCH}" | grep -q "${NVCM_ENV_BRANCH}"; then
+    git fetch origin "${NVCM_ENV_BRANCH}"
+    git checkout "${NVCM_ENV_BRANCH}"
+else
+    echo "ERROR: env branch '${NVCM_ENV_BRANCH}' does not exist in ${values_repo}."
+    echo "Seed it from main first (see the kiwi-argocd README migration steps)."
+    exit 1
+fi
+
+if [ ! -f "$state_file" ]; then
+    echo "ERROR: ${state_file} not found on ${NVCM_ENV_BRANCH}; the env is not seeded."
+    exit 1
+fi
+
+# Honor a manual hold: an occupant who set hold: true is protecting the slot.
+current_hold=$(yq -r '.hold // false' "$state_file")
+current_occupant=$(yq -r '.occupant // "none"' "$state_file")
+if [ "$current_hold" = "true" ] && [ "$current_occupant" != "$occupant" ]; then
+    echo "ERROR: ${NVCM_ENV} is on hold by '${current_occupant}' (deploy-state hold: true)."
+    echo "Coordinate with them or have them release the hold before promoting."
+    exit 1
+fi
+
+# Baseline pin: the kiwi-argocd main SHA whose baseline values this deployment
+# renders against. Pinning (instead of tracking main) makes rollback exact.
+git fetch origin main
+baseline_rev="$(git rev-parse origin/main)"
+
+export NVCM_ENV NVCM_ENV_NAMESPACE NVCM_ENV_BRANCH NVCM_ENV_RELEASE_NAME \
+    NVCM_CHART_REPO PROMOTE_VERSION PR_SHA PR_NUM occupant baseline_rev \
+    DIGEST_NV_CONFIG_MANAGER DIGEST_NV_CONFIG_MANAGER_UI \
+    DIGEST_NV_CONFIG_MANAGER_KEA DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN \
+    DIGEST_NV_CONFIG_MANAGER_NAUTOBOT DIGEST_NV_CONFIG_MANAGER_NATS_READY
+updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+export updated_at
+
+yq -n '
+  .env = strenv(NVCM_ENV) |
+  .namespace = strenv(NVCM_ENV_NAMESPACE) |
+  .envBranch = strenv(NVCM_ENV_BRANCH) |
+  .releaseName = strenv(NVCM_ENV_RELEASE_NAME) |
+  .chartRepo = strenv(NVCM_CHART_REPO) |
+  .chartVersion = strenv(PROMOTE_VERSION) |
+  .baselineRevision = strenv(baseline_rev) |
+  .images.nvConfigManager = strenv(DIGEST_NV_CONFIG_MANAGER) |
+  .images.nvConfigManagerUi = strenv(DIGEST_NV_CONFIG_MANAGER_UI) |
+  .images.kea = strenv(DIGEST_NV_CONFIG_MANAGER_KEA) |
+  .images.keaAdmin = strenv(DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN) |
+  .images.nautobot = strenv(DIGEST_NV_CONFIG_MANAGER_NAUTOBOT) |
+  .images.natsReady = strenv(DIGEST_NV_CONFIG_MANAGER_NATS_READY) |
+  .sourceSHA = strenv(PR_SHA) |
+  .pr = (strenv(PR_NUM) | tonumber) |
+  .occupant = strenv(occupant) |
+  .updatedAt = strenv(updated_at) |
+  .hold = false
+' > "${state_file}.new"
+
+# Keep the leading DO-NOT-HAND-EDIT comment header from the existing file.
+{
+    awk '/^---$/ { next } /^#/ { print; next } { exit }' "$state_file"
+    cat "${state_file}.new"
+} > "$state_file"
+rm -f "${state_file}.new"
+
+if git diff --quiet "$state_file"; then
+    echo "No deploy-state changes; ${NVCM_ENV} is already at ${PROMOTE_VERSION}."
+    exit 0
+fi
+
+echo "Deploy-state diff:"
+git diff "$state_file"
+
+git add "$state_file"
+git commit -m "[nvcm CI] Promote PR #${PR_NUM} (${PROMOTE_VERSION}) to ${NVCM_ENV}
+
+Source commit: ${PR_SHA}
+Baseline: ${baseline_rev}
+Triggered by: ${occupant}
+Pipeline: ${CI_PIPELINE_URL}"
+git push origin "HEAD:refs/heads/${NVCM_ENV_BRANCH}"
+
+echo ""
+echo "Deploy-state committed. ArgoCD will sync ${NVCM_ENV} to chart ${PROMOTE_VERSION} with digest-pinned images."
+echo "View: https://${CI_SERVER_HOST}/${values_repo}/-/commits/${NVCM_ENV_BRANCH}"

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -7,10 +7,10 @@
 # The deploy-state file is the ONLY file this script touches - human-owned
 # overrides on the env branch are never modified.
 #
-# Requires (dotenv from earlier stages): PR_NUM, PR_SHA
 # Requires (FILE artifacts, read as the source of truth - see "Attested inputs"
-#          below): chart.env from test-promote-chart (PROMOTE_VERSION,
-#          BASELINE_REVISION, ENV_BRANCH_REVISION) and digests.env from
+#          below): promote.env from test-promote-build (PR_NUM, PR_SHA),
+#          chart.env from test-promote-chart (PROMOTE_VERSION,
+#          BASELINE_REVISION, ENV_BRANCH_REVISION), and digests.env from
 #          test-promote-push-images (DIGEST_<IMAGE> x9)
 # Requires (eval of test_env_config.sh): NVCM_ENV, NVCM_ENV_BRANCH,
 #          NVCM_ENV_NAMESPACE, NVCM_ENV_RELEASE_NAME, NVCM_ENV_STATE_DIR
@@ -20,8 +20,6 @@
 #          https://helm.ngc.nvidia.com/nvidian/cfa)
 set -euo pipefail
 
-: "${PR_NUM:?missing dotenv from test-promote-build}"
-: "${PR_SHA:?missing dotenv from test-promote-build}"
 : "${NVCM_ENV:?eval test_env_config.sh first}"
 : "${NVCM_ENV_BRANCH:?eval test_env_config.sh first}"
 : "${NVCM_ENV_NAMESPACE:?eval test_env_config.sh first}"
@@ -35,12 +33,14 @@ set -euo pipefail
 # so an operator-supplied variable of the same name would silently override the
 # values these provenance guards compare against. Files cannot be overridden
 # that way, so the deployment-affecting inputs are taken from disk.
+#   promote.env (test-promote-build)       - resolved PR number + SHA
 #   chart.env   (test-promote-chart)       - revisions + verified chart version
 #   digests.env (test-promote-push-images) - registry digests as pushed
 # ---------------------------------------------------------------------------
+promote_attest="${CI_PROJECT_DIR}/promote.env"
 chart_attest="${CI_PROJECT_DIR}/chart.env"
 digest_attest="${CI_PROJECT_DIR}/digests.env"
-for f in "$chart_attest" "$digest_attest"; do
+for f in "$promote_attest" "$chart_attest" "$digest_attest"; do
     [ -f "$f" ] || { echo "ERROR: missing attestation artifact ${f}"; exit 1; }
 done
 
@@ -51,6 +51,8 @@ attest() {
     printf '%s' "$val"
 }
 
+PR_NUM="$(attest PR_NUM "$promote_attest")"
+PR_SHA="$(attest PR_SHA "$promote_attest")"
 PROMOTE_VERSION="$(attest PROMOTE_VERSION "$chart_attest")"
 BASELINE_REVISION="$(attest BASELINE_REVISION "$chart_attest")"
 ENV_BRANCH_REVISION="$(attest ENV_BRANCH_REVISION "$chart_attest")"
@@ -126,11 +128,11 @@ if [ "$current_hold" = "true" ] && [ "$current_occupant" != "$occupant" ]; then
 fi
 
 # Baseline pin: the kiwi-argocd main SHA whose baseline values the render gate
-# validated against, captured in test-promote-chart and passed via dotenv.
+# validated against, attested by test-promote-chart in chart.env (read above).
 # Consuming that exact SHA - rather than re-resolving origin/main here - keeps
 # the deployed baseline identical to the one that was validated even if main
 # moved in between. Pinning (vs tracking main) also makes rollback exact.
-baseline_rev="${BASELINE_REVISION:?BASELINE_REVISION missing (dotenv from test-promote-chart)}"
+baseline_rev="$BASELINE_REVISION"
 
 export NVCM_ENV NVCM_ENV_NAMESPACE NVCM_ENV_BRANCH NVCM_ENV_RELEASE_NAME \
     NVCM_CHART_REPO PROMOTE_VERSION PR_SHA PR_NUM occupant baseline_rev \

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -35,18 +35,23 @@ set -euo pipefail
 
 if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
     # A full URL override is used as-is (provide any auth it needs in the URL).
-    values_repo="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
     values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
+    # Credential-free label for logs: strip any "userinfo@" (e.g. oauth2:token@)
+    # so an override URL that embeds a token can't leak it into the job log.
+    values_repo_display="$(printf '%s' "$NV_CONFIG_MANAGER_VALUES_REPO_URL" | sed -E 's#://[^/@]*@#://#')"
+    # No clean project path is available from a full-URL override.
+    values_repo_path=""
 else
     # A path builds the authenticated GitLab URL with the push token.
-    values_repo="${NVCM_VALUES_REPO_PATH:?Set NVCM_VALUES_REPO_PATH or NV_CONFIG_MANAGER_VALUES_REPO_URL}"
-    values_repo_url="https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo}.git"
+    values_repo_path="${NVCM_VALUES_REPO_PATH:?Set NVCM_VALUES_REPO_PATH or NV_CONFIG_MANAGER_VALUES_REPO_URL}"
+    values_repo_url="https://oauth2:${NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN}@${CI_SERVER_HOST}/${values_repo_path}.git"
+    values_repo_display="$values_repo_path"
 fi
 
 state_file="${NVCM_ENV_STATE_DIR}/deploy-state.yaml"
 occupant="${GITLAB_USER_LOGIN:-${GITLAB_USER_NAME:-ci}}"
 
-echo "Committing deploy-state for env '${NVCM_ENV}' to ${values_repo}@${NVCM_ENV_BRANCH}:${state_file}"
+echo "Committing deploy-state for env '${NVCM_ENV}' to ${values_repo_display}@${NVCM_ENV_BRANCH}:${state_file}"
 
 git clone "$values_repo_url" values-repo
 cd values-repo
@@ -55,7 +60,7 @@ if git ls-remote --heads origin "${NVCM_ENV_BRANCH}" | grep -q "${NVCM_ENV_BRANC
     git fetch origin "${NVCM_ENV_BRANCH}"
     git checkout "${NVCM_ENV_BRANCH}"
 else
-    echo "ERROR: env branch '${NVCM_ENV_BRANCH}' does not exist in ${values_repo}."
+    echo "ERROR: env branch '${NVCM_ENV_BRANCH}' does not exist in ${values_repo_display}."
     echo "Seed it from main first (see the kiwi-argocd README migration steps)."
     exit 1
 fi
@@ -136,4 +141,8 @@ git push origin "HEAD:refs/heads/${NVCM_ENV_BRANCH}"
 
 echo ""
 echo "Deploy-state committed. ArgoCD will sync ${NVCM_ENV} to chart ${PROMOTE_VERSION} with digest-pinned images."
-echo "View: https://${CI_SERVER_HOST}/${values_repo}/-/commits/${NVCM_ENV_BRANCH}"
+# Only build the web view URL from a known project path - a full-URL override
+# has no clean path and could otherwise produce a malformed/credential URL.
+if [ -n "$values_repo_path" ]; then
+    echo "View: https://${CI_SERVER_HOST}/${values_repo_path}/-/commits/${NVCM_ENV_BRANCH}"
+fi

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -8,7 +8,9 @@
 # overrides on the env branch are never modified.
 #
 # Requires (dotenv from earlier stages): PROMOTE_VERSION, PR_NUM, PR_SHA,
-#          DIGEST_<IMAGE> x6, BASELINE_REVISION (from test-promote-chart)
+#          DIGEST_<IMAGE> x9, and from test-promote-chart: BASELINE_REVISION
+#          (main SHA whose baseline was validated) + ENV_BRANCH_REVISION
+#          (env-branch SHA whose overrides were validated)
 # Requires (eval of test_env_config.sh): NVCM_ENV, NVCM_ENV_BRANCH,
 #          NVCM_ENV_NAMESPACE, NVCM_ENV_RELEASE_NAME, NVCM_ENV_STATE_DIR
 # Requires (protected variables): NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN,
@@ -26,6 +28,7 @@ set -euo pipefail
 : "${NVCM_ENV_RELEASE_NAME:?eval test_env_config.sh first}"
 : "${NVCM_ENV_STATE_DIR:?eval test_env_config.sh first}"
 : "${NVCM_CHART_REPO:?Set NVCM_CHART_REPO to the Helm repo URL ArgoCD reads the chart from}"
+: "${ENV_BRANCH_REVISION:?ENV_BRANCH_REVISION missing (dotenv from test-promote-chart)}"
 : "${DIGEST_NV_CONFIG_MANAGER:?missing dotenv from test-promote-push-images}"
 : "${DIGEST_NV_CONFIG_MANAGER_UI:?missing dotenv from test-promote-push-images}"
 : "${DIGEST_NV_CONFIG_MANAGER_KEA:?missing dotenv from test-promote-push-images}"
@@ -70,6 +73,21 @@ fi
 
 if [ ! -f "$state_file" ]; then
     echo "ERROR: ${state_file} not found on ${NVCM_ENV_BRANCH}; the env is not seeded."
+    exit 1
+fi
+
+# The render gate in test-promote-chart validated this env's overrides at a
+# specific env-branch revision. resource_group serializes promote/rollback/
+# release runs, but not human pushes to the env branch, so the overrides can
+# change in between. Refuse to write deploy-state against overrides that were
+# never validated - fail closed and let the operator re-run.
+current_env_rev="$(git rev-parse HEAD)"
+if [ "$current_env_rev" != "$ENV_BRANCH_REVISION" ]; then
+    echo "ERROR: ${NVCM_ENV_BRANCH} moved since the render gate validated it."
+    echo "  validated: ${ENV_BRANCH_REVISION}"
+    echo "  current:   ${current_env_rev}"
+    echo "Someone pushed to the env branch mid-promote, so its overrides are"
+    echo "unvalidated against this chart. Re-run the promote pipeline."
     exit 1
 fi
 

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -91,6 +91,7 @@ baseline_rev="${BASELINE_REVISION:?BASELINE_REVISION missing (dotenv from test-p
 
 export NVCM_ENV NVCM_ENV_NAMESPACE NVCM_ENV_BRANCH NVCM_ENV_RELEASE_NAME \
     NVCM_CHART_REPO PROMOTE_VERSION PR_SHA PR_NUM occupant baseline_rev \
+    current_hold \
     DIGEST_NV_CONFIG_MANAGER DIGEST_NV_CONFIG_MANAGER_UI \
     DIGEST_NV_CONFIG_MANAGER_KEA DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN \
     DIGEST_NV_CONFIG_MANAGER_NAUTOBOT DIGEST_NV_CONFIG_MANAGER_NATS_READY \
@@ -98,6 +99,8 @@ export NVCM_ENV NVCM_ENV_NAMESPACE NVCM_ENV_BRANCH NVCM_ENV_RELEASE_NAME \
     DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI
 updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 export updated_at
+
+trap 'rm -f "${state_file}.new" "${state_file}.merged"' EXIT
 
 yq -n '
   .env = strenv(NVCM_ENV) |
@@ -120,14 +123,17 @@ yq -n '
   .pr = (strenv(PR_NUM) | tonumber) |
   .occupant = strenv(occupant) |
   .updatedAt = strenv(updated_at) |
-  .hold = false
+  .hold = (strenv(current_hold) == "true")
 ' > "${state_file}.new"
 
 # Keep the leading DO-NOT-HAND-EDIT comment header from the existing file.
+# Assemble into a separate file: redirecting straight onto "$state_file" would
+# truncate it before awk could read the header back out of it.
 {
     awk '/^---$/ { next } /^#/ { print; next } { exit }' "$state_file"
     cat "${state_file}.new"
-} > "$state_file"
+} > "${state_file}.merged"
+mv "${state_file}.merged" "$state_file"
 rm -f "${state_file}.new"
 
 if git diff --quiet "$state_file"; then

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -32,6 +32,9 @@ set -euo pipefail
 : "${DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN:?missing dotenv from test-promote-push-images}"
 : "${DIGEST_NV_CONFIG_MANAGER_NAUTOBOT:?missing dotenv from test-promote-push-images}"
 : "${DIGEST_NV_CONFIG_MANAGER_NATS_READY:?missing dotenv from test-promote-push-images}"
+: "${DIGEST_NV_CONFIG_MANAGER_TEMPORAL:?missing dotenv from test-promote-push-images}"
+: "${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP:?missing dotenv from test-promote-push-images}"
+: "${DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI:?missing dotenv from test-promote-push-images}"
 
 if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
     # A full URL override is used as-is (provide any auth it needs in the URL).
@@ -90,7 +93,9 @@ export NVCM_ENV NVCM_ENV_NAMESPACE NVCM_ENV_BRANCH NVCM_ENV_RELEASE_NAME \
     NVCM_CHART_REPO PROMOTE_VERSION PR_SHA PR_NUM occupant baseline_rev \
     DIGEST_NV_CONFIG_MANAGER DIGEST_NV_CONFIG_MANAGER_UI \
     DIGEST_NV_CONFIG_MANAGER_KEA DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN \
-    DIGEST_NV_CONFIG_MANAGER_NAUTOBOT DIGEST_NV_CONFIG_MANAGER_NATS_READY
+    DIGEST_NV_CONFIG_MANAGER_NAUTOBOT DIGEST_NV_CONFIG_MANAGER_NATS_READY \
+    DIGEST_NV_CONFIG_MANAGER_TEMPORAL DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP \
+    DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI
 updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 export updated_at
 
@@ -108,6 +113,9 @@ yq -n '
   .images.keaAdmin = strenv(DIGEST_NV_CONFIG_MANAGER_KEA_ADMIN) |
   .images.nautobot = strenv(DIGEST_NV_CONFIG_MANAGER_NAUTOBOT) |
   .images.natsReady = strenv(DIGEST_NV_CONFIG_MANAGER_NATS_READY) |
+  .images.temporalServer = strenv(DIGEST_NV_CONFIG_MANAGER_TEMPORAL) |
+  .images.temporalBootstrap = strenv(DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP) |
+  .images.temporalUi = strenv(DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI) |
   .sourceSHA = strenv(PR_SHA) |
   .pr = (strenv(PR_NUM) | tonumber) |
   .occupant = strenv(occupant) |

--- a/.gitlab/ci/sonar.yml
+++ b/.gitlab/ci/sonar.yml
@@ -78,6 +78,10 @@ sonar-scanner:
   # The internal mirror is post-merge reporting, not an upstream merge gate.
   allow_failure: true
   rules:
+    # Skip during test-env promote pipelines (web pipelines on the default
+    # branch with $NVCM_PROMOTE_ENV set).
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       changes: *sonar-change-paths
       when: always
@@ -112,6 +116,9 @@ sonarqube-vulnerability-report:
     - 'jq -e ''.version and (.vulnerabilities | type == "array")'' gl-sast-sonar-report.json >/dev/null'
   allow_failure: true
   rules:
+    # Skip during test-env promote pipelines (see sonar-scanner).
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       changes: *sonar-change-paths
       when: always

--- a/.gitlab/ci/sonar.yml
+++ b/.gitlab/ci/sonar.yml
@@ -80,7 +80,7 @@ sonar-scanner:
   rules:
     # Skip during test-env promote pipelines (web pipelines on the default
     # branch with $NVCM_PROMOTE_ENV set).
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       changes: *sonar-change-paths
@@ -117,7 +117,7 @@ sonarqube-vulnerability-report:
   allow_failure: true
   rules:
     # Skip during test-env promote pipelines (see sonar-scanner).
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       changes: *sonar-change-paths

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -415,7 +415,7 @@ test-main-py:
   rules:
     # Skip during test-env promote pipelines (web pipelines on the default
     # branch with $NVCM_PROMOTE_ENV set).
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_COMMIT_TAG
       when: on_success
@@ -465,7 +465,7 @@ test-main-network-templates:
   rules:
     # Skip during test-env promote pipelines (web pipelines on the default
     # branch with $NVCM_PROMOTE_ENV set).
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_COMMIT_TAG
       when: on_success
@@ -501,7 +501,7 @@ test-main-installer:
   rules:
     # Skip during test-env promote pipelines (web pipelines on the default
     # branch with $NVCM_PROMOTE_ENV set).
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_COMMIT_TAG
       when: on_success
@@ -537,7 +537,7 @@ test-main-ui-e2e:
   rules:
     # Skip during test-env promote pipelines (web pipelines on the default
     # branch with $NVCM_PROMOTE_ENV set).
-    - if: $NVCM_PROMOTE_ENV
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/
       when: never
     - if: $CI_COMMIT_TAG
       when: on_success

--- a/.gitlab/ci/test.yml
+++ b/.gitlab/ci/test.yml
@@ -413,6 +413,10 @@ test-main-py:
     - linux/amd64
     - docker
   rules:
+    # Skip during test-env promote pipelines (web pipelines on the default
+    # branch with $NVCM_PROMOTE_ENV set).
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_COMMIT_TAG
       when: on_success
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -459,6 +463,10 @@ test-main-network-templates:
     - linux/amd64
     - docker
   rules:
+    # Skip during test-env promote pipelines (web pipelines on the default
+    # branch with $NVCM_PROMOTE_ENV set).
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_COMMIT_TAG
       when: on_success
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -491,6 +499,10 @@ test-main-installer:
     - linux/amd64
     - docker
   rules:
+    # Skip during test-env promote pipelines (web pipelines on the default
+    # branch with $NVCM_PROMOTE_ENV set).
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_COMMIT_TAG
       when: on_success
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -523,6 +535,10 @@ test-main-ui-e2e:
     - linux/amd64
     - docker
   rules:
+    # Skip during test-env promote pipelines (web pipelines on the default
+    # branch with $NVCM_PROMOTE_ENV set).
+    - if: $NVCM_PROMOTE_ENV
+      when: never
     - if: $CI_COMMIT_TAG
       when: on_success
     - if: $GITLAB_USER_EMAIL == $CI_PUSH_EMAIL


### PR DESCRIPTION
## Description

> **Draft — stacked on #134.** This is the protected promote half of the test/test01 GitOps deploy flow; #134 (the untrusted build stage) must merge first. Kept as a draft until then. The kiwi-argocd ApplicationSet/values changes are a separate MR.

Adds the **protected promote pipeline** that deploys a PR to the shared **test / test01** environments by consuming the immutable artifacts built in #134 and committing a machine-written `deploy-state.yaml` to the env branch in the ArgoCD values repo. It targets **only** test/test01 (every rule requires `NVCM_PROMOTE_ENV` ∈ {test, test01}); production stays on the tag-driven release flow.

Run on the mirror's default branch with `NVCM_PROMOTE_PR` + `NVCM_PROMOTE_ENV`. Jobs (`.gitlab/ci/promote-test-envs.yml`):
- `test-promote-build` — resolves the vetted `pull-request/<n>` snapshot, reuses or triggers the #134 build, and gates provenance on **GitLab pipeline metadata** (sha/ref/status/source) — never on anything the untrusted build wrote.
- `test-promote-push-images` — downloads the image tarballs by job id, `docker load`, retag to `0.0.0-pr<n>.<sha>`, push, capture registry digests.
- `test-promote-chart` — downloads the chart `.tgz` packaged in #134's secret-free stage, validates the render against the env's baseline+overrides+digests, and publishes it (no PR checkout, no repackaging — `helm template` only, which is sandboxed).
- `test-promote-deploy-state` — commits `deploy-state.yaml` to the env branch (`NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN`), owning the GitLab Environment.
- `test-rollback-env` / `test-release-env` — commit a prior deploy-state / reset to canonicals.

**Security model:** the promote stage operates only on already-built immutable artifacts, so no untrusted PR code executes with secrets. Provenance is established from GitLab metadata; the build stage (#134) holds no secrets.

**Default-branch job guards:** a `web`-source pipeline on the default branch with `NVCM_PROMOTE_ENV` set would otherwise also match `docker-build-main-*`, `test-main-*`, sonar, and pulse (their `rules:changes` evaluate true on non-push pipelines). Each gets a leading `- if: $NVCM_PROMOTE_ENV / when: never` so a promote run doesn't rebuild/retest main as a side effect. Normal push/MR/tag pipelines are unaffected.

**Chart source:** the promote publishes the dev chart to the existing **NGC Helm registry** (`https://helm.ngc.nvidia.com/nvidian/cfa`) via the `ngc` target; ArgoCD pulls it by exact version. (Confirmed exact-prerelease pins resolve there.)

**Required protected CI/CD variables:** `NVCM_MIRROR_API_TOKEN`, `NVCM_TEST_ENV_TARGETS`, `NVCM_CHART_REPO`, `NV_CONFIG_MANAGER_VALUES_PUSH_TOKEN`, `NVCM_VALUES_REPO_PATH`, plus the existing image/chart target vars. Documented in `.gitlab/ci/README.md`.

## Validation

- `yq` parse of `.gitlab-ci.yml` + `promote-test-envs.yml` + the four guarded CI files; `bash -n` on all four promote scripts.
- Confirmed the promote source allowlist and default-branch guards behave as intended.
- Exercised the build→promote chart handoff locally: packaged the chart as #134's `pr-build-chart` does, then ran the promote render gate against the real test baseline+overrides+digests → renders `nvcr.io/nvidian/cfa/...@sha256:...`.
- End-to-end pipeline validation is gated on #134 merging (nothing here runs until the build stage exists) and the protected variables being provisioned.

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration not run — not applicable. This PR only adds GitLab CI job definitions and shell scripts for the deploy pipeline; it changes no application code or Helm chart runtime output, and nothing the Kind suite exercises.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strengthened **test/test01** promotion to use file-artifact-based provenance, validate chart integrity (including digest-verified rendering and mismatch detection), and pin deployments to attested chart versions and image digests.
  * Added a fail-closed test-environment configuration resolver restricted to `test` and `test01`.
* **Documentation**
  * Updated the promotion runbook with downstream values-repo token allowlist requirements and token usage rules.
* **Bug Fixes**
  * Prevented promote pipelines from triggering default-branch image rebuilds, manifest publishing, Sonar scans, Pulse scans, and related test jobs; tightened build/pipeline execution guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->