### PR TITLE
Make Git hooks compatible with macOS Bash

### DIFF
--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -38,6 +38,10 @@ trim() {
     printf '%s' "$value"
 }
 
+lowercase() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 trailers="$(git interpret-trailers --parse "$COMMIT_MSG_FILE")"
 valid_signoff_count=0
 invalid_signoffs=()
@@ -46,14 +50,15 @@ git_user_email="$(git config user.email || true)"
 
 while IFS= read -r line; do
     token="$(trim "${line%%:*}")"
-    if [[ "${token,,}" != "signed-off-by" ]]; then
+    if [[ "$(lowercase "$token")" != "signed-off-by" ]]; then
         continue
     fi
 
     value="$(trim "${line#*:}")"
+    lowercase_value="$(lowercase "$value")"
     if [[ "$value" =~ ^[^[:space:]\<\>][^\<\>]*[[:space:]]\<[^\<\>@[:space:]]+@[^\<\>[:space:]]+\>$ ]] \
-        && [[ "${value,,}" != *"your name"* ]] \
-        && [[ "${value,,}" != *"your.email@example.com"* ]]; then
+        && [[ "$lowercase_value" != *"your name"* ]] \
+        && [[ "$lowercase_value" != *"your.email@example.com"* ]]; then
         ((valid_signoff_count += 1))
     else
         invalid_signoffs+=("$value")

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -57,7 +57,10 @@ LICENSE_TEXT="Licensed under the Apache License"
 missing_files=()
 checked_count=0
 
-mapfile -d '' -t staged_files < <(git diff --cached --name-only -z --diff-filter=ACM)
+staged_files=()
+while IFS= read -r -d '' staged_file; do
+    staged_files+=("$staged_file")
+done < <(git diff --cached --name-only -z --diff-filter=ACM)
 
 should_skip() {
     local file="$1"


### PR DESCRIPTION
## Description

Make the repository's `pre-commit` and `commit-msg` hooks compatible with the Bash 3.2 version provided by macOS. The hooks use a `/bin/bash` shebang but previously relied on Bash 4 features: `mapfile` for staged-file collection and `${value,,}` for lowercasing. As a result, normal signed commits failed before their validations could complete on macOS.

Replace `mapfile` with a NUL-safe `while read` loop and replace lowercase parameter expansion with portable `tr`. The hooks continue to preserve filenames safely, validate SPDX headers, and enforce DCO sign-offs without requiring Homebrew Bash or a commit bypass.

## Validation

- `/bin/bash --version` (`GNU bash, version 3.2.57`)
- `/bin/bash -n scripts/hooks/pre-commit`
- `/bin/bash -n scripts/hooks/commit-msg`
- `shellcheck scripts/hooks/pre-commit scripts/hooks/commit-msg`
- Created a signed commit through the installed hooks using normal `git commit -s`; both the pre-commit and DCO checks completed successfully without `--no-verify`.
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run because this change only affects local Git hook shell compatibility and does not affect application or cluster runtime behavior.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

No documentation or generated-artifact updates are needed because the change only restores the documented local hook behavior on macOS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of commit sign-off trailers regardless of letter casing.
  * Fixed staged-file detection in pre-commit checks to improve reliability.
  * Existing validation and formatting checks continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->