### PR TITLE
minor installer and doc fixes

### DIFF
--- a/components/nautobot/README.md
+++ b/components/nautobot/README.md
@@ -42,7 +42,9 @@ docker build -t nv-config-manager-nats-ready:local -f build/nats-ready.Dockerfil
 
 ## Jobs
 
-`nv_config_manager_jobs/` contains bootstrap and development jobs. The installer stages these jobs when `content.include_bootstrap_jobs` or `content.jobs` is enabled in `nv-config-manager-install.yaml`.
+`nv_config_manager_jobs/` contains bootstrap and development jobs. Bootstrap jobs are
+always available from the Nautobot image; the installer stages only custom job paths
+configured through `content.jobs` in `nv-config-manager-install.yaml`.
 
 ## Plugins
 

--- a/deploy/configs/ci-integration-test.yaml
+++ b/deploy/configs/ci-integration-test.yaml
@@ -64,7 +64,6 @@ content:
   jobs:
     - path: development/mock_topology
   template_plugins: []
-  include_bootstrap_jobs: true
   run_after_deploy:
     - job: custom.mock_topology.jobs.mock_topology_design.MockTopologyDesign
       input: '{"blueprint": "superpod", "deployment_name": "test"}'

--- a/deploy/configs/local-dgxc.yaml
+++ b/deploy/configs/local-dgxc.yaml
@@ -66,7 +66,6 @@ content:
   jobs:
     - path: development/mock_topology
   template_plugins: []
-  include_bootstrap_jobs: true
   run_after_deploy:
     - job: custom.mock_topology.jobs.mock_topology_design.MockTopologyDesign
       input: '{"blueprint": "dgx_cloud", "deployment_name": "test"}'

--- a/deploy/configs/local-sec.yaml
+++ b/deploy/configs/local-sec.yaml
@@ -79,7 +79,6 @@ content:
   jobs:
     - path: development/mock_topology
   template_plugins: []
-  include_bootstrap_jobs: true
   run_after_deploy:
     - job: custom.mock_topology.jobs.mock_topology_design.MockTopologyDesign
       input: '{"blueprint": "superpod", "deployment_name": "test"}'

--- a/deploy/configs/local-superpod.yaml
+++ b/deploy/configs/local-superpod.yaml
@@ -66,7 +66,6 @@ content:
   jobs:
     - path: development/mock_topology
   template_plugins: []
-  include_bootstrap_jobs: true
   run_after_deploy:
     - job: custom.mock_topology.jobs.mock_topology_design.MockTopologyDesign
       input: '{"blueprint": "superpod", "deployment_name": "test"}'

--- a/docs/install/tui-wizard-reference.mdx
+++ b/docs/install/tui-wizard-reference.mdx
@@ -119,18 +119,17 @@ The **Scan Plugin Templates** button inspects Jinja2 templates from Content plug
 
 ## 6. Ingest Data
 
-Configure custom Nautobot jobs, bootstrap jobs, and post-deploy job execution. Use this section to stage a Design Builder topology loader, include the standard bootstrap jobs, or run other Nautobot jobs after Helm deployment.
+Configure custom Nautobot jobs and post-deploy job execution. Bundled bootstrap jobs are always available from the Nautobot image. Use this section to stage a Design Builder topology loader or run other Nautobot jobs after Helm deployment.
 
 | Field | Description |
 | :---- | :---------- |
-| Include Bootstrap Jobs | Ship standard bootstrap jobs |
 | Custom Nautobot Jobs | Paths to job directories or tarballs |
 | Post-Deploy Jobs | Nautobot jobs to run after deployment, including class name and JSON input |
 | Jobs PVC Storage Class | Kubernetes storage class for the Nautobot jobs PVC |
 | Jobs PVC Access Mode | `ReadWriteOnce` or `ReadWriteMany` |
 | Node Selector | Node label selector for loader and Nautobot pods that mount the jobs PVC |
 
-Custom jobs and bootstrap jobs require local Nautobot (`services.nautobot: true`). If Nautobot is remote, validation shows a warning.
+Custom jobs require local Nautobot (`services.nautobot: true`). If Nautobot is remote, configure custom jobs directly on that instance.
 
 For a concrete Design Builder example, see [Design Builder Data Loading](../nautobot/design-builder-data-loading.mdx).
 

--- a/docs/install/tui-wizard-reference.mdx
+++ b/docs/install/tui-wizard-reference.mdx
@@ -124,12 +124,12 @@ Configure custom Nautobot jobs and post-deploy job execution. Bundled bootstrap 
 | Field | Description |
 | :---- | :---------- |
 | Custom Nautobot Jobs | Paths to job directories or tarballs |
-| Post-Deploy Jobs | Nautobot jobs to run after deployment, including class name and JSON input |
+| Post-Deploy Jobs | Nautobot jobs to run after deployment, including class name and JSON input (local Nautobot only) |
 | Jobs PVC Storage Class | Kubernetes storage class for the Nautobot jobs PVC |
 | Jobs PVC Access Mode | `ReadWriteOnce` or `ReadWriteMany` |
 | Node Selector | Node label selector for loader and Nautobot pods that mount the jobs PVC |
 
-Custom jobs require local Nautobot (`services.nautobot: true`). If Nautobot is remote, configure custom jobs directly on that instance.
+Custom and post-deploy jobs require local Nautobot (`services.nautobot: true`). If Nautobot is remote, configure and run those jobs directly on that instance.
 
 For a concrete Design Builder example, see [Design Builder Data Loading](../nautobot/design-builder-data-loading.mdx).
 

--- a/docs/nautobot/design-builder-data-loading.mdx
+++ b/docs/nautobot/design-builder-data-loading.mdx
@@ -60,7 +60,6 @@ Set `blueprint` to the context directory name when you run the job. You can set 
 content:
   jobs:
     - path: path/to/mock_topology
-  include_bootstrap_jobs: true
   run_after_deploy:
     - job: mock_topology.jobs.mock_topology_design.MockTopologyDesign
       input: '{"blueprint": "site_a", "deployment_name": "site-a"}'
@@ -76,7 +75,6 @@ Stage the job directory with `content.jobs`, then run the job with `content.run_
 content:
   jobs:
     - path: development/mock_topology
-  include_bootstrap_jobs: true
   run_after_deploy:
     - job: mock_topology.jobs.mock_topology_design.MockTopologyDesign
       input: '{"blueprint": "superpod", "deployment_name": "test"}'

--- a/docs/network-ztp/upload-images.mdx
+++ b/docs/network-ztp/upload-images.mdx
@@ -64,7 +64,7 @@ Path: `POST /v1/files/{platform}/{version}/{filename}`
 
 | Parameter | Where | Required | Description |
 | :-------- | :---- | :------- | :---------- |
-| `platform` | path | yes | Platform key — for example `cumulus-linux`, `mlnx-os`, `nvos`. Must match the platform value devices in Nautobot resolve to. |
+| `platform` | path | yes | Platform key — for example `cumulus-linux`, `mlnx-os`, `nv-os`. Must match the platform value devices in Nautobot resolve to. |
 | `version` | path | yes | Version string the workflows will reference — for example `5.14.0`. Used directly in the `{platform}/{version}/` storage path. |
 | `filename` | path | yes | The on-disk filename to store. Devices fetch by this name. |
 | `checksum` | query | yes | SHA256 of the file you are uploading. |

--- a/installer/README.md
+++ b/installer/README.md
@@ -434,11 +434,11 @@ Path fields open an interactive directory picker (see below).
 | Jobs PVC Storage Class | Kubernetes storage class for the Nautobot jobs PVC (optional, uses cluster default) |
 | Jobs PVC Access Mode | `ReadWriteOnce` or `ReadWriteMany` for the Nautobot jobs PVC |
 | Jobs Node Selector | Node label selector for loader and Nautobot pods that mount the jobs PVC |
-| Post-Deploy Jobs | Nautobot jobs to run after deployment (class name + JSON input) |
+| Post-Deploy Jobs | Nautobot jobs to run after deployment (class name + JSON input; local Nautobot only) |
 
 > **Note:** Bundled bootstrap jobs are always available from the Nautobot image.
-> Custom jobs require local Nautobot (`services.nautobot: true`). If Nautobot is set
-> to remote, configure custom jobs directly on that instance.
+> Custom and post-deploy jobs require local Nautobot (`services.nautobot: true`). If
+> Nautobot is set to remote, configure and run those jobs directly on that instance.
 
 #### 7. Template Plugins
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -430,15 +430,15 @@ Path fields open an interactive directory picker (see below).
 
 | Field | Description |
 |-------|-------------|
-| Include Bootstrap Jobs | Ship standard bootstrap jobs |
 | Custom Jobs | Paths to job directories or tarballs (use `...` to browse) |
 | Jobs PVC Storage Class | Kubernetes storage class for the Nautobot jobs PVC (optional, uses cluster default) |
 | Jobs PVC Access Mode | `ReadWriteOnce` or `ReadWriteMany` for the Nautobot jobs PVC |
 | Jobs Node Selector | Node label selector for loader and Nautobot pods that mount the jobs PVC |
 | Post-Deploy Jobs | Nautobot jobs to run after deployment (class name + JSON input) |
 
-> **Note:** Custom jobs and bootstrap jobs require local Nautobot
-> (`services.nautobot: true`). If Nautobot is set to remote, a validation warning is shown.
+> **Note:** Bundled bootstrap jobs are always available from the Nautobot image.
+> Custom jobs require local Nautobot (`services.nautobot: true`). If Nautobot is set
+> to remote, configure custom jobs directly on that instance.
 
 #### 7. Template Plugins
 

--- a/installer/src/nv_config_manager_installer/air_sim/installer_config.py
+++ b/installer/src/nv_config_manager_installer/air_sim/installer_config.py
@@ -166,7 +166,6 @@ def generate_air_sim_install_config(
         "content": {
             "jobs": content_jobs,
             "template_plugins": template_plugins,
-            "include_bootstrap_jobs": True,
             "run_after_deploy": run_after_deploy,
         },
         "infrastructure": {

--- a/installer/src/nv_config_manager_installer/cli.py
+++ b/installer/src/nv_config_manager_installer/cli.py
@@ -118,9 +118,7 @@ def _collect_validation_errors(config: NVConfigManagerInstallConfig) -> list[str
         errors.append("At least one site is required")
     if config.sso.enabled and not config.sso.issuer_url:
         errors.append("sso.issuer_url is required when SSO is enabled")
-    if not config.services.nautobot and (
-        config.content.jobs or config.content.include_bootstrap_jobs
-    ):
+    if not config.services.nautobot and config.content.jobs:
         errors.append(
             "Custom jobs require a local Nautobot deployment "
             "(services.nautobot must be true, or remove content.jobs)"

--- a/installer/src/nv_config_manager_installer/cli.py
+++ b/installer/src/nv_config_manager_installer/cli.py
@@ -118,10 +118,11 @@ def _collect_validation_errors(config: NVConfigManagerInstallConfig) -> list[str
         errors.append("At least one site is required")
     if config.sso.enabled and not config.sso.issuer_url:
         errors.append("sso.issuer_url is required when SSO is enabled")
-    if not config.services.nautobot and config.content.jobs:
+    if not config.services.nautobot and config.content.requires_local_nautobot:
         errors.append(
-            "Custom jobs require a local Nautobot deployment "
-            "(services.nautobot must be true, or remove content.jobs)"
+            "Custom jobs and post-deploy jobs require a local Nautobot deployment "
+            "(services.nautobot must be true, or remove content.jobs and "
+            "content.run_after_deploy)"
         )
     return errors
 

--- a/installer/src/nv_config_manager_installer/deployer.py
+++ b/installer/src/nv_config_manager_installer/deployer.py
@@ -1350,7 +1350,7 @@ class Deployer:
         else:
             self.callback.on_log("Fresh install: no existing Helm release found")
 
-        if self.config.content.jobs or self.config.content.include_bootstrap_jobs:
+        if self.config.content.jobs:
             self._rerun.jobs_changed = self._check_content_diff(
                 _build_job_paths(self.config), "nautobot-custom-jobs", ns, "Jobs content"
             )
@@ -2281,7 +2281,7 @@ class Deployer:
             self.callback.on_log(msg)
 
     def _setup_jobs_pvc(self) -> None:
-        if not self.config.content.jobs and not self.config.content.include_bootstrap_jobs:
+        if not self.config.content.jobs:
             self._skip_step("setup-jobs-pvc", "No custom jobs configured")
             return
 

--- a/installer/src/nv_config_manager_installer/deployer.py
+++ b/installer/src/nv_config_manager_installer/deployer.py
@@ -1041,7 +1041,7 @@ class Deployer:
         options: DeployOptions,
         callback: DeployCallback | None = None,
     ) -> None:
-        self.config = config
+        self.config = NVConfigManagerInstallConfig.model_validate(config.model_dump())
         self.options = options
         self.callback = callback or _NoopCallback()
         self._secrets_state: dict[str, str] = {}

--- a/installer/src/nv_config_manager_installer/helm_values.py
+++ b/installer/src/nv_config_manager_installer/helm_values.py
@@ -801,7 +801,7 @@ def _build_nautobot(config: NVConfigManagerInstallConfig) -> dict[str, Any]:
             "persistence": {"staticFiles": {"enabled": True, "size": "1Gi"}},
         }
     )
-    if config.content.jobs or config.content.include_bootstrap_jobs:
+    if config.content.jobs:
         jobs_config = config.content.jobs_config
         section["customJobs"] = {
             "enabled": True,

--- a/installer/src/nv_config_manager_installer/schema.py
+++ b/installer/src/nv_config_manager_installer/schema.py
@@ -402,7 +402,6 @@ class ContentConfig(BaseModel):
     jobs_config: JobsConfig = Field(default_factory=JobsConfig)
     template_plugins: list[TemplatePath] = Field(default_factory=list)
     template_plugins_config: TemplatePluginsConfig = Field(default_factory=TemplatePluginsConfig)
-    include_bootstrap_jobs: bool = True
     run_after_deploy: list[PostDeployJob] = Field(default_factory=list)
 
 
@@ -524,10 +523,7 @@ class ZTPOSImage(BaseModel):
     def validate_platform(cls, value: str) -> str:
         """Reject ZTP platforms the installer does not yet support."""
         if value and value not in SUPPORTED_ZTP_IMAGE_PLATFORMS:
-            supported = ", ".join(sorted(SUPPORTED_ZTP_IMAGE_PLATFORMS))
-            raise ValueError(
-                f"Unsupported ZTP platform {value!r}. Supported platforms: {supported}."
-            )
+            raise ValueError(f"Unsupported ZTP platform {value!r}.")
         return value
 
 
@@ -840,13 +836,11 @@ class NVConfigManagerInstallConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_external_nautobot(self) -> NVConfigManagerInstallConfig:
-        """Custom jobs and bootstrap jobs require local Nautobot."""
-        if not self.services.nautobot and (
-            self.content.jobs or self.content.include_bootstrap_jobs
-        ):
+        """Custom jobs require local Nautobot."""
+        if not self.services.nautobot and self.content.jobs:
             msg = (
-                "Custom jobs and bootstrap jobs require a local Nautobot deployment "
-                "(services.nautobot must be true). Disable them or switch to local Nautobot."
+                "Custom jobs require a local Nautobot deployment "
+                "(services.nautobot must be true). Remove content.jobs or switch to local Nautobot."
             )
             raise ValueError(msg)
         return self

--- a/installer/src/nv_config_manager_installer/schema.py
+++ b/installer/src/nv_config_manager_installer/schema.py
@@ -404,6 +404,11 @@ class ContentConfig(BaseModel):
     template_plugins_config: TemplatePluginsConfig = Field(default_factory=TemplatePluginsConfig)
     run_after_deploy: list[PostDeployJob] = Field(default_factory=list)
 
+    @property
+    def requires_local_nautobot(self) -> bool:
+        """Return whether the configured content needs the local Nautobot deployment."""
+        return bool(self.jobs or self.run_after_deploy)
+
 
 class ServicesConfig(BaseModel):
     """Toggle individual NVIDIA Config Manager services on/off.
@@ -836,11 +841,12 @@ class NVConfigManagerInstallConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_external_nautobot(self) -> NVConfigManagerInstallConfig:
-        """Custom jobs require local Nautobot."""
-        if not self.services.nautobot and self.content.jobs:
+        """Reject content that cannot run against an external Nautobot instance."""
+        if not self.services.nautobot and self.content.requires_local_nautobot:
             msg = (
-                "Custom jobs require a local Nautobot deployment "
-                "(services.nautobot must be true). Remove content.jobs or switch to local Nautobot."
+                "Custom jobs and post-deploy jobs require a local Nautobot deployment "
+                "(services.nautobot must be true). Remove content.jobs and "
+                "content.run_after_deploy or switch to local Nautobot."
             )
             raise ValueError(msg)
         return self

--- a/installer/src/nv_config_manager_installer/tui/screens/content.py
+++ b/installer/src/nv_config_manager_installer/tui/screens/content.py
@@ -27,7 +27,6 @@ from textual_fspicker import SelectDirectory
 
 from nv_config_manager_installer.schema import JobPath, NVConfigManagerInstallConfig, PostDeployJob
 from nv_config_manager_installer.tui.screens.node_picker import NodeSelectorPanel
-from nv_config_manager_installer.tui.widgets import LabeledSwitch
 
 
 class IngestDataScreen(Container):
@@ -53,12 +52,6 @@ class IngestDataScreen(Container):
         warning.styles.padding = (0, 1)
         warning.display = not self._config.services.nautobot
         yield warning
-
-        yield LabeledSwitch(
-            "Include bootstrap jobs",
-            value=ct.include_bootstrap_jobs,
-            id="content-bootstrap",
-        )
 
         # -- Custom jobs --
         yield Label("Custom Nautobot Jobs", classes="field-label")
@@ -167,7 +160,6 @@ class IngestDataScreen(Container):
 
     def _collect_all(self) -> None:
         ct = self._config.content
-        ct.include_bootstrap_jobs = self.query_one("#content-bootstrap", LabeledSwitch).value
 
         jobs: list[JobPath] = []
         for i in range(len(ct.jobs)):
@@ -203,7 +195,6 @@ class IngestDataScreen(Container):
         self._collect_all()
         config.content.jobs = list(self._config.content.jobs)
         config.content.jobs_config = self._config.content.jobs_config.model_copy()
-        config.content.include_bootstrap_jobs = self._config.content.include_bootstrap_jobs
         config.content.run_after_deploy = list(self._config.content.run_after_deploy)
 
     def sync_from_config(self, config: NVConfigManagerInstallConfig) -> None:

--- a/installer/src/nv_config_manager_installer/tui/screens/content.py
+++ b/installer/src/nv_config_manager_installer/tui/screens/content.py
@@ -43,8 +43,9 @@ class IngestDataScreen(Container):
         yield Label("─" * 40, classes="section-divider")
 
         warning = Label(
-            "⚠ Nautobot is external — custom jobs cannot be loaded via PVC mount. "
-            "Configure jobs on the external Nautobot instance directly.",
+            "⚠ Nautobot is external — custom jobs cannot be loaded via PVC mount and "
+            "post-deploy jobs cannot be run. Configure or run them on the external "
+            "Nautobot instance directly.",
             id="content-nautobot-warning",
         )
         warning.styles.color = "yellow"

--- a/installer/src/nv_config_manager_installer/tui/screens/network_secrets.py
+++ b/installer/src/nv_config_manager_installer/tui/screens/network_secrets.py
@@ -298,6 +298,9 @@ class NetworkSecretsScreen(Container):
     def get_status(self, config: NVConfigManagerInstallConfig) -> str:
         if not config.network_secrets:
             return "[ ]"
-        if all(e.secret_key for e in config.network_secrets):
+        if all(
+            e.secret_key and (e.source != PasswordSource.MANUAL or e.value.strip())
+            for e in config.network_secrets
+        ):
             return "[*]"
         return "[!]"

--- a/installer/tests/test_cli.py
+++ b/installer/tests/test_cli.py
@@ -25,10 +25,12 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from nv_config_manager_installer.cli import _run_pvc_updater, main
+from nv_config_manager_installer.cli import _collect_validation_errors, _run_pvc_updater, main
 from nv_config_manager_installer.schema import (
     ClusterConfig,
+    ContentConfig,
     NVConfigManagerInstallConfig,
+    ServicesConfig,
     SiteConfig,
 )
 
@@ -116,6 +118,18 @@ class TestValidateCommand:
         result = runner.invoke(main, ["air-sim", "deploy", "--help"])
         assert result.exit_code == 0
         assert "--config" in result.output
+
+    def test_external_nautobot_rejects_post_deploy_jobs(self):
+        config = NVConfigManagerInstallConfig()
+        config.services = ServicesConfig(
+            nautobot=False,
+            external_nautobot_url="https://nb.example.com",
+        )
+        config.content = ContentConfig(run_after_deploy=[{"job": "jobs.bootstrap.SiteBootstrap"}])
+
+        errors = _collect_validation_errors(config)
+
+        assert any("post-deploy jobs require a local Nautobot" in error for error in errors)
 
 
 class TestInitCommand:

--- a/installer/tests/test_deployer.py
+++ b/installer/tests/test_deployer.py
@@ -60,6 +60,7 @@ from nv_config_manager_installer.schema import (
     KubernetesSecretsConfig,
     NetworkSecretEntry,
     NVConfigManagerInstallConfig,
+    PostDeployJob,
     RedfishConfig,
     RedfishVendorCreds,
     SecretsConfig,
@@ -200,6 +201,14 @@ class TestDeployerInit:
         deployer = Deployer(config, DeployOptions())
         ids = [s.id for s in deployer.steps]
         assert len(ids) == len(set(ids))
+
+    def test_revalidates_tui_config_before_deployment(self):
+        config = _make_config()
+        config.services.nautobot = False
+        config.content.run_after_deploy = [PostDeployJob(job="jobs.bootstrap.SiteBootstrap")]
+
+        with pytest.raises(ValueError, match="post-deploy jobs require a local Nautobot"):
+            Deployer(config, DeployOptions())
 
 
 class TestGatewayClassReuse:

--- a/installer/tests/test_deployer.py
+++ b/installer/tests/test_deployer.py
@@ -1237,7 +1237,7 @@ class TestConditionalRestart:
     """Verify _restart_nautobot and _restart_render_service skip logic."""
 
     def _make_deployer(self, *, jobs=True, templates=False) -> tuple:
-        content_kwargs: dict = {"include_bootstrap_jobs": False}
+        content_kwargs: dict = {}
         if jobs:
             content_kwargs["jobs"] = [JobPath(path="/fake/jobs")]
         if templates:
@@ -1327,7 +1327,6 @@ class TestPvcContentUpload:
 
         config = _make_config()
         config.content = ContentConfig(
-            include_bootstrap_jobs=True,
             jobs=[JobPath(path=str(job_dir))],
         )
         deployer = Deployer(config, DeployOptions(), RecordingCallback())
@@ -1357,7 +1356,6 @@ class TestPvcContentUpload:
 
         config = _make_config()
         config.content = ContentConfig(
-            include_bootstrap_jobs=False,
             template_plugins=[TemplatePath(path=str(plugin_dir))],
         )
         deployer = Deployer(config, DeployOptions(), RecordingCallback())
@@ -1703,7 +1701,6 @@ class TestK8sClientIntegration:
         config = _make_config()
         config.content = ContentConfig(
             jobs=[JobPath(path="/fake/jobs")],
-            include_bootstrap_jobs=False,
             jobs_config=JobsConfig(
                 storage_class="local-path",
                 access_mode="ReadWriteOnce",
@@ -1730,6 +1727,16 @@ class TestK8sClientIntegration:
             mount_path="/jobs",
             node_selector={"kubernetes.io/hostname": "worker-1"},
         )
+
+    def test_jobs_pvc_is_skipped_without_custom_jobs(self):
+        callback = RecordingCallback()
+        deployer = Deployer(_make_config(), DeployOptions(), callback)
+        deployer._k8s = _mock_k8s()
+
+        deployer._setup_jobs_pvc()
+
+        assert dict(callback.step_updates)["setup-jobs-pvc"] == StepStatus.SKIPPED
+        deployer._k8s.ensure_pvc.assert_not_called()
 
 
 class TestContentAddressedTags:

--- a/installer/tests/test_helm_values.py
+++ b/installer/tests/test_helm_values.py
@@ -263,7 +263,7 @@ class TestGenerateHelmValues:
     def test_nautobot_disabled(self):
         config = _make_config(
             services=ServicesConfig(nautobot=False),
-            content=ContentConfig(jobs=[], include_bootstrap_jobs=False),
+            content=ContentConfig(jobs=[]),
         )
         values = _gen(config)
 
@@ -697,7 +697,6 @@ class TestGenerateHelmValues:
         config = _make_config(
             content=ContentConfig(
                 jobs=[JobPath(path="/opt/jobs/custom")],
-                include_bootstrap_jobs=True,
             ),
         )
         values = _gen(config)
@@ -705,6 +704,11 @@ class TestGenerateHelmValues:
         assert values["nautobot"]["customJobs"]["enabled"] is True
         assert values["nautobot"]["customJobs"]["createPvc"] is False
         assert values["nautobot"]["customJobs"]["pvcName"] == "nautobot-custom-jobs"
+
+    def test_no_custom_jobs_omits_custom_jobs_values(self):
+        values = _gen(_make_config(content=ContentConfig()))
+
+        assert "customJobs" not in values["nautobot"]
 
     def test_custom_jobs_node_selector_in_values(self):
         config = _make_config(
@@ -748,7 +752,7 @@ class TestGenerateHelmValues:
                 nautobot=False,
                 external_nautobot_url="https://nb.prod.example.com",
             ),
-            content=ContentConfig(jobs=[], include_bootstrap_jobs=False),
+            content=ContentConfig(jobs=[]),
         )
         values = _gen(config)
 

--- a/installer/tests/test_schema.py
+++ b/installer/tests/test_schema.py
@@ -73,6 +73,11 @@ class TestNVConfigManagerInstallConfig:
         with pytest.raises(ValueError, match="Unsupported ZTP platform 'sonic'"):
             ZTPOSImage(platform="sonic", version="4.0.0", path="/images/sonic.bin")
 
+    def test_ztp_image_accepts_nv_os_platform(self):
+        image = ZTPOSImage(platform="nv-os", version="25.02.2344", path="/images/nv-os.bin")
+
+        assert image.platform == "nv-os"
+
     def test_yaml_roundtrip(self):
         config = NVConfigManagerInstallConfig(
             cluster=ClusterConfig(
@@ -296,17 +301,10 @@ class TestNVConfigManagerInstallConfig:
                 content=ContentConfig(jobs=[{"path": "jobs/my_job"}]),
             )
 
-    def test_bootstrap_jobs_require_local_nautobot(self):
-        with pytest.raises(ValueError, match="Custom jobs.*require a local Nautobot"):
-            NVConfigManagerInstallConfig(
-                services=ServicesConfig(nautobot=False),
-                content=ContentConfig(include_bootstrap_jobs=True),
-            )
-
     def test_external_nautobot_valid_without_jobs(self):
         config = NVConfigManagerInstallConfig(
             services=ServicesConfig(nautobot=False, external_nautobot_url="https://nb.example.com"),
-            content=ContentConfig(jobs=[], include_bootstrap_jobs=False),
+            content=ContentConfig(jobs=[]),
         )
         assert config.services.nautobot is False
         assert config.services.external_nautobot_url == "https://nb.example.com"

--- a/installer/tests/test_schema.py
+++ b/installer/tests/test_schema.py
@@ -301,6 +301,15 @@ class TestNVConfigManagerInstallConfig:
                 content=ContentConfig(jobs=[{"path": "jobs/my_job"}]),
             )
 
+    def test_post_deploy_jobs_require_local_nautobot(self):
+        with pytest.raises(ValueError, match="post-deploy jobs require a local Nautobot"):
+            NVConfigManagerInstallConfig(
+                services=ServicesConfig(
+                    nautobot=False, external_nautobot_url="https://nb.example.com"
+                ),
+                content=ContentConfig(run_after_deploy=[{"job": "jobs.bootstrap.SiteBootstrap"}]),
+            )
+
     def test_external_nautobot_valid_without_jobs(self):
         config = NVConfigManagerInstallConfig(
             services=ServicesConfig(nautobot=False, external_nautobot_url="https://nb.example.com"),

--- a/installer/tests/test_tui.py
+++ b/installer/tests/test_tui.py
@@ -299,6 +299,9 @@ def test_network_secrets_status_requires_manual_values():
 
     assert screen.get_status(config) == "[!]"
 
+    config.network_secrets[0].value = "   "
+    assert screen.get_status(config) == "[!]"
+
     config.network_secrets[0].value = "manual-password"
     assert screen.get_status(config) == "[*]"
 

--- a/installer/tests/test_tui.py
+++ b/installer/tests/test_tui.py
@@ -40,6 +40,7 @@ from nv_config_manager_installer.schema import (
 from nv_config_manager_installer.tui.app import NVConfigManagerInstallerApp
 from nv_config_manager_installer.tui.screens.cluster import ClusterScreen
 from nv_config_manager_installer.tui.screens.deploy import DeployScreen
+from nv_config_manager_installer.tui.screens.network_secrets import NetworkSecretsScreen
 from nv_config_manager_installer.tui.widgets import LabeledSwitch
 
 
@@ -282,6 +283,24 @@ async def test_network_secrets_eso_initializes_required_site_entries():
 
         secret_keys = {entry.secret_key for entry in app.config.network_secrets}
         assert {"root_password", "api_user_key"} <= secret_keys
+
+
+def test_network_secrets_status_requires_manual_values():
+    config = NVConfigManagerInstallConfig(
+        network_secrets=[
+            NetworkSecretEntry(
+                name="BGP Password",
+                secret_key="bgp_password",
+                source=PasswordSource.MANUAL,
+            )
+        ]
+    )
+    screen = NetworkSecretsScreen(config)
+
+    assert screen.get_status(config) == "[!]"
+
+    config.network_secrets[0].value = "manual-password"
+    assert screen.get_status(config) == "[*]"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`3d25ef95b7d2`](https://github.com/NVIDIA/nv-config-manager/actions/runs/29611232764).
<!-- kind-integration-result:end -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running configured jobs automatically after deployment.
  - Added support for `nv-os` in ZTP image configuration.

- **Improvements**
  - Bundled Nautobot bootstrap jobs are always available from the Nautobot image.
  - Custom and post-deploy jobs are handled separately and require a local Nautobot instance.
  - The installer UI no longer offers an “Include Bootstrap Jobs” option.
  - If no custom jobs are configured, jobs-related PVC setup is skipped.

- **Bug Fixes**
  - Improved validation for manually entered network secret values (including whitespace-only input).
  - Updated example deployment configs to run mock topology setup after deployment.

- **Documentation**
  - Clarified post-deploy/custom job guidance and corrected `nv-os` platform examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->