### PR TITLE
Add deliberate approval gate for CI trust-boundary changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,11 @@
 # Default reviewers for all repository changes.
 * @dmathur0 @jojung1 @polarweasel @ryanheffernan @spidercensus @susanhooks @zsblevins
+
+# These files define the boundary between untrusted pull requests and privileged CI.
+/.gitlab-ci.yml @dmathur0 @jojung1 @polarweasel @ryanheffernan @spidercensus @susanhooks @zsblevins
+/.gitlab/ci/ @dmathur0 @jojung1 @polarweasel @ryanheffernan @spidercensus @susanhooks @zsblevins
+/.github/CODEOWNERS @dmathur0 @jojung1 @polarweasel @ryanheffernan @spidercensus @susanhooks @zsblevins
+/.github/actions/ @dmathur0 @jojung1 @polarweasel @ryanheffernan @spidercensus @susanhooks @zsblevins
+/.github/copy-pr-bot.yaml @dmathur0 @jojung1 @polarweasel @ryanheffernan @spidercensus @susanhooks @zsblevins
+/.github/scripts/ @dmathur0 @jojung1 @polarweasel @ryanheffernan @spidercensus @susanhooks @zsblevins
+/.github/workflows/ @dmathur0 @jojung1 @polarweasel @ryanheffernan @spidercensus @susanhooks @zsblevins

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,10 @@
 - [ ] Kind integration passes, or this PR explains why it was not run.
 
 The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
-review, approve the current commit and start the suite with these PR comments:
+review, approve the current commit and start the suite with these PR comments. If this PR changes
+CI trust-boundary files, first review the `Trust Boundary Review` check and apply the
+`trust-boundary-reviewed` label only after reviewing the current head. The label is cleared when
+the PR head changes.
 
 ```text
 /ok to test <sha>

--- a/.github/scripts/trust-boundary-review.js
+++ b/.github/scripts/trust-boundary-review.js
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const APPROVAL_LABEL = "trust-boundary-reviewed";
+const APPROVER_PERMISSIONS = new Set(["admin", "write"]);
+
+const TRUST_BOUNDARY_PATHS = [
+  ".gitlab-ci.yml",
+  ".github/CODEOWNERS",
+  ".github/copy-pr-bot.yaml",
+];
+const TRUST_BOUNDARY_PREFIXES = [
+  ".gitlab/ci/",
+  ".github/actions/",
+  ".github/scripts/",
+  ".github/workflows/",
+];
+
+function isTrustBoundaryPath(path) {
+  return (
+    TRUST_BOUNDARY_PATHS.includes(path) ||
+    TRUST_BOUNDARY_PREFIXES.some((prefix) => path.startsWith(prefix))
+  );
+}
+
+async function ensureApprovalLabel({ github, owner, repo }) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name: APPROVAL_LABEL });
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+    try {
+      await github.rest.issues.createLabel({
+        owner,
+        repo,
+        name: APPROVAL_LABEL,
+        color: "b60205",
+        description: "Current PR head has received deliberate trust-boundary review",
+      });
+    } catch (createError) {
+      // Another PR run may have created this repository-wide label concurrently.
+      if (createError.status !== 422) {
+        throw createError;
+      }
+    }
+  }
+}
+
+async function removeApprovalLabel({ github, owner, repo, pullNumber }) {
+  try {
+    await github.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: pullNumber,
+      name: APPROVAL_LABEL,
+    });
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+  }
+}
+
+async function writeSummary(core, changedPaths, message) {
+  core.summary.addHeading("Trust Boundary Review");
+  core.summary.addRaw(message);
+  if (changedPaths.length > 0) {
+    core.summary.addHeading("Trust-boundary files", 3);
+    core.summary.addList(changedPaths);
+  }
+  await core.summary.write();
+}
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const pullNumber = context.payload.pull_request.number;
+  const action = context.payload.action;
+  const eventLabel = context.payload.label?.name;
+  const actor = context.payload.sender.login;
+
+  await ensureApprovalLabel({ github, owner, repo });
+
+  const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: 100,
+  });
+  const changedPaths = changedFiles
+    .filter(
+      ({ filename, previous_filename: previousFilename }) =>
+        isTrustBoundaryPath(filename) ||
+        (previousFilename && isTrustBoundaryPath(previousFilename)),
+    )
+    .map(({ filename }) => filename)
+    .sort();
+
+  let approved = context.payload.pull_request.labels.some(
+    ({ name }) => name === APPROVAL_LABEL,
+  );
+  let failure;
+
+  if (action === "synchronize" && approved) {
+    await removeApprovalLabel({ github, owner, repo, pullNumber });
+    approved = false;
+    failure =
+      "The trust-boundary approval was cleared because the PR head changed. " +
+      "Review the current changes and apply the label again.";
+  }
+
+  if (action === "labeled" && eventLabel === APPROVAL_LABEL) {
+    let permission = "none";
+    try {
+      const response = await github.rest.repos.getCollaboratorPermissionLevel({
+        owner,
+        repo,
+        username: actor,
+      });
+      permission = response.data.permission;
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+    }
+    if (!APPROVER_PERMISSIONS.has(permission)) {
+      await removeApprovalLabel({ github, owner, repo, pullNumber });
+      approved = false;
+      failure = `@${actor} needs write access to approve trust-boundary changes.`;
+    }
+  }
+
+  if (changedPaths.length === 0) {
+    await writeSummary(core, [], "No trust-boundary files changed.");
+    return;
+  }
+
+  if (!approved) {
+    failure ??=
+      `A maintainer must review the current PR head and apply the ${APPROVAL_LABEL} label ` +
+      "before approving CI execution.";
+    await writeSummary(core, changedPaths, failure);
+    core.setFailed(failure);
+    return;
+  }
+
+  await writeSummary(
+    core,
+    changedPaths,
+    `The ${APPROVAL_LABEL} label confirms deliberate review of the current PR head.`,
+  );
+};
+
+module.exports.APPROVAL_LABEL = APPROVAL_LABEL;
+module.exports.isTrustBoundaryPath = isTrustBoundaryPath;

--- a/.github/scripts/trust-boundary-review.test.js
+++ b/.github/scripts/trust-boundary-review.test.js
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const reviewTrustBoundary = require("./trust-boundary-review.js");
+const { APPROVAL_LABEL, isTrustBoundaryPath } = reviewTrustBoundary;
+
+function createSummary() {
+  const state = { headings: [], lists: [], raw: [], writes: 0 };
+  return {
+    ...state,
+    addHeading(value) {
+      state.headings.push(value);
+      return this;
+    },
+    addList(value) {
+      state.lists.push(value);
+      return this;
+    },
+    addRaw(value) {
+      state.raw.push(value);
+      return this;
+    },
+    async write() {
+      state.writes += 1;
+    },
+    state,
+  };
+}
+
+function createFixture(options = {}) {
+  const createdLabels = [];
+  const failures = [];
+  const removedLabels = [];
+  const summary = createSummary();
+  const context = {
+    repo: { owner: "NVIDIA", repo: "nv-config-manager" },
+    payload: {
+      action: options.action ?? "opened",
+      label: options.eventLabel ? { name: options.eventLabel } : undefined,
+      pull_request: {
+        number: 134,
+        labels: (options.labels ?? []).map((name) => ({ name })),
+      },
+      sender: { login: options.actor ?? "reviewer" },
+    },
+  };
+  const github = {
+    paginate: async () =>
+      (options.files ?? ["README.md"]).map((file) =>
+        typeof file === "string" ? { filename: file } : file,
+      ),
+    rest: {
+      issues: {
+        getLabel: async () => {
+          if (options.missingApprovalLabel) {
+            const error = new Error("Not Found");
+            error.status = 404;
+            throw error;
+          }
+        },
+        createLabel: async (args) => createdLabels.push(args),
+        removeLabel: async (args) => removedLabels.push(args),
+      },
+      pulls: {
+        listFiles: async () => {},
+      },
+      repos: {
+        getCollaboratorPermissionLevel: async () => {
+          if (options.missingCollaborator) {
+            const error = new Error("Not Found");
+            error.status = 404;
+            throw error;
+          }
+          return { data: { permission: options.permission ?? "write" } };
+        },
+      },
+    },
+  };
+  const core = {
+    setFailed: (message) => failures.push(message),
+    summary,
+  };
+
+  return { context, core, createdLabels, failures, github, removedLabels, summary };
+}
+
+async function runFixture(options) {
+  const fixture = createFixture(options);
+  await reviewTrustBoundary(fixture);
+  return fixture;
+}
+
+test("recognizes files that define the CI trust boundary", () => {
+  for (const path of [
+    ".gitlab-ci.yml",
+    ".gitlab/ci/test.yml",
+    ".github/CODEOWNERS",
+    ".github/copy-pr-bot.yaml",
+    ".github/actions/example/action.yml",
+    ".github/scripts/example.js",
+    ".github/workflows/public-ci.yml",
+  ]) {
+    assert.equal(isTrustBoundaryPath(path), true, path);
+  }
+  assert.equal(isTrustBoundaryPath("README.md"), false);
+  assert.equal(isTrustBoundaryPath("github/workflows/example.yml"), false);
+});
+
+test("passes when no trust-boundary files changed", async () => {
+  const result = await runFixture({ files: ["README.md"] });
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.summary.state.writes, 1);
+  assert.match(result.summary.state.raw[0], /No trust-boundary files changed/);
+});
+
+test("requires deliberate approval for trust-boundary changes", async () => {
+  const result = await runFixture({ files: [".github/workflows/public-ci.yml"] });
+
+  assert.match(result.failures[0], /must review the current PR head/);
+  assert.deepEqual(result.summary.state.lists[0], [".github/workflows/public-ci.yml"]);
+});
+
+test("accepts a maintainer approval label", async () => {
+  const result = await runFixture({
+    action: "labeled",
+    eventLabel: APPROVAL_LABEL,
+    files: [".gitlab-ci.yml"],
+    labels: [APPROVAL_LABEL],
+    permission: "write",
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.removedLabels, []);
+  assert.match(result.summary.state.raw[0], /confirms deliberate review/);
+});
+
+test("clears approval whenever the PR head changes", async () => {
+  const result = await runFixture({
+    action: "synchronize",
+    files: [".gitlab/ci/test.yml"],
+    labels: [APPROVAL_LABEL],
+  });
+
+  assert.equal(result.removedLabels.length, 1);
+  assert.match(result.failures[0], /approval was cleared/);
+});
+
+test("removes approval applied by an actor without write access", async () => {
+  const result = await runFixture({
+    action: "labeled",
+    eventLabel: APPROVAL_LABEL,
+    files: [".github/copy-pr-bot.yaml"],
+    labels: [APPROVAL_LABEL],
+    permission: "triage",
+  });
+
+  assert.equal(result.removedLabels.length, 1);
+  assert.match(result.failures[0], /needs write access/);
+});
+
+test("removes approval when the actor is not a repository collaborator", async () => {
+  const result = await runFixture({
+    action: "labeled",
+    eventLabel: APPROVAL_LABEL,
+    files: [".github/CODEOWNERS"],
+    labels: [APPROVAL_LABEL],
+    missingCollaborator: true,
+  });
+
+  assert.equal(result.removedLabels.length, 1);
+  assert.match(result.failures[0], /needs write access/);
+});
+
+test("detects a trust-boundary file renamed out of a protected path", async () => {
+  const result = await runFixture({
+    files: [{ filename: "archive/public-ci.yml", previous_filename: ".github/workflows/public-ci.yml" }],
+  });
+
+  assert.match(result.failures[0], /must review the current PR head/);
+  assert.deepEqual(result.summary.state.lists[0], ["archive/public-ci.yml"]);
+});
+
+test("creates the repository approval label when it is missing", async () => {
+  const result = await runFixture({ missingApprovalLabel: true });
+
+  assert.equal(result.createdLabels.length, 1);
+  assert.equal(result.createdLabels[0].name, APPROVAL_LABEL);
+});

--- a/.github/workflows/trust-boundary-review.yml
+++ b/.github/workflows/trust-boundary-review.yml
@@ -1,0 +1,30 @@
+name: Trust Boundary Review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+
+jobs:
+  review:
+    name: Trust Boundary Review
+    runs-on: linux-amd64-cpu4
+    concurrency:
+      group: trust-boundary-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      # pull_request_target runs from the default branch. Keep the checkout
+      # explicit so this privileged check never loads PR-controlled code.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - name: Check trust-boundary approval
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const review = require("./.github/scripts/trust-boundary-review.js");
+            await review({ github, context, core });


### PR DESCRIPTION
## Description

Add a default-branch-owned Trust Boundary Review check for changes to the CI trust boundary used by #134.

- Detect changes to .gitlab-ci.yml, .gitlab/ci/**, GitHub workflows/scripts, CODEOWNERS, and copy-pr-bot policy.
- Require a write-access maintainer to deliberately apply trust-boundary-reviewed.
- Clear that label whenever the pull-request head changes, so approval is tied to the reviewed revision.
- Add explicit CODEOWNERS entries and reviewer guidance to the PR template.

## Security model

The copy-pr-bot maintainer approval remains the explicit authorization boundary. This check adds a separate, visible acknowledgement before approval when that boundary itself changes.

The workflow uses pull_request_target only to read pull-request metadata and manage the approval label. It checks out the repository default branch explicitly and never checks out or executes pull-request-controlled code.

## Validation

- node --test .github/scripts/*.test.js (33 tests passed)
- yq eval . .github/workflows/trust-boundary-review.yml
- git diff --check
- Commit hook: SPDX headers and DCO sign-off passed

## Rollout note

After this merges and the check has run once, add Trust Boundary Review as a required status check in the main branch ruleset. The new pull_request_target workflow cannot run on this PR itself because GitHub loads that workflow from the default branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated review checks for changes to sensitive CI and workflow files.
  * Added approval labeling to track completed trust-boundary reviews.
  * Approval labels are cleared when pull request changes require renewed review.
  * Added clear workflow summaries and failure messages for missing or invalid approvals.

* **Documentation**
  * Updated pull request guidance with instructions for reviewing and labeling sensitive changes.

* **Tests**
  * Added coverage for approval, label, permission, file-change, and rename scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->