### PR TITLE
bulk add devices

### DIFF
--- a/components/nautobot/nautobot-nv-config-manager/.gitignore
+++ b/components/nautobot/nautobot-nv-config-manager/.gitignore
@@ -14,6 +14,7 @@ dist/
 .ruff_cache/
 coverage.xml
 htmlcov/
+rspec.xml
 
 # Environments
 .env

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/forms.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/forms.py
@@ -16,6 +16,7 @@
 
 from django import forms
 from nautobot.apps.forms import (
+    BootstrapMixin,
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
     StaticSelect2,
@@ -27,9 +28,11 @@ from nautobot.extras.forms import (
     NautobotFilterForm,
     NautobotModelForm,
 )
+from nautobot.extras.models import Role
 from nautobot.tenancy.models import Tenant
 
 from nv_config_manager.models import ConfigManagerDeviceStatus
+from nv_config_manager.utils import get_eligible_unmanaged_devices
 
 
 class ConfigManagerDeviceStatusFilterForm(NautobotFilterForm):  # pylint: disable=too-many-ancestors
@@ -54,26 +57,28 @@ class ConfigManagerDeviceStatusFilterForm(NautobotFilterForm):  # pylint: disabl
     )
 
 
-class ConfigManagerDeviceStatusAddForm(NautobotModelForm):  # pylint: disable=too-many-ancestors
-    """Add form for ConfigManagerDeviceStatus."""
+class ConfigManagerDeviceStatusBulkAddForm(BootstrapMixin, forms.Form):
+    """Bulk-add form for enrolling unmanaged devices into Config Manager."""
 
-    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), label="Tenant")
     location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
-        query_params={
-            "tenant": "$tenant",
-        },
         label="Location",
-        required=False,
+        required=True,
     )
-    device = DynamicModelChoiceField(
+    roles = DynamicModelMultipleChoiceField(
+        queryset=Role.objects.all(),
+        label="Role",
+        required=True,
+    )
+    devices = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
+        label="Devices",
+        required=True,
         query_params={
             "location": "$location",
-            "tenant": "$tenant",
+            "role": "$roles",
             "nv_config_manager_device_status": False,
         },
-        label="Device",
     )
     render_enabled = forms.NullBooleanField(
         label="Enable Render",
@@ -81,7 +86,9 @@ class ConfigManagerDeviceStatusAddForm(NautobotModelForm):  # pylint: disable=to
         widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
     ztp_enabled = forms.NullBooleanField(
-        label="Enable ZTP", required=False, widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES)
+        label="Enable ZTP",
+        required=False,
+        widget=StaticSelect2(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
     deploy_enabled = forms.NullBooleanField(
         label="Enable Deploy",
@@ -102,17 +109,46 @@ class ConfigManagerDeviceStatusAddForm(NautobotModelForm):  # pylint: disable=to
     class Meta:
         """Metaclass attributes."""
 
-        model = ConfigManagerDeviceStatus
         fields = [
             "location",
-            "tenant",
-            "device",
+            "roles",
+            "devices",
             "render_enabled",
             "ztp_enabled",
             "deploy_enabled",
             "backup_enabled",
             "is_aggregate_managed",
         ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.label_suffix = ""
+
+    def clean(self):
+        """Reject any selected device outside the eligible (unmanaged) set."""
+        cleaned_data = super().clean()
+        if self.errors:
+            return cleaned_data
+
+        eligible_ids = set(
+            get_eligible_unmanaged_devices(
+                cleaned_data["location"],
+                cleaned_data["roles"],
+            ).values_list("pk", flat=True)
+        )
+        selected = cleaned_data.get("devices") or []
+        if any(device.pk not in eligible_ids for device in selected):
+            raise forms.ValidationError("One or more selected devices are not eligible for enrollment.")
+
+        return cleaned_data
+
+    def get_devices_to_add(self):
+        """Return the selected devices."""
+        return self.cleaned_data.get("devices") or Device.objects.none()
+
+
+# Backward-compatible alias for imports expecting the old add form name.
+ConfigManagerDeviceStatusAddForm = ConfigManagerDeviceStatusBulkAddForm
 
 
 class ConfigManagerDeviceStatusEditForm(NautobotModelForm):  # pylint: disable=too-many-ancestors

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/forms.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/forms.py
@@ -66,9 +66,10 @@ class ConfigManagerDeviceStatusBulkAddForm(BootstrapMixin, forms.Form):
         required=True,
     )
     roles = DynamicModelMultipleChoiceField(
-        queryset=Role.objects.all(),
+        queryset=Role.objects.filter(content_types__app_label="dcim", content_types__model="device"),
         label="Role",
         required=True,
+        query_params={"content_types": "dcim.device"},
     )
     devices = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/templates/nv_config_manager/configmanagerdevicestatus_add.html
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/templates/nv_config_manager/configmanagerdevicestatus_add.html
@@ -1,36 +1,23 @@
-{% extends 'generic/object_edit.html' %} 
-{% load helpers %} 
+{% extends 'generic/object_create.html' %}
+{% load helpers %}
 {% load form_helpers %}
 
-{% block title%}
-  Add a Managed Device
+{% block title %}
+  Add Managed Devices
 {% endblock title %}
 
 {% block form %}
 <div class="panel panel-default">
   <div class="panel-heading">
-    <strong>Device Selection</strong>
+    <strong>Device Filters</strong>
   </div>
   <div class="panel-body">
-    <div class="alert alert-info" style="padding: 8px 12px; margin-bottom: 15px; font-size: 13px;">
-      Select a Tenant, then optionally a Location, to filter available Devices.
-    </div>
     <div class="container-fluid">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <div class="form-group">
-            {{ form.tenant.label_tag }}
-            {{ form.tenant }}
-          </div>
-          <div class="form-group">
-            {{ form.location.label_tag }}
-            {{ form.location }}
-            <span class="help-block">Optional. Narrows the device list by location.</span>
-          </div>
-          <div class="form-group">
-            {{ form.device.label_tag }}
-            {{ form.device }}
-          </div>
+          {% render_field form.location %}
+          {% render_field form.roles %}
+          {% render_field form.devices %}
         </div>
       </div>
     </div>
@@ -45,59 +32,19 @@
     <div class="container-fluid">
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <div class="form-group">
-            {{ form.render_enabled.label_tag }}
-            {{ form.render_enabled }}
-          </div>
-          <div class="form-group">
-            {{ form.ztp_enabled.label_tag }}
-            {{ form.ztp_enabled }}
-          </div>
-          <div class="form-group">
-            {{ form.deploy_enabled.label_tag }}
-            {{ form.deploy_enabled }}
-          </div>
-          <div class="form-group">
-            {{ form.backup_enabled.label_tag }}
-            {{ form.backup_enabled }}
-          </div>
-          <div class="form-group">
-            {{ form.is_aggregate_managed.label_tag }}
-            {{ form.is_aggregate_managed }}
-          </div>
+          {% render_field form.render_enabled %}
+          {% render_field form.ztp_enabled %}
+          {% render_field form.deploy_enabled %}
+          {% render_field form.backup_enabled %}
+          {% render_field form.is_aggregate_managed %}
         </div>
       </div>
     </div>
   </div>
 </div>
+{% endblock %}
 
-<script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", function () {
-    const locationField = document.querySelector("#id_location");
-    const tenantField = document.querySelector("#id_tenant");
-    const deviceField = document.querySelector("#id_device");
-
-    function toggleDeviceField() {
-      if (!locationField.value && !tenantField.value) {
-        deviceField.disabled = true;
-      } else {
-        deviceField.disabled = false;
-      }
-    }
-
-    toggleDeviceField();
-
-    const observer = new MutationObserver(function(mutations) {
-      mutations.forEach(function(mutation) {
-        if (mutation.type === 'childList') {
-          toggleDeviceField();
-        }
-      });
-    });
-
-    const config = { childList: true, subtree: true };
-    observer.observe(locationField, config);
-    observer.observe(tenantField, config);
-  });
-</script>
+{% block buttons %}
+<button type="submit" class="btn btn-primary">Add Devices</button>
+<a href="{{ return_url }}" class="btn btn-default">Cancel</a>
 {% endblock %}

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_forms.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_forms.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 """Tests for nv_config_manager forms."""
 
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer
 from nautobot.extras.models import Role, Status
@@ -167,6 +168,7 @@ class ConfigManagerDeviceStatusBulkAddFormTestCase(TestCase):
             status=location_status,
         )
         cls.role = Role.objects.create(name="Bulk Form Role", color="333333")
+        cls.role.content_types.add(ContentType.objects.get_for_model(Device))
         cls.device_type = DeviceType.objects.create(
             manufacturer=manufacturer,
             model=data.SECOND_DEVICE_TYPE_MODEL,
@@ -216,3 +218,16 @@ class ConfigManagerDeviceStatusBulkAddFormTestCase(TestCase):
         self.assertTrue(form.is_valid())
         names = set(form.get_devices_to_add().values_list("name", flat=True))
         self.assertEqual(names, {self.device.name})
+
+    def test_roles_dropdown_filtered_to_device_roles(self):
+        """The role dropdown is scoped to device roles so its options match validation."""
+        form = ConfigManagerDeviceStatusBulkAddForm()
+        self.assertEqual(form.fields["roles"].query_params.get("content_types"), "dcim.device")
+
+    def test_rejects_non_device_role(self):
+        """A role lacking the dcim.device content type is rejected, not silently accepted."""
+        non_device_role = Role.objects.create(name="Bulk Form IPAM Role", color="444444")
+        non_device_role.content_types.set([ContentType.objects.get(app_label="ipam", model="prefix")])
+        form = ConfigManagerDeviceStatusBulkAddForm(self._base_data(roles=[str(non_device_role.pk)]))
+        self.assertFalse(form.is_valid())
+        self.assertIn("roles", form.errors)

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_forms.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_forms.py
@@ -1,0 +1,218 @@
+#  SPDX-FileCopyrightText: Copyright (c) "2025" NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License")
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Tests for nv_config_manager forms."""
+
+from django.test import TestCase
+from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer
+from nautobot.extras.models import Role, Status
+from nautobot.tenancy.models import Tenant
+
+from nv_config_manager.forms import ConfigManagerDeviceStatusBulkAddForm
+from nv_config_manager.models import ConfigManagerDeviceStatus
+from nv_config_manager.tests.fixtures import mock_data as data
+from nv_config_manager.utils import (
+    bulk_create_managed_devices,
+    get_eligible_unmanaged_devices,
+    nullbool_to_bool,
+)
+
+
+class EligibleDeviceQueryTestCase(TestCase):
+    """Tests for unmanaged-device candidate selection."""
+
+    @classmethod
+    def setUpTestData(cls):
+        manufacturer = Manufacturer.objects.create(name=data.MANUFACTURER_NAME)
+        site_type = LocationType.objects.create(name="Bulk Add Site Type")
+        module_type = LocationType.objects.create(name="Bulk Add Module Type", parent=site_type)
+        location_status = Status.objects.get_for_model(Location).first()
+        device_status = Status.objects.get_for_model(Device).first()
+
+        cls.parent_location = Location.objects.create(
+            name="Bulk Parent",
+            location_type=site_type,
+            status=location_status,
+        )
+        cls.child_location = Location.objects.create(
+            name="Bulk Child",
+            location_type=module_type,
+            parent=cls.parent_location,
+            status=location_status,
+        )
+        cls.tenant_a = Tenant.objects.create(name="Bulk Tenant A")
+        cls.tenant_b = Tenant.objects.create(name="Bulk Tenant B")
+        cls.device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model=data.DEVICE_TYPE_MODEL,
+        )
+        cls.network_role = Role.objects.create(name="Bulk Network Role", color="111111")
+        cls.compute_role = Role.objects.create(name="Bulk Compute Role", color="222222")
+
+        cls.parent_network = Device.objects.create(
+            name="bulk-parent-network",
+            location=cls.parent_location,
+            device_type=cls.device_type,
+            role=cls.network_role,
+            tenant=cls.tenant_a,
+            status=device_status,
+        )
+        cls.child_network = Device.objects.create(
+            name="bulk-child-network",
+            location=cls.child_location,
+            device_type=cls.device_type,
+            role=cls.network_role,
+            tenant=cls.tenant_a,
+            status=device_status,
+        )
+        cls.child_compute = Device.objects.create(
+            name="bulk-child-compute",
+            location=cls.child_location,
+            device_type=cls.device_type,
+            role=cls.compute_role,
+            tenant=cls.tenant_a,
+            status=device_status,
+        )
+        cls.other_tenant_device = Device.objects.create(
+            name="bulk-other-tenant",
+            location=cls.child_location,
+            device_type=cls.device_type,
+            role=cls.network_role,
+            tenant=cls.tenant_b,
+            status=device_status,
+        )
+        cls.managed_device = Device.objects.create(
+            name="bulk-managed",
+            location=cls.child_location,
+            device_type=cls.device_type,
+            role=cls.network_role,
+            tenant=cls.tenant_a,
+            status=device_status,
+        )
+        ConfigManagerDeviceStatus.objects.create(device=cls.managed_device)
+
+    def test_includes_descendant_locations(self):
+        """Eligible query includes devices from child locations."""
+        eligible = get_eligible_unmanaged_devices(self.parent_location, [self.network_role])
+        names = set(eligible.values_list("name", flat=True))
+        self.assertIn(self.parent_network.name, names)
+        self.assertIn(self.child_network.name, names)
+
+    def test_filters_by_multiple_roles(self):
+        """Eligible query matches any selected role."""
+        eligible = get_eligible_unmanaged_devices(
+            self.parent_location,
+            [self.network_role, self.compute_role],
+        )
+        names = set(eligible.values_list("name", flat=True))
+        self.assertIn(self.child_network.name, names)
+        self.assertIn(self.child_compute.name, names)
+
+    def test_excludes_managed_devices(self):
+        """Already-managed devices are not returned."""
+        eligible = get_eligible_unmanaged_devices(self.child_location, [self.network_role])
+        self.assertNotIn(self.managed_device.name, set(eligible.values_list("name", flat=True)))
+
+    def test_nullbool_to_bool_defaults_false(self):
+        """Tri-state booleans default to False."""
+        self.assertFalse(nullbool_to_bool(None))
+        self.assertFalse(nullbool_to_bool(False))
+        self.assertTrue(nullbool_to_bool(True))
+
+    def test_bulk_create_managed_devices_applies_defaults(self):
+        """Bulk create enrolls devices with shared service settings."""
+        created_count, skipped_count = bulk_create_managed_devices(
+            [self.parent_network, self.child_network],
+            render_enabled=True,
+            is_aggregate_managed=True,
+        )
+        self.assertEqual(created_count, 2)
+        self.assertEqual(skipped_count, 0)
+        managed = ConfigManagerDeviceStatus.objects.get(device=self.parent_network)
+        self.assertTrue(managed.render_enabled)
+        self.assertTrue(managed.is_aggregate_managed)
+
+    def test_bulk_create_skips_existing_managed_devices(self):
+        """Bulk create skips devices that became managed concurrently."""
+        created_count, skipped_count = bulk_create_managed_devices(
+            [self.managed_device],
+        )
+        self.assertEqual(created_count, 0)
+        self.assertEqual(skipped_count, 1)
+
+
+class ConfigManagerDeviceStatusBulkAddFormTestCase(TestCase):
+    """Tests for the bulk-add form validation."""
+
+    @classmethod
+    def setUpTestData(cls):
+        manufacturer = Manufacturer.objects.create(name=data.SECOND_MANUFACTURER_NAME)
+        site_type = LocationType.objects.create(name="Bulk Form Site Type")
+        location_status = Status.objects.get_for_model(Location).first()
+        device_status = Status.objects.get_for_model(Device).first()
+        cls.location = Location.objects.create(
+            name="Bulk Form Site",
+            location_type=site_type,
+            status=location_status,
+        )
+        cls.role = Role.objects.create(name="Bulk Form Role", color="333333")
+        cls.device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model=data.SECOND_DEVICE_TYPE_MODEL,
+        )
+        cls.device = Device.objects.create(
+            name="bulk-form-device",
+            location=cls.location,
+            device_type=cls.device_type,
+            role=cls.role,
+            status=device_status,
+        )
+
+    def _base_data(self, **overrides):
+        data = {
+            "location": str(self.location.pk),
+            "roles": [str(self.role.pk)],
+            "devices": [str(self.device.pk)],
+        }
+        data.update(overrides)
+        return data
+
+    def test_requires_location_roles_and_devices(self):
+        """Location, role, and devices are all required."""
+        form = ConfigManagerDeviceStatusBulkAddForm({})
+        self.assertFalse(form.is_valid())
+        self.assertIn("location", form.errors)
+        self.assertIn("roles", form.errors)
+        self.assertIn("devices", form.errors)
+
+    def test_rejects_ineligible_device_selection(self):
+        """A selected device outside the location/role scope is rejected."""
+        managed = Device.objects.create(
+            name="bulk-form-managed",
+            location=self.location,
+            device_type=self.device_type,
+            role=self.role,
+            status=Status.objects.get_for_model(Device).first(),
+        )
+        ConfigManagerDeviceStatus.objects.create(device=managed)
+        form = ConfigManagerDeviceStatusBulkAddForm(self._base_data(devices=[str(managed.pk)]))
+        self.assertFalse(form.is_valid())
+        self.assertIn("One or more selected devices are not eligible for enrollment.", form.errors["__all__"])
+
+    def test_valid_selection_returns_devices_to_add(self):
+        """A valid submission returns the selected devices."""
+        form = ConfigManagerDeviceStatusBulkAddForm(self._base_data())
+        self.assertTrue(form.is_valid())
+        names = set(form.get_devices_to_add().values_list("name", flat=True))
+        self.assertEqual(names, {self.device.name})

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_views.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_views.py
@@ -17,6 +17,7 @@
 
 import re
 from datetime import timedelta
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 from bs4 import BeautifulSoup
@@ -51,8 +52,6 @@ from nv_config_manager.models import (
 )
 from nv_config_manager.tests.fixtures import mock_data as data
 from nv_config_manager.tests.fixtures.create_obj_fixtures import create_nested_locations
-
-from unittest.mock import patch
 
 with_temporal_url = override_settings(
     PLUGINS_CONFIG={"nv_config_manager": {"temporal_url": "https://temporal.example.com"}}

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_views.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_views.py
@@ -52,6 +52,8 @@ from nv_config_manager.models import (
 from nv_config_manager.tests.fixtures import mock_data as data
 from nv_config_manager.tests.fixtures.create_obj_fixtures import create_nested_locations
 
+from unittest.mock import patch
+
 with_temporal_url = override_settings(
     PLUGINS_CONFIG={"nv_config_manager": {"temporal_url": "https://temporal.example.com"}}
 )
@@ -1245,7 +1247,6 @@ class ConfigManagerDeviceStatusBulkAddViewTestCase(ConfigManagerViewTestMixin, T
 
     def test_rolls_back_on_creation_failure(self):
         """A creation failure rolls back the entire bulk-add transaction."""
-        from unittest.mock import patch
 
         self._grant_add_permission()
         second_network = Device.objects.create(

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_views.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/tests/test_views.py
@@ -26,6 +26,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from nautobot.apps.testing import (
+    TestCase,
     ViewTestCases,
     extract_page_body,
 )
@@ -38,7 +39,8 @@ from nautobot.dcim.models import (
     Platform,
     Rack,
 )
-from nautobot.extras.models import Role, Status
+from nautobot.extras.choices import ObjectChangeActionChoices
+from nautobot.extras.models import ObjectChange, Role, Status
 from nautobot.tenancy.models import Tenant
 from nautobot.users.models import ObjectPermission
 
@@ -1105,3 +1107,163 @@ class ManagedDeviceTabViewTestCases:  # pylint: disable=too-few-public-methods
             pattern = r"&mdash;\s*(.*?)\s*&mdash;"
             message = re.search(pattern, tbody_content).group(1)
             self.assertIn(message, "No Managed Devices found")
+
+
+class ConfigManagerDeviceStatusBulkAddViewTestCase(ConfigManagerViewTestMixin, TestCase):
+    """Tests for the bulk-add managed devices view."""
+
+    @classmethod
+    def setUpTestData(cls):
+        manufacturer = Manufacturer.objects.create(name="Bulk View Manufacturer")
+        site_type = LocationType.objects.create(name="Bulk View Site Type")
+        module_type = LocationType.objects.create(name="Bulk View Module Type", parent=site_type)
+        location_status = Status.objects.get_for_model(Location).first()
+        device_status = Status.objects.get_for_model(Device).first()
+
+        cls.parent_location = Location.objects.create(
+            name="Bulk View Parent",
+            location_type=site_type,
+            status=location_status,
+        )
+        cls.child_location = Location.objects.create(
+            name="Bulk View Child",
+            location_type=module_type,
+            parent=cls.parent_location,
+            status=location_status,
+        )
+        cls.network_role = Role.objects.create(name="Bulk View Network", color="444444")
+        cls.compute_role = Role.objects.create(name="Bulk View Compute", color="555555")
+        device_ct = ContentType.objects.get_for_model(Device)
+        cls.network_role.content_types.add(device_ct)
+        cls.compute_role.content_types.add(device_ct)
+        cls.device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model="Bulk View Model",
+        )
+        cls.network_device = Device.objects.create(
+            name="bulk-view-network",
+            location=cls.child_location,
+            device_type=cls.device_type,
+            role=cls.network_role,
+            status=device_status,
+        )
+        cls.compute_device = Device.objects.create(
+            name="bulk-view-compute",
+            location=cls.child_location,
+            device_type=cls.device_type,
+            role=cls.compute_role,
+            status=device_status,
+        )
+        cls.already_managed = Device.objects.create(
+            name="bulk-view-managed",
+            location=cls.child_location,
+            device_type=cls.device_type,
+            role=cls.network_role,
+            status=device_status,
+        )
+        ConfigManagerDeviceStatus.objects.create(device=cls.already_managed)
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("plugins:nv_config_manager:configmanagerdevicestatus_add")
+
+    def _grant_add_permission(self):
+        obj_perm = ObjectPermission(name="Bulk add permission", actions=["add", "view"])
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(ConfigManagerDeviceStatus))
+
+    def _add_data(self, **overrides):
+        data = {
+            "location": str(self.parent_location.pk),
+            "roles": [str(self.network_role.pk)],
+            "devices": [str(self.network_device.pk)],
+            "render_enabled": "true",
+            "is_aggregate_managed": "true",
+        }
+        data.update(overrides)
+        return data
+
+    def test_get_renders_bulk_add_form(self):
+        """GET renders the bulk-add form."""
+        self._grant_add_permission()
+        response = self.client.get(self.url)
+        self.assertHttpStatus(response, 200)
+        self.assertContains(response, "Device Filters")
+        self.assertContains(response, 'name="devices"')
+        self.assertNotContains(response, "Select a Location and one or more Device Roles")
+
+    def test_adds_selected_devices_with_shared_flags(self):
+        """Submitting creates managed devices with the selected service flags."""
+        self._grant_add_permission()
+        response = self.client.post(self.url, self._add_data())
+        self.assertHttpStatus(response, 302)
+        managed = ConfigManagerDeviceStatus.objects.get(device=self.network_device)
+        self.assertTrue(managed.render_enabled)
+        self.assertTrue(managed.is_aggregate_managed)
+        self.assertFalse(ConfigManagerDeviceStatus.objects.filter(device=self.compute_device).exists())
+
+    def test_records_change_log_for_added_devices(self):
+        """Each enrolled device gets a create change-log entry attributed to the user."""
+        self._grant_add_permission()
+        response = self.client.post(self.url, self._add_data())
+        self.assertHttpStatus(response, 302)
+        managed = ConfigManagerDeviceStatus.objects.get(device=self.network_device)
+        change = ObjectChange.objects.get(
+            changed_object_id=managed.pk,
+            action=ObjectChangeActionChoices.ACTION_CREATE,
+        )
+        self.assertEqual(change.user_name, self.user.username)
+
+    def test_adds_only_selected_devices(self):
+        """Only the devices chosen in the Devices box are enrolled."""
+        self._grant_add_permission()
+        second_network = Device.objects.create(
+            name="bulk-view-network-2",
+            location=self.child_location,
+            device_type=self.device_type,
+            role=self.network_role,
+            status=Status.objects.get_for_model(Device).first(),
+        )
+        response = self.client.post(self.url, self._add_data(devices=[str(second_network.pk)]))
+        self.assertHttpStatus(response, 302)
+        self.assertTrue(ConfigManagerDeviceStatus.objects.filter(device=second_network).exists())
+        self.assertFalse(ConfigManagerDeviceStatus.objects.filter(device=self.network_device).exists())
+
+    def test_requires_permission(self):
+        """Users without add permission cannot access the bulk-add view."""
+        response = self.client.get(self.url)
+        self.assertHttpStatus(response, 403)
+
+    def test_rejects_ineligible_device(self):
+        """A device outside the selected location/role scope is rejected."""
+        self._grant_add_permission()
+        response = self.client.post(self.url, self._add_data(devices=[str(self.compute_device.pk)]))
+        self.assertHttpStatus(response, 200)
+        self.assertContains(response, "One or more selected devices are not eligible for enrollment.")
+        self.assertFalse(ConfigManagerDeviceStatus.objects.filter(device=self.compute_device).exists())
+
+    def test_rolls_back_on_creation_failure(self):
+        """A creation failure rolls back the entire bulk-add transaction."""
+        from unittest.mock import patch
+
+        self._grant_add_permission()
+        second_network = Device.objects.create(
+            name="bulk-view-network-rollback",
+            location=self.child_location,
+            device_type=self.device_type,
+            role=self.network_role,
+            status=Status.objects.get_for_model(Device).first(),
+        )
+        with patch(
+            "nv_config_manager.utils.models.ConfigManagerDeviceStatus.objects.bulk_create",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = self.client.post(
+                self.url,
+                self._add_data(devices=[str(self.network_device.pk), str(second_network.pk)]),
+            )
+        self.assertHttpStatus(response, 200)
+        self.assertContains(response, "Failed to add managed devices")
+        self.assertFalse(ConfigManagerDeviceStatus.objects.filter(device=self.network_device).exists())
+        self.assertFalse(ConfigManagerDeviceStatus.objects.filter(device=second_network).exists())

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/utils.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/utils.py
@@ -14,7 +14,9 @@
 #  limitations under the License.
 """Util Functions."""
 
-from nautobot.dcim.models import Location
+from django.db import transaction
+from nautobot.dcim.models import Device, Location
+from nautobot.extras.models import Role
 
 from nv_config_manager import models
 
@@ -34,6 +36,62 @@ def get_all_descendants(node: Location):
     # Use Nautobot's built-in TreeModel method for efficient tree traversal
     # Return only IDs as a list for better performance
     return list(node.descendants(include_self=True).values_list("id", flat=True))
+
+
+def get_eligible_unmanaged_devices(
+    location: Location,
+    roles: list[Role] | tuple[Role, ...],
+):
+    """Return unmanaged devices in a location tree matching the given roles."""
+    location_ids = get_all_descendants(location)
+    return (
+        Device.objects.filter(
+            location_id__in=location_ids,
+            role__in=roles,
+            configmanagerdevicestatus__isnull=True,
+        )
+        .select_related("location", "role")
+        .order_by("name")
+    )
+
+
+def nullbool_to_bool(value: bool | None) -> bool:
+    """Map form values to boolean model values."""
+    return bool(value) if value is not None else False
+
+
+def bulk_create_managed_devices(
+    devices,
+    *,
+    render_enabled: bool | None = None,
+    ztp_enabled: bool | None = None,
+    deploy_enabled: bool | None = None,
+    backup_enabled: bool | None = None,
+    is_aggregate_managed: bool | None = None,
+) -> tuple[int, int]:
+    """Create managed-device rows for devices, skipping existing enrollments."""
+    defaults = {
+        "render_enabled": nullbool_to_bool(render_enabled),
+        "ztp_enabled": nullbool_to_bool(ztp_enabled),
+        "deploy_enabled": nullbool_to_bool(deploy_enabled),
+        "backup_enabled": nullbool_to_bool(backup_enabled),
+        "is_aggregate_managed": nullbool_to_bool(is_aggregate_managed),
+    }
+    created_count = 0
+    skipped_count = 0
+
+    with transaction.atomic():
+        for device in devices:
+            _, created = models.ConfigManagerDeviceStatus.objects.get_or_create(
+                device=device,
+                defaults=defaults,
+            )
+            if created:
+                created_count += 1
+            else:
+                skipped_count += 1
+
+    return created_count, skipped_count
 
 
 def generate_config_store_url(

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/utils.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/utils.py
@@ -14,11 +14,17 @@
 #  limitations under the License.
 """Util Functions."""
 
+import logging
+import uuid
+
 from django.db import transaction
 from nautobot.dcim.models import Device, Location
+from nautobot.extras.choices import ObjectChangeActionChoices, ObjectChangeEventContextChoices
 from nautobot.extras.models import Role
 
 from nv_config_manager import models
+
+logger = logging.getLogger(__name__)
 
 
 def get_all_descendants(node: Location):
@@ -68,6 +74,8 @@ def bulk_create_managed_devices(
     deploy_enabled: bool | None = None,
     backup_enabled: bool | None = None,
     is_aggregate_managed: bool | None = None,
+    user=None,
+    request_id=None,
 ) -> tuple[int, int]:
     """Create managed-device rows for devices, skipping existing enrollments."""
     defaults = {
@@ -77,21 +85,54 @@ def bulk_create_managed_devices(
         "backup_enabled": nullbool_to_bool(backup_enabled),
         "is_aggregate_managed": nullbool_to_bool(is_aggregate_managed),
     }
-    created_count = 0
-    skipped_count = 0
+    device_list = list(devices)
+    already_managed_ids = set(
+        models.ConfigManagerDeviceStatus.objects.filter(device__in=device_list).values_list("device_id", flat=True)
+    )
+
+    to_create = []
+    seen_ids: set = set()
+    for device in device_list:
+        if device.pk in already_managed_ids or device.pk in seen_ids:
+            continue
+        seen_ids.add(device.pk)
+        # ConfigManagerDeviceStatus.save() pins its pk to the device pk; replicate that
+        # here since bulk_create bypasses save().
+        to_create.append(models.ConfigManagerDeviceStatus(id=device.pk, device=device, **defaults))
 
     with transaction.atomic():
-        for device in devices:
-            _, created = models.ConfigManagerDeviceStatus.objects.get_or_create(
-                device=device,
-                defaults=defaults,
-            )
-            if created:
-                created_count += 1
-            else:
-                skipped_count += 1
+        models.ConfigManagerDeviceStatus.objects.bulk_create(to_create)
+        _log_created_object_changes(to_create, user=user, request_id=request_id)
 
+    created_count = len(to_create)
+    skipped_count = len(device_list) - created_count
+    if to_create:
+        logger.info(
+            "Enrolled %d device(s) into Config Manager: %s",
+            created_count,
+            ", ".join(sorted(status.device.name for status in to_create)),
+        )
     return created_count, skipped_count
+
+
+def _log_created_object_changes(instances, *, user=None, request_id=None):
+    """Emit a Nautobot change-log entry for each managed device created via bulk_create.
+
+    bulk_create bypasses save() and its post_save signals, so the change-log
+    entries Nautobot would normally record are written explicitly here.
+    """
+    if not instances:
+        return
+    request_id = request_id or uuid.uuid4()
+    for instance in instances:
+        change = instance.to_objectchange(ObjectChangeActionChoices.ACTION_CREATE)
+        if change is None:
+            continue
+        change.user = user
+        change.request_id = request_id
+        change.change_context = ObjectChangeEventContextChoices.CONTEXT_WEB
+        change.change_context_detail = "bulk add managed devices"
+        change.save()
 
 
 def generate_config_store_url(

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/views.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/views.py
@@ -14,17 +14,25 @@
 #  limitations under the License.
 """Views."""
 
+import logging
+
 from django.conf import settings
-from django.shortcuts import get_object_or_404
+from django.contrib import messages
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.views import View
 from nautobot.core.views import generic
+from nautobot.core.views.mixins import ObjectPermissionRequiredMixin
 from nautobot.dcim.models import Device, Location
 
 from nv_config_manager import filters, forms, models, tables
 from nv_config_manager.utils import (
+    bulk_create_managed_devices,
     generate_config_store_url,
     get_all_descendants,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def generate_config_urls(instance):
@@ -78,12 +86,58 @@ class ConfigManagerDeviceStatusListView(generic.ObjectListView):
         return context
 
 
-class ConfigManagerDeviceStatusAddView(generic.ObjectEditView):
-    """Add view for ConfigManagerDeviceStatus."""
+class ConfigManagerDeviceStatusAddView(ObjectPermissionRequiredMixin, View):
+    """Bulk-add view for ConfigManagerDeviceStatus."""
 
     queryset = models.ConfigManagerDeviceStatus.objects.all()
-    model_form = forms.ConfigManagerDeviceStatusAddForm
     template_name = "nv_config_manager/configmanagerdevicestatus_add.html"
+
+    def get_required_permission(self):
+        """Require permission to add managed devices."""
+        return "nv_config_manager.add_configmanagerdevicestatus"
+
+    def _return_url(self):
+        return reverse("plugins:nv_config_manager:configmanagerdevicestatus_list")
+
+    def _context(self, form):
+        return {
+            "form": form,
+            "return_url": self._return_url(),
+            "editing": False,
+            "obj": None,
+            "obj_type": "Managed Device",
+        }
+
+    def get(self, request):
+        """Render the bulk-add filter form."""
+        form = forms.ConfigManagerDeviceStatusBulkAddForm()
+        return render(request, self.template_name, self._context(form))
+
+    def post(self, request):
+        """Enroll the selected devices into Config Manager."""
+        form = forms.ConfigManagerDeviceStatusBulkAddForm(request.POST)
+        if not form.is_valid():
+            return render(request, self.template_name, self._context(form))
+
+        try:
+            created_count, skipped_count = bulk_create_managed_devices(
+                list(form.get_devices_to_add()),
+                render_enabled=form.cleaned_data.get("render_enabled"),
+                ztp_enabled=form.cleaned_data.get("ztp_enabled"),
+                deploy_enabled=form.cleaned_data.get("deploy_enabled"),
+                backup_enabled=form.cleaned_data.get("backup_enabled"),
+                is_aggregate_managed=form.cleaned_data.get("is_aggregate_managed"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Bulk managed-device enrollment failed")
+            messages.error(request, f"Failed to add managed devices: {exc}")
+            return render(request, self.template_name, self._context(form))
+
+        if created_count:
+            messages.success(request, f"Added {created_count} managed device(s) to Config Manager.")
+        if skipped_count:
+            messages.warning(request, f"Skipped {skipped_count} device(s) that were already managed.")
+        return redirect(self._return_url())
 
 
 class ConfigManagerDeviceStatusEditView(generic.ObjectEditView):

--- a/components/nautobot/nautobot-nv-config-manager/nv_config_manager/views.py
+++ b/components/nautobot/nautobot-nv-config-manager/nv_config_manager/views.py
@@ -127,10 +127,15 @@ class ConfigManagerDeviceStatusAddView(ObjectPermissionRequiredMixin, View):
                 deploy_enabled=form.cleaned_data.get("deploy_enabled"),
                 backup_enabled=form.cleaned_data.get("backup_enabled"),
                 is_aggregate_managed=form.cleaned_data.get("is_aggregate_managed"),
+                user=request.user,
+                request_id=getattr(request, "id", None),
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             logger.exception("Bulk managed-device enrollment failed")
-            messages.error(request, f"Failed to add managed devices: {exc}")
+            messages.error(
+                request,
+                "Failed to add managed devices.",
+            )
             return render(request, self.template_name, self._context(form))
 
         if created_count:


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`6c7ab98`](https://github.com/NVIDIA/nv-config-manager/commit/6c7ab9817b37621c2892e690819b80ea23a94a8e) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/29941280064).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a device-filtered bulk enrollment flow for configuration-managed device statuses (location + roles + multi-device selection).
  * Added management option controls (render/ztp/deploy/backup and aggregate management) with clear success vs already-managed feedback.
* **Bug Fixes**
  * Prevents enrolling devices outside the selected location/role scope (including descendants) and excludes devices that are already managed.
  * Enforces required add permissions and properly reports invalid selections.
* **Tests**
  * Added/expanded coverage for eligibility filtering, form/view validation, messaging, and atomic behavior.
* **Chores**
  * Updated ignore rules to prevent generated test output from being tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->