### PR TITLE
fix(ci): put commit sha in kind result comment

### DIFF
--- a/.github/scripts/kind-integration-result.js
+++ b/.github/scripts/kind-integration-result.js
@@ -66,8 +66,9 @@ module.exports = async ({ github, context, core, run: explicitRun }) => {
     }
 
     const conclusion = run.conclusion ?? "unknown";
-    const shortSha = run.head_sha.slice(0, 12);
-    const resultLine = `Kind integration completed with **${conclusion}** for [\`${shortSha}\`](${run.html_url}).`;
+    const shortSha = run.head_sha.slice(0, 7);
+    const commitUrl = `${context.serverUrl}/${owner}/${repo}/commit/${run.head_sha}`;
+    const resultLine = `Kind integration completed with **${conclusion}** for [\`${shortSha}\`](${commitUrl}) in [this workflow run](${run.html_url}).`;
 
     await github.rest.pulls.update({
       owner,

--- a/.github/scripts/kind-integration-result.test.js
+++ b/.github/scripts/kind-integration-result.test.js
@@ -8,6 +8,7 @@ const reportKindIntegrationResult = require("./kind-integration-result.js");
 
 const SHA = "a".repeat(40);
 const RUN_URL = "https://github.com/NVIDIA/nv-config-manager/actions/runs/123";
+const COMMIT_URL = `https://github.com/NVIDIA/nv-config-manager/commit/${SHA}`;
 const TEMPLATE_BODY = `## Description
 
 Example PR.
@@ -29,6 +30,7 @@ function createFixture(options = {}) {
   const warnings = [];
   const context = {
     repo: { owner: "NVIDIA", repo: "nv-config-manager" },
+    serverUrl: "https://github.com",
     payload: {},
   };
   if (!options.omitWorkflowRun) {
@@ -98,7 +100,7 @@ Example PR.
 
 Passing Kind Integration run, if not automatically reported:
 <!-- kind-integration-result:start -->
-Kind integration completed with **success** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+Kind integration completed with **success** for [\`aaaaaaa\`](${COMMIT_URL}) in [this workflow run](${RUN_URL}).
 <!-- kind-integration-result:end -->
 
 ## Checklist
@@ -129,7 +131,7 @@ Kind integration completed with **success** for [\`bbbbbbbbbbbb\`](https://old.e
 
 Passing Kind Integration run, if not automatically reported:
 <!-- kind-integration-result:start -->
-Kind integration completed with **failure** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+Kind integration completed with **failure** for [\`aaaaaaa\`](${COMMIT_URL}) in [this workflow run](${RUN_URL}).
 <!-- kind-integration-result:end -->
 `,
     },
@@ -202,7 +204,7 @@ No validation section.
 ## Kind Integration
 
 <!-- kind-integration-result:start -->
-Kind integration completed with **success** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+Kind integration completed with **success** for [\`aaaaaaa\`](${COMMIT_URL}) in [this workflow run](${RUN_URL}).
 <!-- kind-integration-result:end -->
 `,
   );
@@ -224,7 +226,7 @@ No validation section.
 ## Kind Integration
 
 <!-- kind-integration-result:start -->
-Kind integration completed with **failure** for [\`aaaaaaaaaaaa\`](${RUN_URL}).
+Kind integration completed with **failure** for [\`aaaaaaa\`](${COMMIT_URL}) in [this workflow run](${RUN_URL}).
 <!-- kind-integration-result:end -->
 `,
   );

--- a/.github/scripts/kind-integration-result.test.js
+++ b/.github/scripts/kind-integration-result.test.js
@@ -170,7 +170,11 @@ test("updates from explicit run details when workflow_run did not fire", async (
 test("uses the GitHub Enterprise server URL for commit links", async () => {
   const result = await runFixture({ serverUrl: "https://github.example.com" });
 
-  assert.ok(result.updates[0].body.includes(expectedCommitUrl(result.context)));
+  assert.ok(
+    result.updates[0].body.includes(
+      `[\`aaaaaaa\`](${expectedCommitUrl(result.context)})`,
+    ),
+  );
 });
 
 test("does nothing without workflow_run or explicit run details", async () => {

--- a/.github/scripts/kind-integration-result.test.js
+++ b/.github/scripts/kind-integration-result.test.js
@@ -7,8 +7,8 @@ const { test } = require("node:test");
 const reportKindIntegrationResult = require("./kind-integration-result.js");
 
 const SHA = "a".repeat(40);
+const DEFAULT_SERVER_URL = "https://github.com";
 const RUN_URL = "https://github.com/NVIDIA/nv-config-manager/actions/runs/123";
-const COMMIT_URL = `https://github.com/NVIDIA/nv-config-manager/commit/${SHA}`;
 const TEMPLATE_BODY = `## Description
 
 Example PR.
@@ -30,7 +30,7 @@ function createFixture(options = {}) {
   const warnings = [];
   const context = {
     repo: { owner: "NVIDIA", repo: "nv-config-manager" },
-    serverUrl: "https://github.com",
+    serverUrl: options.serverUrl ?? DEFAULT_SERVER_URL,
     payload: {},
   };
   if (!options.omitWorkflowRun) {
@@ -75,6 +75,10 @@ function createFixture(options = {}) {
   return { context, github, core, updates, warnings };
 }
 
+function expectedCommitUrl(context) {
+  return `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${SHA}`;
+}
+
 async function runFixture(options) {
   const fixture = createFixture(options);
   await reportKindIntegrationResult({
@@ -100,7 +104,7 @@ Example PR.
 
 Passing Kind Integration run, if not automatically reported:
 <!-- kind-integration-result:start -->
-Kind integration completed with **success** for [\`aaaaaaa\`](${COMMIT_URL}) in [this workflow run](${RUN_URL}).
+Kind integration completed with **success** for [\`aaaaaaa\`](${expectedCommitUrl(result.context)}) in [this workflow run](${RUN_URL}).
 <!-- kind-integration-result:end -->
 
 ## Checklist
@@ -131,7 +135,7 @@ Kind integration completed with **success** for [\`bbbbbbbbbbbb\`](https://old.e
 
 Passing Kind Integration run, if not automatically reported:
 <!-- kind-integration-result:start -->
-Kind integration completed with **failure** for [\`aaaaaaa\`](${COMMIT_URL}) in [this workflow run](${RUN_URL}).
+Kind integration completed with **failure** for [\`aaaaaaa\`](${expectedCommitUrl(result.context)}) in [this workflow run](${RUN_URL}).
 <!-- kind-integration-result:end -->
 `,
     },
@@ -161,6 +165,12 @@ test("updates from explicit run details when workflow_run did not fire", async (
   assert.equal(result.updates.length, 1);
   assert.match(result.updates[0].body, /\*\*success\*\*/);
   assert.ok(result.updates[0].body.includes(RUN_URL));
+});
+
+test("uses the GitHub Enterprise server URL for commit links", async () => {
+  const result = await runFixture({ serverUrl: "https://github.example.com" });
+
+  assert.ok(result.updates[0].body.includes(expectedCommitUrl(result.context)));
 });
 
 test("does nothing without workflow_run or explicit run details", async () => {
@@ -204,7 +214,7 @@ No validation section.
 ## Kind Integration
 
 <!-- kind-integration-result:start -->
-Kind integration completed with **success** for [\`aaaaaaa\`](${COMMIT_URL}) in [this workflow run](${RUN_URL}).
+Kind integration completed with **success** for [\`aaaaaaa\`](${expectedCommitUrl(result.context)}) in [this workflow run](${RUN_URL}).
 <!-- kind-integration-result:end -->
 `,
   );
@@ -226,7 +236,7 @@ No validation section.
 ## Kind Integration
 
 <!-- kind-integration-result:start -->
-Kind integration completed with **failure** for [\`aaaaaaa\`](${COMMIT_URL}) in [this workflow run](${RUN_URL}).
+Kind integration completed with **failure** for [\`aaaaaaa\`](${expectedCommitUrl(secondResult.context)}) in [this workflow run](${RUN_URL}).
 <!-- kind-integration-result:end -->
 `,
   );


### PR DESCRIPTION
## Description

Fix the automatically reported Kind integration result so the abbreviated commit SHA links to the tested commit, while the workflow-run text links separately to the Actions run.

The reporter previously displayed a 12-character SHA that linked to the Actions run instead of the commit, making the commit reference misleading. It now displays the conventional 7-character SHA, links it to the full commit URL, and preserves a separate link to the exact workflow run.


## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind won't be affected until this merges, no need to run

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

Documentation, screenshots, and generated artifacts are not affected by this Markdown-link correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Integration results now display a shorter commit identifier.
  * Commit identifiers link directly to the relevant commit, while workflow runs remain linked separately.
  * Commit links now work correctly with custom GitHub server URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->