### PR TITLE
fix(ui): Fix ambiguous spacing in lease dialog

### DIFF
--- a/ui/src/components/dhcp/lease-dashboard.tsx
+++ b/ui/src/components/dhcp/lease-dashboard.tsx
@@ -689,7 +689,7 @@ function ClearLeaseDialog({
             <span className="font-mono font-medium text-foreground">
               {lease?.ip_address}
             </span>
-            . The address can be assigned again immediately.
+            {". The address can be assigned again immediately."}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>


### PR DESCRIPTION
## Description

Fix ambiguous JSX spacing after the styled lease IP address in the clear-lease confirmation dialog. 

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

No kind needed - one line no-op UI change.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

No documentation or generated-artifact updates are needed because the rendered text and behavior are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected punctuation and spacing in the DHCP lease removal confirmation dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->