### PR TITLE
fix(oidc): support Entra ID tokens without profile lookup

### DIFF
--- a/deploy/helm/templates/oidc-proxy.yaml
+++ b/deploy/helm/templates/oidc-proxy.yaml
@@ -79,6 +79,10 @@ data:
     set_authorization_header = true
     set_xauthrequest = true
     oidc_groups_claim = {{ $.Values.oidc.groupsClaim | default "groups" | quote }}
+    # Some providers advertise a profile endpoint that does not accept access
+    # tokens issued for a custom API audience (for example, Entra UserInfo).
+    skip_claims_from_profile_url = {{ $.Values.oidc.proxy.skipClaimsFromProfileURL }}
+    insecure_oidc_allow_unverified_email = {{ $.Values.oidc.proxy.insecureAllowUnverifiedEmail }}
     silence_ping_logging = true
     {{- with $internalIssuerUrl }}
     # Keep the public issuer for token validation, but use explicit in-cluster

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -912,6 +912,13 @@ oidc:
   proxy:
     replicas: 2
     cookieName: _nvcm_oidc_proxy
+    # Use only ID token claims instead of the OIDC discovery profile URL.
+    # Keep disabled by default for compatibility with providers that require
+    # claims to be resolved from their UserInfo endpoint.
+    skipClaimsFromProfileURL: false
+    # Allow an ID token that omits email_verified. Signature, issuer, audience,
+    # and nonce validation remain enabled.
+    insecureAllowUnverifiedEmail: false
     image:
       repository: quay.io/oauth2-proxy/oauth2-proxy
       tag: v7.15.3


### PR DESCRIPTION
## Description

* Fixes oauth2-proxy integration with Entra, local tests were keycloak only

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OIDC proxy options for controlling profile claim retrieval and acceptance of unverified email addresses.
  * Both options are disabled by default and can be enabled through deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->