### PR TITLE
feat(workflow): aggregate child backup workflow results

### DIFF
--- a/docs/temporal/workflows/multi-deploy.mdx
+++ b/docs/temporal/workflows/multi-deploy.mdx
@@ -208,7 +208,7 @@ Each batch requires manual approval:
    - Full diff content
 1. **Approve or reject**: Manual approval gate for each batch
 1. **Deployment**: Parallel configuration application to all devices in batch
-1. **Backup**: Automatic backup creation for successful deployments
+1. **Backup**: Automatic backup creation for successful deployments, with a direct link to every backup child workflow
 
 ### Navigation Example
 

--- a/docs/temporal/workflows/multi-deploy.mdx
+++ b/docs/temporal/workflows/multi-deploy.mdx
@@ -137,6 +137,9 @@ The workflow returns comprehensive results:
     "successful_devices": 12,     # Successfully configured devices
     "failed_devices": 2,          # Devices that failed configuration
     "rejected_devices": 1,        # Devices in rejected batches
+    "total_backups": 12,          # Backup child workflows completed
+    "successful_backups": 11,     # Backup child workflows that succeeded
+    "failed_backups": 1,          # Backup child workflows that failed
     "discovery_failures": {},     # Devices that failed diff collection
     "diff_groups": 3,             # Number of unique diff groups
     "total_batches": 5,           # Total batch workflows created
@@ -144,7 +147,26 @@ The workflow returns comprehensive results:
         "batch_0_abc123": {
             "approved": true,
             "successful_devices": ["spine-01", "spine-02"],
-            "failed_devices": {}
+            "failed_devices": {},
+            "backups": {
+                "total": 2,
+                "successful": 2,
+                "failed": 0,
+                "results": {
+                    "spine-01": {
+                        "success": true,
+                        "changed": true,
+                        "error": null,
+                        "child_workflow_id": "backup-workflow-id"
+                    },
+                    "spine-02": {
+                        "success": true,
+                        "changed": false,
+                        "error": null,
+                        "child_workflow_id": "another-backup-workflow-id"
+                    }
+                }
+            }
         }
     }
 }

--- a/docs/temporal/workflows/multi-deploy.mdx
+++ b/docs/temporal/workflows/multi-deploy.mdx
@@ -215,25 +215,24 @@ Each batch requires manual approval:
 The parent workflow displays clickable links with full UI URLs like:
 
 ```text
-Started 2 batch workflows for approval:
+2 batches awaiting approval
 
-- [Batch 2](https://config-manager.example.com/workflows/a1b2c3d4-5e6f-7890-1234-567890abcdef) - 1 devices (spine-03)
-- [Batch 1](https://config-manager.example.com/workflows/23292a68-4a9d-4f15-bac6-6d3c1520d602) - 2 devices (spine-01, spine-02)
+- ⏳ [Batch 1](https://config-manager.example.com/workflows/23292a68-4a9d-4f15-bac6-6d3c1520d602) — spine-01, spine-02
+- ⏳ [Batch 2](https://config-manager.example.com/workflows/a1b2c3d4-5e6f-7890-1234-567890abcdef) — spine-03
 
-Click on the batch links above to review and approve configuration diffs.
+Select a batch to review and approve its shared diff.
 ```
 
 After completion, status is shown with full UI URLs:
 
 ```text
-Batch deployment completed:
-- 3 devices configured successfully
-- 0 devices failed
-- 0 devices rejected (not configured)
+Deployment complete
 
-Child Workflows (click to view details):
-- [Batch 1](https://config-manager.example.com/workflows/23292a68-4a9d-4f15-bac6-6d3c1520d602) - 2 devices (spine-01, spine-02) - Completed (2 success, 0 failed)
-- [Batch 2](https://config-manager.example.com/workflows/a1b2c3d4-5e6f-7890-1234-567890abcdef) - 1 devices (spine-03) - Completed (1 success, 0 failed)
+Devices: 3 configured · 0 failed · 0 rejected
+
+Batches
+- ✅ [Batch 1](https://config-manager.example.com/workflows/23292a68-4a9d-4f15-bac6-6d3c1520d602) — spine-01, spine-02 · Configured 2/2 · Backups 2/2
+- ✅ [Batch 2](https://config-manager.example.com/workflows/a1b2c3d4-5e6f-7890-1234-567890abcdef) — spine-03 · Configured 1/1 · Backups 1/1
 ```
 
 ### UI URL Construction

--- a/docs/user-guides/batch-deploy/index.mdx
+++ b/docs/user-guides/batch-deploy/index.mdx
@@ -46,7 +46,9 @@ The workflow runs three stages in order. Only the first stage requires human app
 
 1. **`perform_backups` — Capture a fresh backup for every successful device.**
 
-   For each device in `successful_devices`, the workflow starts the [Configuration Backup](../configuration-backup/index.mdx) workflow as a child workflow with `trigger=WORKFLOW`, attaching the device's intended-config commit SHA so the new backup is correlated with the configuration version that was just applied. All backup children are started immediately and awaited in parallel with a 10-minute run timeout. Backup failures are not surfaced as workflow failures — the device is configured and in service; only the post-deploy backup is missing.
+   For each device in `successful_devices`, the workflow starts the [Configuration Backup](../configuration-backup/index.mdx) workflow as a child workflow with `trigger=WORKFLOW`, attaching the device's intended-config commit SHA so the new backup is correlated with the configuration version that was just applied. All backup children are started immediately and awaited concurrently with a 10-minute run timeout.
+
+   The stage updates its display as children finish and records each terminal result by device name, including whether the backup succeeded, whether it changed the stored configuration, any error, and the child workflow ID. A failed backup is included in `failed_backups` and the per-device result, but it does not fail the deployment batch — the device is configured and in service; only the post-deploy backup is missing.
 
 If `review_shared_diff` rejects, the workflow archives the result and exits without running the two subsequent stages.
 
@@ -57,8 +59,9 @@ Confirm the run succeeded by checking all of the following:
 - **All three stages green** on the Config Manager run page (or `review_shared_diff` green and the others marked unreachable, if the diff was rejected).
 - **`successful_devices`** in the workflow result lists every device the operator expected to receive the change.
 - **`failed_devices`** is empty. Any entry is a `{device_name: error}` pair; investigate the error and re-run with a corrected batch input.
-- **A fresh backup exists** for every successful device. The `perform_backups` stage display reports the number of backup child workflows it initiated; cross-check those child runs from the status page if a device is in production and you need the new backup confirmed.
-- **Parent workflow link** (when invoked by Multi-Deploy) reflects the batch result in the parent's `execute_batches` display.
+- **The `backups` summary is complete.** Its `total` count should equal the number of successfully configured devices, and `successful + failed` should equal `total`. The `results` map contains the success state, changed state, error, and child workflow ID for every device backup.
+- **A fresh backup exists** for every result with `success=true`. For a failed result, use its `error` and `child_workflow_id` to inspect the child run and correct the underlying problem.
+- **Parent workflow link** (when invoked by Multi-Deploy) shows the configuration and backup success/failure counts in the parent's `execute_batches` display.
 
 ## Common issues
 
@@ -80,7 +83,7 @@ Something is rewriting devices' running configurations out of band (a parallel m
 
 **Backup workflow failed but apply succeeded.**
 
-The device is configured and in service; only the post-deploy backup is missing. Re-run the [Configuration Backup](../configuration-backup/index.mdx) workflow against the device once the underlying issue is resolved.
+The device is configured and in service; only the post-deploy backup is missing. Inspect the device's entry in `backups.results` for the error and child workflow ID, then re-run the [Configuration Backup](../configuration-backup/index.mdx) workflow against the device once the underlying issue is resolved.
 
 **Deploy-disabled switch ended up in a direct Batch Deploy invocation.**
 

--- a/docs/user-guides/batch-deploy/index.mdx
+++ b/docs/user-guides/batch-deploy/index.mdx
@@ -48,7 +48,7 @@ The workflow runs three stages in order. Only the first stage requires human app
 
    For each device in `successful_devices`, the workflow starts the [Configuration Backup](../configuration-backup/index.mdx) workflow as a child workflow with `trigger=WORKFLOW`, attaching the device's intended-config commit SHA so the new backup is correlated with the configuration version that was just applied. All backup children are started immediately and awaited concurrently with a 10-minute run timeout.
 
-   The stage updates its display as children finish and records each terminal result by device name, including whether the backup succeeded, whether it changed the stored configuration, any error, and the child workflow ID. A failed backup is included in `failed_backups` and the per-device result, but it does not fail the deployment batch — the device is configured and in service; only the post-deploy backup is missing.
+   The stage displays a direct link to every backup child as soon as it starts and updates each link as the child succeeds or fails. It also records each terminal result by device name, including whether the backup succeeded, whether it changed the stored configuration, any error, and the child workflow ID. A failed backup is included in `failed_backups` and the per-device result, but it does not fail the deployment batch — the device is configured and in service; only the post-deploy backup is missing.
 
 If `review_shared_diff` rejects, the workflow archives the result and exits without running the two subsequent stages.
 
@@ -60,7 +60,7 @@ Confirm the run succeeded by checking all of the following:
 - **`successful_devices`** in the workflow result lists every device the operator expected to receive the change.
 - **`failed_devices`** is empty. Any entry is a `{device_name: error}` pair; investigate the error and re-run with a corrected batch input.
 - **The `backups` summary is complete.** Its `total` count should equal the number of successfully configured devices, and `successful + failed` should equal `total`. The `results` map contains the success state, changed state, error, and child workflow ID for every device backup.
-- **A fresh backup exists** for every result with `success=true`. For a failed result, use its `error` and `child_workflow_id` to inspect the child run and correct the underlying problem.
+- **A fresh backup exists** for every result with `success=true`. Open its link in the `perform_backups` stage to inspect the child run. For a failed result, use the same link and its recorded error to correct the underlying problem.
 - **Parent workflow link** (when invoked by Multi-Deploy) shows the configuration and backup success/failure counts in the parent's `execute_batches` display.
 
 ## Common issues

--- a/docs/user-guides/multi-deploy/index.mdx
+++ b/docs/user-guides/multi-deploy/index.mdx
@@ -56,7 +56,7 @@ The parent workflow runs four stages in order. None of the parent stages require
 
    For each batch, the parent starts a child [Batch Deploy](../batch-deploy/index.mdx) and posts a clickable link to it on the stage display. The parent stage stays running and updates the display as each child completes (succeeded, failed, or rejected). The approval gate for each batch lives inside its child workflow — open the child link to review the diff and approve or reject.
 
-The parent workflow is complete only after every child batch workflow terminates. The final result aggregates total successes, failures, and rejections across all batches.
+The parent workflow is complete only after every child batch workflow terminates. The final result aggregates configuration successes, failures, and rejections across all batches, along with `total_backups`, `successful_backups`, and `failed_backups` from the backup children spawned by those batches.
 
 ## Diff grouping and batching
 
@@ -82,10 +82,10 @@ That is 30 devices, 3 diff groups, and 5 child batch workflows — meaning 5 app
 
 Confirm the run succeeded by checking all of the following:
 
-- **Parent workflow status** shows all four stages green on the Config Manager run page and reports a final summary with `total_devices`, `successful_devices`, `failed_devices`, and `rejected_devices`.
+- **Parent workflow status** shows all four stages green on the Config Manager run page and reports a final summary with device deployment counts and `total_backups`, `successful_backups`, and `failed_backups`.
 - **Every child batch workflow** linked from the `execute_batches` display reached a terminal state. Click each batch link to confirm the per-batch outcome (approved + applied, approved with some device failures, or rejected).
 - **Discovery failures** in the parent result are an expected output, not a workflow failure. Any device that failed diff collection is listed under `discovery_failures` with the error string — typically unreachable devices, missing intended configs, or render failures. Address these separately and re-run the workflow.
-- **Backups completed** for every successfully applied device. The child workflow's `perform_backups` stage triggers a [Configuration Backup](../configuration-backup/index.mdx) per device as a child workflow; failures there mean the device is configured but no fresh backup was captured.
+- **Backup totals reconcile.** `successful_backups + failed_backups` should equal `total_backups`, and `total_backups` should equal the number of successfully applied devices. Per-device details are available under each entry in `batch_results` at `backups.results`, including the backup child workflow ID and any error.
 - **Rejected batches.** If an approver rejected a batch, its devices appear in `rejected_devices` and never had configuration applied. Re-run a smaller scope once the underlying objection is resolved.
 
 ## Common issues

--- a/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
@@ -74,6 +74,37 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 )
 
 
+def _format_device_list(device_names: list[str]) -> str:
+    """Format a compact device preview for a batch link."""
+    device_list = ", ".join(device_names[:3])
+    if len(device_names) > 3:
+        device_list += f" +{len(device_names) - 3} more"
+    return device_list
+
+
+def _format_batch_status(result: dict[str, Any], device_count: int) -> tuple[str, str]:
+    """Format the icon and compact terminal status for a batch result."""
+    if "error" in result:
+        return "❌", "Workflow failed"
+    if not result.get("approved", False):
+        return "⛔", "Rejected"
+
+    successful = len(result.get("successful_devices") or [])
+    failed = len(result.get("failed_devices") or {})
+    backups = result.get("backups") or {}
+    successful_backups = backups.get("successful", 0)
+    failed_backups = backups.get("failed", 0)
+    total_backups = backups.get("total", successful_backups + failed_backups)
+    icon = "✅" if failed == 0 and failed_backups == 0 else "⚠️"
+
+    backup_status = (
+        f"Backups **{successful_backups}/{total_backups}**"
+        if total_backups
+        else "Backups **not run**"
+    )
+    return icon, f"Configured **{successful}/{device_count}** · {backup_status}"
+
+
 class MultiDeployInput(BaseModel):
     """Multi-Deploy Workflow Input Definition."""
 
@@ -789,23 +820,21 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
         child_workflow_links = []
         for batch_id, handle in batch_handles.items():
             batch_index = int(batch_id.split("_")[1])
-            device_count = len(stage_input.batches[batch_index])
             device_names = [d.device.name for d in stage_input.batches[batch_index]]
-            device_list = ", ".join(device_names[:3])
-            if len(device_names) > 3:
-                device_list += f" and {len(device_names) - 3} more"
+            device_list = _format_device_list(device_names)
 
             child_workflow_url = build_workflow_url(ui_base_url, handle.id)
 
             child_workflow_links.append(
-                f"- [Batch {batch_index + 1}]({child_workflow_url}) - {device_count} devices ({device_list})"
+                f"- ⏳ [Batch {batch_index + 1}]({child_workflow_url}) — {device_list}"
             )
 
         # Update the stage output with links while workflows are running
+        batch_label = "batch" if len(batch_handles) == 1 else "batches"
         initial_display = (
-            f"**Started {len(batch_handles)} batch workflows for approval:**\n\n"
+            f"**{len(batch_handles)} {batch_label} awaiting approval**\n\n"
             + "\n".join(child_workflow_links)
-            + "\n\n*Click on the batch links above to review and approve configuration diffs.*"
+            + "\n\n*Select a batch to review and approve its shared diff.*"
         )
 
         initial_output = MultiDeployWorkflow.ExecuteBatchesStageOutput(
@@ -828,9 +857,7 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                 batch_index = int(batch_id.split("_")[1])
                 device_count = len(stage_input.batches[batch_index])
                 device_names = [d.device.name for d in stage_input.batches[batch_index]]
-                device_list = ", ".join(device_names[:3])
-                if len(device_names) > 3:
-                    device_list += f" and {len(device_names) - 3} more"
+                device_list = _format_device_list(device_names)
 
                 child_workflow_url = build_workflow_url(ui_base_url, handle.id)
 
@@ -838,32 +865,16 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                 if batch_id in batch_results:
                     result = batch_results[batch_id]
                     if isinstance(result, dict):
-                        if "error" in result:
-                            status = "❌ Failed"
-                        elif result.get("approved", False):
-                            successful_devices = result.get("successful_devices", [])
-                            failed_devices = result.get("failed_devices", {})
-                            successful = len(successful_devices) if successful_devices else 0
-                            failed = len(failed_devices) if failed_devices else 0
-                            backups = result.get("backups", {})
-                            successful_backups = backups.get("successful", 0)
-                            failed_backups = backups.get("failed", 0)
-                            status = (
-                                f"✅ Completed ({successful} configured, {failed} config failed; "
-                                f"{successful_backups} backups successful, "
-                                f"{failed_backups} backups failed)"
-                            )
-                        else:
-                            status = "⛔ Rejected"
+                        icon, status = _format_batch_status(result, device_count)
                     else:
-                        status = "❓ Unknown result"
+                        icon, status = "❓", "Unknown result"
                 elif completed_batches and batch_id in completed_batches:
-                    status = "⏳ Processing result..."
+                    icon, status = "⏳", "Processing result"
                 else:
-                    status = "⏳ Waiting for approval..."
+                    icon, status = "⏳", "Awaiting approval"
 
                 batch_links.append(
-                    f"- [Batch {batch_index + 1}]({child_workflow_url}) - {device_count} devices ({device_list}) - {status}"
+                    f"- {icon} [Batch {batch_index + 1}]({child_workflow_url}) — {device_list} · {status}"
                 )
 
             return batch_links
@@ -939,21 +950,21 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
 
             if completed_count < total_count:
                 # Still in progress
+                batch_label = "batch" if total_count == 1 else "batches"
                 display = (
-                    f"**Batch deployment in progress ({completed_count}/{total_count} completed):**\n"
-                    f"- {total_successful} devices configured successfully\n"
-                    f"- {total_failed} devices failed\n"
-                    f"- {total_rejected} devices rejected (not configured)\n\n"
-                    f"**Child Workflows (click to view details):**\n" + "\n".join(batch_links)
+                    f"**Deployment in progress** — {completed_count}/{total_count} "
+                    f"{batch_label} complete\n\n"
+                    f"**Devices:** {total_successful} configured · {total_failed} failed · "
+                    f"{total_rejected} rejected\n\n"
+                    f"**Batches**\n" + "\n".join(batch_links)
                 )
             else:
                 # All completed
                 display = (
-                    f"**Batch deployment completed:**\n"
-                    f"- {total_successful} devices configured successfully\n"
-                    f"- {total_failed} devices failed\n"
-                    f"- {total_rejected} devices rejected (not configured)\n\n"
-                    f"**Child Workflows (click to view details):**\n" + "\n".join(batch_links)
+                    f"**Deployment complete**\n\n"
+                    f"**Devices:** {total_successful} configured · {total_failed} failed · "
+                    f"{total_rejected} rejected\n\n"
+                    f"**Batches**\n" + "\n".join(batch_links)
                 )
 
             # Update the stage output with current progress
@@ -970,11 +981,10 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
         # to ensure consistency
         final_batch_links = generate_batch_links(batch_results)
         display = (
-            f"**Batch deployment completed:**\n"
-            f"- {total_successful} devices configured successfully\n"
-            f"- {total_failed} devices failed\n"
-            f"- {total_rejected} devices rejected (not configured)\n\n"
-            f"**Child Workflows (click to view details):**\n" + "\n".join(final_batch_links)
+            f"**Deployment complete**\n\n"
+            f"**Devices:** {total_successful} configured · {total_failed} failed · "
+            f"{total_rejected} rejected\n\n"
+            f"**Batches**\n" + "\n".join(final_batch_links)
         )
 
         return MultiDeployWorkflow.ExecuteBatchesStageOutput(

--- a/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
@@ -135,6 +135,15 @@ class BatchDeployInput(BaseModel):
     )
 
 
+class BatchBackupResultData(BaseModel):
+    """Completion data for one backup child workflow in a deployment batch."""
+
+    success: bool
+    changed: bool | None = None
+    error: str | None = None
+    child_workflow_id: str
+
+
 @workflow.defn
 class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, ArchiveMixin):
     """Batch configuration deployment workflow for multiple devices."""
@@ -318,10 +327,14 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     class BackupsStageOutput(StageOutput):
         """Backups Stage Output."""
 
+        backup_results: dict[str, BatchBackupResultData]
+        successful_backups: int
+        failed_backups: int
+
     @stage_executor("perform_backups")
     async def perform_backups(self, stage_input: BackupsStageInput) -> BackupsStageOutput:
         """Perform backups for all successfully configured devices."""
-        backup_handles = []
+        backup_handles: dict[str, Any] = {}
 
         for device_data in stage_input.successful_devices:
             backup_input = BackupInput(
@@ -337,13 +350,74 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                 BackupWorkflow.run, backup_input, run_timeout=timedelta(minutes=10)
             )
             self.append_child_workflow("perform_backups", backup_handle.id)
-            backup_handles.append(backup_handle)
+            backup_handles[device_data.device.name] = backup_handle
 
-        # Wait for all backups to complete
-        await asyncio.gather(*backup_handles, return_exceptions=True)
+        backup_results: dict[str, BatchBackupResultData] = {}
+        remaining_items = list(backup_handles.items())
+        total_backups = len(backup_handles)
+
+        while remaining_items:
+            remaining_handles = [handle for _, handle in remaining_items]
+            done, _ = await workflow.wait(remaining_handles, return_when=asyncio.FIRST_COMPLETED)
+
+            for completed_handle in done:
+                device_name = None
+                for index, (name, handle) in enumerate(remaining_items):
+                    if handle is completed_handle:
+                        device_name = name
+                        remaining_items.pop(index)
+                        break
+
+                if device_name is None:
+                    continue
+
+                try:
+                    changed = completed_handle.result()
+                    backup_results[device_name] = BatchBackupResultData(
+                        success=True,
+                        changed=changed,
+                        child_workflow_id=completed_handle.id,
+                    )
+                except ChildWorkflowError as exc:
+                    backup_results[device_name] = BatchBackupResultData(
+                        success=False,
+                        error=str(exc.cause),
+                        child_workflow_id=completed_handle.id,
+                    )
+
+            successful_backups = sum(result.success for result in backup_results.values())
+            failed_backups = len(backup_results) - successful_backups
+            completed_backups = len(backup_results)
+            self.set_stage_output(
+                "perform_backups",
+                BatchDeployWorkflow.BackupsStageOutput(
+                    backup_results=backup_results.copy(),
+                    successful_backups=successful_backups,
+                    failed_backups=failed_backups,
+                    display=(
+                        f"**Backups in progress ({completed_backups}/{total_backups} completed):**\n"
+                        f"- {successful_backups} backups successful\n"
+                        f"- {failed_backups} backups failed\n"
+                        f"- {total_backups - completed_backups} backups in progress"
+                    ),
+                ),
+            )
+
+        successful_backups = sum(result.success for result in backup_results.values())
+        failed_backups = len(backup_results) - successful_backups
+        changed_backups = sum(
+            result.changed is True for result in backup_results.values() if result.success
+        )
 
         return BatchDeployWorkflow.BackupsStageOutput(
-            display=f"Initiated backups for {len(backup_handles)} devices."
+            backup_results=backup_results,
+            successful_backups=successful_backups,
+            failed_backups=failed_backups,
+            display=(
+                f"Backups completed for {total_backups} devices. "
+                f"Success: {successful_backups} ({changed_backups} changed), "
+                f"Failed: {failed_backups}"
+            ),
         )
 
     @run_nv_config_manager_workflow
@@ -365,6 +439,12 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
             "approved": review_output.approved,
             "successful_devices": [],
             "failed_devices": {},
+            "backups": {
+                "total": 0,
+                "successful": 0,
+                "failed": 0,
+                "results": {},
+            },
         }
 
         if review_output.approved:
@@ -387,12 +467,20 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                 if device.device.name in apply_output.successful_devices
             ]
 
-            if successful_device_data:
-                await self.perform_backups(
-                    BatchDeployWorkflow.BackupsStageInput(
-                        successful_devices=successful_device_data,
-                    )
+            backups_output = await self.perform_backups(
+                BatchDeployWorkflow.BackupsStageInput(
+                    successful_devices=successful_device_data,
                 )
+            )
+            result["backups"] = {
+                "total": len(backups_output.backup_results),
+                "successful": backups_output.successful_backups,
+                "failed": backups_output.failed_backups,
+                "results": {
+                    device_name: backup_result.model_dump()
+                    for device_name, backup_result in backups_output.backup_results.items()
+                },
+            }
         else:
             # Mark stages as unreachable
             self.set_stage_state("apply_configurations", StateEnum.UNREACHABLE)
@@ -757,7 +845,14 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                             failed_devices = result.get("failed_devices", {})
                             successful = len(successful_devices) if successful_devices else 0
                             failed = len(failed_devices) if failed_devices else 0
-                            status = f"✅ Completed ({successful} success, {failed} failed)"
+                            backups = result.get("backups", {})
+                            successful_backups = backups.get("successful", 0)
+                            failed_backups = backups.get("failed", 0)
+                            status = (
+                                f"✅ Completed ({successful} configured, {failed} config failed; "
+                                f"{successful_backups} backups successful, "
+                                f"{failed_backups} backups failed)"
+                            )
                         else:
                             status = "⛔ Rejected"
                     else:
@@ -913,6 +1008,9 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                 "successful_devices": 0,
                 "failed_devices": 0,
                 "rejected_devices": 0,
+                "total_backups": 0,
+                "successful_backups": 0,
+                "failed_backups": 0,
                 "discovery_failures": {},
                 "message": f"No devices found with role '{workflow_input.role}'",
             }
@@ -928,6 +1026,9 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                 "successful_devices": 0,
                 "failed_devices": 0,
                 "rejected_devices": 0,
+                "total_backups": 0,
+                "successful_backups": 0,
+                "failed_backups": 0,
                 "discovery_failures": diffs_output.failed_devices,
                 "message": "No devices have configuration changes to deploy",
             }
@@ -951,11 +1052,20 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
 
         await self.archive_results()
 
+        backup_summaries = [
+            batch_result.get("backups", {})
+            for batch_result in execute_output.batch_results.values()
+            if "error" not in batch_result
+        ]
+
         return {
             "total_devices": len(discover_output.devices),
             "successful_devices": execute_output.total_successful,
             "failed_devices": execute_output.total_failed + len(diffs_output.failed_devices),
             "rejected_devices": execute_output.total_rejected,
+            "total_backups": sum(summary.get("total", 0) for summary in backup_summaries),
+            "successful_backups": sum(summary.get("successful", 0) for summary in backup_summaries),
+            "failed_backups": sum(summary.get("failed", 0) for summary in backup_summaries),
             "discovery_failures": diffs_output.failed_devices,
             "batch_results": execute_output.batch_results,
             "diff_groups": len(batch_output.diff_groups),

--- a/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
@@ -426,28 +426,23 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                     successful_backups=successful_backups,
                     failed_backups=failed_backups,
                     display=(
-                        f"**Backups in progress ({completed_backups}/{total_backups} completed):**\n"
-                        f"- {successful_backups} backups successful\n"
-                        f"- {failed_backups} backups failed\n"
-                        f"- {total_backups - completed_backups} backups in progress"
+                        f"**Backups in progress** — {completed_backups}/{total_backups} complete\n\n"
+                        f"**Devices:** {successful_backups} successful · {failed_backups} failed · "
+                        f"{total_backups - completed_backups} in progress"
                     ),
                 ),
             )
 
         successful_backups = sum(result.success for result in backup_results.values())
         failed_backups = len(backup_results) - successful_backups
-        changed_backups = sum(
-            result.changed is True for result in backup_results.values() if result.success
-        )
 
         return BatchDeployWorkflow.BackupsStageOutput(
             backup_results=backup_results,
             successful_backups=successful_backups,
             failed_backups=failed_backups,
             display=(
-                f"Backups completed for {total_backups} devices. "
-                f"Success: {successful_backups} ({changed_backups} changed), "
-                f"Failed: {failed_backups}"
+                f"**Backups complete**\n\n"
+                f"**Devices:** {successful_backups} successful · {failed_backups} failed"
             ),
         )
 

--- a/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
@@ -105,6 +105,27 @@ def _format_batch_status(result: dict[str, Any], device_count: int) -> tuple[str
     return icon, f"Configured **{successful}/{device_count}** · {backup_status}"
 
 
+def _format_backup_workflow_links(
+    ui_base_url: str,
+    backup_handles: dict[str, Any],
+    backup_results: dict[str, Any],
+) -> str:
+    """Format backup child workflow links with their current status."""
+    links = []
+    for device_name, handle in backup_handles.items():
+        result = backup_results.get(device_name)
+        if result is None:
+            icon, status = "⏳", "In progress"
+        elif result.success:
+            icon, status = "✅", "Successful"
+        else:
+            icon, status = "❌", "Failed"
+
+        workflow_url = build_workflow_url(ui_base_url, handle.id)
+        links.append(f"- {icon} [{device_name} backup]({workflow_url}) — {status}")
+    return "\n".join(links) or "*No backup workflows were started.*"
+
+
 class MultiDeployInput(BaseModel):
     """Multi-Deploy Workflow Input Definition."""
 
@@ -365,6 +386,11 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     @stage_executor("perform_backups")
     async def perform_backups(self, stage_input: BackupsStageInput) -> BackupsStageOutput:
         """Perform backups for all successfully configured devices."""
+        ui_base_url = await workflow.execute_activity(
+            get_ui_base_url,
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+        )
         backup_handles: dict[str, Any] = {}
 
         for device_data in stage_input.successful_devices:
@@ -386,6 +412,20 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
         backup_results: dict[str, BatchBackupResultData] = {}
         remaining_items = list(backup_handles.items())
         total_backups = len(backup_handles)
+        initial_links = _format_backup_workflow_links(ui_base_url, backup_handles, backup_results)
+        self.set_stage_output(
+            "perform_backups",
+            BatchDeployWorkflow.BackupsStageOutput(
+                backup_results={},
+                successful_backups=0,
+                failed_backups=0,
+                display=(
+                    f"**Backups in progress** — 0/{total_backups} complete\n\n"
+                    f"**Devices:** 0 successful · 0 failed · {total_backups} in progress\n\n"
+                    f"**Backup workflows**\n{initial_links}"
+                ),
+            ),
+        )
 
         while remaining_items:
             remaining_handles = [handle for _, handle in remaining_items]
@@ -419,6 +459,9 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
             successful_backups = sum(result.success for result in backup_results.values())
             failed_backups = len(backup_results) - successful_backups
             completed_backups = len(backup_results)
+            backup_links = _format_backup_workflow_links(
+                ui_base_url, backup_handles, backup_results
+            )
             self.set_stage_output(
                 "perform_backups",
                 BatchDeployWorkflow.BackupsStageOutput(
@@ -428,13 +471,15 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                     display=(
                         f"**Backups in progress** — {completed_backups}/{total_backups} complete\n\n"
                         f"**Devices:** {successful_backups} successful · {failed_backups} failed · "
-                        f"{total_backups - completed_backups} in progress"
+                        f"{total_backups - completed_backups} in progress\n\n"
+                        f"**Backup workflows**\n{backup_links}"
                     ),
                 ),
             )
 
         successful_backups = sum(result.success for result in backup_results.values())
         failed_backups = len(backup_results) - successful_backups
+        backup_links = _format_backup_workflow_links(ui_base_url, backup_handles, backup_results)
 
         return BatchDeployWorkflow.BackupsStageOutput(
             backup_results=backup_results,
@@ -442,7 +487,8 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
             failed_backups=failed_backups,
             display=(
                 f"**Backups complete**\n\n"
-                f"**Devices:** {successful_backups} successful · {failed_backups} failed"
+                f"**Devices:** {successful_backups} successful · {failed_backups} failed\n\n"
+                f"**Backup workflows**\n{backup_links}"
             ),
         )
 

--- a/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
@@ -49,6 +49,7 @@ from nv_config_manager.temporal.ngc.workflows.multi_deploy import (
     BatchDeployWorkflow,
     MultiDeployInput,
     MultiDeployWorkflow,
+    _format_batch_status,
 )
 
 
@@ -266,7 +267,27 @@ async def test_multi_deploy_workflow_basic_flow(
 
         stages = await handle.query("stages")
         execute_stage = next(stage for stage in stages if stage["name"] == "execute_batches")
-        assert "3 backups successful, 0 backups failed" in execute_stage["output"]["display"]
+        assert "**Deployment complete**" in execute_stage["output"]["display"]
+        assert (
+            "**Devices:** 3 configured · 0 failed · 0 rejected"
+            in execute_stage["output"]["display"]
+        )
+        assert "Configured **3/3** · Backups **3/3**" in execute_stage["output"]["display"]
+
+
+def test_format_batch_status_with_backup_failure():
+    """Show partial backup completion compactly and flag it for attention."""
+    result = {
+        "approved": True,
+        "successful_devices": ["spine-01", "spine-02"],
+        "failed_devices": {},
+        "backups": {"total": 2, "successful": 1, "failed": 1},
+    }
+
+    assert _format_batch_status(result, 2) == (
+        "⚠️",
+        "Configured **2/2** · Backups **1/2**",
+    )
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
@@ -631,4 +631,6 @@ async def test_batch_deploy_workflow_directly(
         assert backups_stage["state"] == "COMPLETE"
         assert backups_stage["output"]["successful_backups"] == 1
         assert backups_stage["output"]["failed_backups"] == 1
-        assert "Backups completed for 2 devices" in backups_stage["output"]["display"]
+        assert backups_stage["output"]["display"] == (
+            "**Backups complete**\n\n**Devices:** 1 successful · 1 failed"
+        )

--- a/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
@@ -21,8 +21,9 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
-from temporalio import activity
+from temporalio import activity, workflow
 from temporalio.client import Client, WorkflowHandle
+from temporalio.exceptions import ApplicationError
 from temporalio.worker import Worker
 
 from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData
@@ -43,7 +44,7 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
     GetNetworkDevicesInput,
     GetNetworkDevicesOutput,
 )
-from nv_config_manager.temporal.ngc.workflows.backup import BackupWorkflow
+from nv_config_manager.temporal.ngc.workflows.backup import BackupInput, BackupWorkflow
 from nv_config_manager.temporal.ngc.workflows.multi_deploy import (
     BatchDeployWorkflow,
     MultiDeployInput,
@@ -115,6 +116,18 @@ async def mock_record_backup_config_manager_plugin(activity_input) -> tuple[bool
 [Latest Commit](https://gitlab.example.com/example-user/deployed-network-configs/-/commit/mock_commit_id)
 """
     return True, f"Persisted new backup configuration:\n{markdown}"
+
+
+@workflow.defn(name="BackupWorkflow", sandboxed=False)
+class MockBatchBackupWorkflow:
+    """Return mixed terminal results for batch backup aggregation tests."""
+
+    @workflow.run
+    async def run(self, workflow_input: BackupInput) -> bool:
+        """Fail one device and report a changed backup for the other."""
+        if workflow_input.device_id == "device_2":
+            raise ApplicationError("mock backup failure", non_retryable=True)
+        return True
 
 
 @pytest.mark.asyncio
@@ -215,8 +228,45 @@ async def test_multi_deploy_workflow_basic_flow(
             "1 total batches" in group_stage["output"]["display"]
         )  # 3 devices with max_batch_size=10
 
-        # Cancel the workflow as we've verified the core functionality
-        await handle.cancel()
+        # Wait for the batch child workflow to request approval
+        start_time = 0
+        while start_time < max_wait_time:
+            stages = await handle.query("stages")
+            execute_stage = next((s for s in stages if s["name"] == "execute_batches"), None)
+            if execute_stage and execute_stage["child_workflows"]:
+                break
+            await asyncio.sleep(0.5)
+            start_time += 0.5
+
+        assert execute_stage and len(execute_stage["child_workflows"]) == 1
+        batch_handle = client.get_workflow_handle(execute_stage["child_workflows"][0])
+
+        start_time = 0
+        while start_time < max_wait_time:
+            batch_stages = await batch_handle.query("stages")
+            review_stage = next(
+                (s for s in batch_stages if s["name"] == "review_shared_diff"), None
+            )
+            if review_stage and review_stage["state"] == "PENDING_APPROVAL":
+                break
+            await asyncio.sleep(0.5)
+            start_time += 0.5
+
+        assert review_stage and review_stage["state"] == "PENDING_APPROVAL"
+        await batch_handle.signal(
+            "approve", {"stage_name": "review_shared_diff", "user": "TestUser"}
+        )
+
+        result = await handle.result()
+        assert result["successful_devices"] == 3
+        assert result["failed_devices"] == 0
+        assert result["total_backups"] == 3
+        assert result["successful_backups"] == 3
+        assert result["failed_backups"] == 0
+
+        stages = await handle.query("stages")
+        execute_stage = next(stage for stage in stages if stage["name"] == "execute_batches")
+        assert "3 backups successful, 0 backups failed" in execute_stage["output"]["display"]
 
 
 @pytest.mark.asyncio
@@ -277,6 +327,9 @@ async def test_multi_deploy_workflow_no_devices(
         assert result["successful_devices"] == 0
         assert result["failed_devices"] == 0
         assert result["rejected_devices"] == 0
+        assert result["total_backups"] == 0
+        assert result["successful_backups"] == 0
+        assert result["failed_backups"] == 0
         assert result["message"] == "No devices found with role 'nonexistent'"
 
 
@@ -335,6 +388,9 @@ async def test_multi_deploy_workflow_no_diffs(
         assert result["successful_devices"] == 0
         assert result["failed_devices"] == 0
         assert result["rejected_devices"] == 0
+        assert result["total_backups"] == 0
+        assert result["successful_backups"] == 0
+        assert result["failed_backups"] == 0
         assert result["message"] == "No devices have configuration changes to deploy"
 
 
@@ -432,7 +488,7 @@ async def test_batch_deploy_workflow_directly(
     async with Worker(
         client,
         task_queue=task_queue_name,
-        workflows=[BatchDeployWorkflow, BackupWorkflow],
+        workflows=[BatchDeployWorkflow, MockBatchBackupWorkflow],
         activities=[
             mock_get_network_device,
             mock_load_intended_configuration,
@@ -536,3 +592,22 @@ async def test_batch_deploy_workflow_directly(
         assert len(result["failed_devices"]) == 0
         assert "spine-01" in result["successful_devices"]
         assert "spine-02" in result["successful_devices"]
+        assert result["backups"]["total"] == 2
+        assert result["backups"]["successful"] == 1
+        assert result["backups"]["failed"] == 1
+        assert set(result["backups"]["results"]) == {"spine-01", "spine-02"}
+        assert result["backups"]["results"]["spine-01"]["success"] is True
+        assert result["backups"]["results"]["spine-01"]["changed"] is True
+        assert result["backups"]["results"]["spine-02"]["success"] is False
+        assert "mock backup failure" in result["backups"]["results"]["spine-02"]["error"]
+        assert all(
+            backup_result["child_workflow_id"]
+            for backup_result in result["backups"]["results"].values()
+        )
+
+        stages = await handle.query("stages")
+        backups_stage = next(stage for stage in stages if stage["name"] == "perform_backups")
+        assert backups_stage["state"] == "COMPLETE"
+        assert backups_stage["output"]["successful_backups"] == 1
+        assert backups_stage["output"]["failed_backups"] == 1
+        assert "Backups completed for 2 devices" in backups_stage["output"]["display"]

--- a/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
@@ -513,6 +513,7 @@ async def test_batch_deploy_workflow_directly(
         activities=[
             mock_get_network_device,
             mock_load_intended_configuration,
+            get_ui_base_url,
             perform_candidate_diff,
             apply_approved_configuration,
             load_running_configuration,
@@ -631,6 +632,11 @@ async def test_batch_deploy_workflow_directly(
         assert backups_stage["state"] == "COMPLETE"
         assert backups_stage["output"]["successful_backups"] == 1
         assert backups_stage["output"]["failed_backups"] == 1
-        assert backups_stage["output"]["display"] == (
-            "**Backups complete**\n\n**Devices:** 1 successful · 1 failed"
-        )
+        backup_display = backups_stage["output"]["display"]
+        assert "**Backups complete**" in backup_display
+        assert "**Devices:** 1 successful · 1 failed" in backup_display
+        assert "**Backup workflows**" in backup_display
+        assert "[spine-01 backup]" in backup_display
+        assert "[spine-02 backup]" in backup_display
+        for backup_result in result["backups"]["results"].values():
+            assert backup_result["child_workflow_id"] in backup_display


### PR DESCRIPTION
## Description

Batch deploy previously awaited all backup child workflows but discarded their return values and failures. The stage reported only that backups were initiated, so operators could not tell from the batch or multi-deploy result whether every child backup completed successfully.

This change:

- records per-device backup success, changed state, error details, and child workflow IDs
- updates the backup stage output as child workflows complete
- includes backup summaries in each batch result
- aggregates total, successful, and failed backup counts in the multi-deploy result
- surfaces backup completion counts in parent workflow status links
- documents the expanded result contract

This gives operators a complete parent-level view of backup completion while preserving successful sibling results when one backup child fails.
<img width="516" height="483" alt="Screenshot 2026-07-20 at 3 57 11 PM" src="https://github.com/user-attachments/assets/891a08f3-7150-40cc-a262-cad1118624d4" />
<img width="519" height="468" alt="Screenshot 2026-07-20 at 3 57 13 PM" src="https://github.com/user-attachments/assets/433e96ed-629f-470e-988d-9aff9df980f1" />
<img width="653" height="374" alt="Screenshot 2026-07-20 at 3 57 35 PM" src="https://github.com/user-attachments/assets/8edb0626-4301-497d-8652-c56545d3ef65" />


## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for review, approve the current commit and start the suite with these PR comments:

```text
/ok to test 2ec660d9
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated `pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`e9b2e3b37d5d`](https://github.com/NVIDIA/nv-config-manager/actions/runs/29785782614).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Multi-device deployment results now include backup rollups: total, successful, and failed backup counts.
  - Batch results now include per-device backup outcomes (success/changed/error) plus the related backup workflow identifier.
  - Batch status and result links now reflect backup completion and failure summaries.

- **Documentation**
  - Updated batch-deploy and multi-deploy guides, plus the Temporal workflow results example, to show the new `backups` structure and verification expectations.

- **Tests / Tooling**
  - Extended workflow tests for mixed backup outcomes and updated assertions for empty/no-diff cases.
  - Updated Kind integration PR-body link formatting and associated tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->