### PR TITLE
feat: audit workflow actions

### DIFF
--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -898,7 +898,7 @@ async def require_sso_or_device(request: Request) -> SSOIdentity | None:
 #
 # Installs a ``GET /whoami`` endpoint plus the ``normalize_auth_data``
 # middleware on a FastAPI app.  Shared across nv-config-manager FastAPI services so the
-# identity contract (request.state.user/roles, /whoami response
+# identity contract (request.state.user/roles/auth_source, /whoami response
 # shape) is guaranteed identical — regressions in one service can't diverge
 # from the others.  Used both by operational diagnostics ("who does X see me
 # as?") and by the SPIFFE client-injection integration tests.
@@ -929,10 +929,11 @@ def install_identity_probe(
       unless the path is in ``unauthenticated_paths``.  This keeps healthchecks
       as the explicit unauthenticated exception instead of requiring every route
       author to remember an auth dependency.
-    - Every request has ``request.state.user`` (str) and ``request.state.roles``
-      (set[str]) populated from :func:`extract_identity`, falling back to
-      ``user="anonymous"`` when auth is disabled and ``user="unknown"`` when
-      auth is enabled but no identity can be derived.
+    - Every request has ``request.state.user`` (str), ``request.state.roles``
+      (set[str]), and ``request.state.auth_source`` (str) populated from
+      :func:`extract_identity`, falling back to ``user="anonymous"`` and
+      ``auth_source="anonymous"`` when auth is disabled, or ``user="unknown"``
+      and ``auth_source="unknown"`` when auth is enabled but no identity can be derived.
     - ``GET /whoami`` returns the current caller's identity. By default this
       endpoint requires a trusted identity, matching the rest of the API
       surface; set ``require_auth=False`` only for local diagnostics.
@@ -987,7 +988,7 @@ def install_identity_probe(
     async def normalize_auth_data(
         request: Request, call_next: Callable[[Request], Any]
     ) -> Response:
-        """Populate ``request.state.user`` / ``request.state.roles``.
+        """Populate the request's normalized user, roles, and authentication source.
 
         Uses the consolidated :func:`extract_identity` so mTLS, SPIFFE
         JWT-SVIDs, OIDC JWTs, and trusted OIDC proxy identity headers are
@@ -997,12 +998,15 @@ def install_identity_probe(
         if identity is not None:
             request.state.user = identity.user
             request.state.roles = identity.groups
+            request.state.auth_source = identity.source
         elif not auth_required():
             request.state.user = ANONYMOUS_IDENTITY.user
             request.state.roles = ANONYMOUS_IDENTITY.groups
+            request.state.auth_source = ANONYMOUS_IDENTITY.source
         else:
             request.state.user = "unknown"
             request.state.roles = {"all"}
+            request.state.auth_source = "unknown"
 
         response: Response = await call_next(request)
         return response

--- a/src/nv_config_manager/common/log.py
+++ b/src/nv_config_manager/common/log.py
@@ -220,13 +220,6 @@ def _escape_log_argument(value: object) -> object:
 class EscapingLoggerAdapter(logging.LoggerAdapter):
     """Logger adapter that escapes unsafe characters in messages and arguments."""
 
-    def process(self, msg: object, kwargs: Any) -> tuple[object, Any]:
-        """Merge per-call structured fields with the adapter's default fields."""
-        call_extra = kwargs.get("extra") or {}
-        adapter_extra = self.extra or {}
-        kwargs["extra"] = {**adapter_extra, **call_extra}
-        return msg, kwargs
-
     def log(self, level: int, msg: object, *args: object, **kwargs: Any) -> None:
         """Delegate an enabled log call after sanitizing its message and arguments."""
         if self.isEnabledFor(level):
@@ -325,4 +318,8 @@ def get_logger(
         logger.addHandler(handler)
         logger.setLevel(_get_log_level())
 
-    return EscapingLoggerAdapter(logger, extra={"category": category})
+    return EscapingLoggerAdapter(
+        logger,
+        extra={"category": category},
+        merge_extra=True,
+    )

--- a/src/nv_config_manager/common/log.py
+++ b/src/nv_config_manager/common/log.py
@@ -62,6 +62,11 @@ class LogCategory:
 _logging_configured = False
 _custom_labels: dict[str, str] = {}
 
+
+class _FallbackStreamHandler(logging.StreamHandler):
+    """Temporary handler used before process-wide logging is configured."""
+
+
 _LOG_LINE_BREAK_ESCAPES = str.maketrans(
     {
         "\n": r"\n",
@@ -255,6 +260,18 @@ def configure_logging(service: str | None = None) -> None:
     for h in root.handlers[:]:
         root.removeHandler(h)
 
+    # Modules can call get_logger() while the service entry point is still
+    # importing. Remove only the temporary handlers installed by get_logger()
+    # so those records do not also propagate to the newly configured root
+    # handler and appear twice.
+    for managed_logger in logging.Logger.manager.loggerDict.values():
+        if not isinstance(managed_logger, logging.Logger):
+            continue
+        for existing_handler in managed_logger.handlers[:]:
+            if isinstance(existing_handler, _FallbackStreamHandler):
+                managed_logger.removeHandler(existing_handler)
+                existing_handler.close()
+
     handler = logging.StreamHandler()
     handler.setFormatter(_build_formatter())
     root.addHandler(handler)
@@ -299,7 +316,7 @@ def get_logger(
     logger = logging.getLogger(name)
 
     if not _logging_configured and not logger.handlers:
-        handler = logging.StreamHandler()
+        handler = _FallbackStreamHandler()
         handler.setFormatter(
             _build_formatter()
             if json_format

--- a/src/nv_config_manager/common/log.py
+++ b/src/nv_config_manager/common/log.py
@@ -47,6 +47,7 @@ class LogCategory:
     TEMPORAL_WORKFLOW = "temporal.workflow"
     TEMPORAL_ACTIVITY = "temporal.activity"
     TEMPORAL_API = "temporal.api"
+    TEMPORAL_AUDIT = "temporal.audit"
     NAUTOBOT = "nautobot"
     AUTH = "auth"
     API = "api"  # Deprecated: use per-service variants (RENDER_API, etc.)
@@ -213,6 +214,13 @@ def _escape_log_argument(value: object) -> object:
 
 class EscapingLoggerAdapter(logging.LoggerAdapter):
     """Logger adapter that escapes unsafe characters in messages and arguments."""
+
+    def process(self, msg: object, kwargs: Any) -> tuple[object, Any]:
+        """Merge per-call structured fields with the adapter's default fields."""
+        call_extra = kwargs.get("extra") or {}
+        adapter_extra = self.extra or {}
+        kwargs["extra"] = {**adapter_extra, **call_extra}
+        return msg, kwargs
 
     def log(self, level: int, msg: object, *args: object, **kwargs: Any) -> None:
         """Delegate an enabled log call after sanitizing its message and arguments."""

--- a/src/nv_config_manager/temporal/api/audit.py
+++ b/src/nv_config_manager/temporal/api/audit.py
@@ -126,6 +126,7 @@ def install_workflow_audit_logging(app: FastAPI) -> None:
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
+        """Log the normalized result of each Workflow API POST action."""
         action_target = _workflow_action_target(request)
         if action_target is None:
             return await call_next(request)

--- a/src/nv_config_manager/temporal/api/audit.py
+++ b/src/nv_config_manager/temporal/api/audit.py
@@ -28,6 +28,7 @@ from nv_config_manager.common.log import LogCategory, escape_log_newlines, get_l
 logger = get_logger(__name__, category=LogCategory.TEMPORAL_AUDIT)
 
 AuditOutcome = Literal["success", "denied", "failure"]
+_LIFECYCLE_ACTIONS = frozenset({"approve", "reject", "retry", "terminate"})
 
 _WORKFLOW_ACTION_PATH = re.compile(
     r"^/v1/workflow/(?P<workflow_id>[^/]+)/"
@@ -71,7 +72,7 @@ def log_workflow_action(
         outcome,
         extra={
             "event_type": "workflow_action",
-            "action": action,
+            "action": escape_log_newlines(action),
             "outcome": outcome,
             "actor": escape_log_newlines(actor),
             "roles": [escape_log_newlines(role) for role in roles],
@@ -96,16 +97,33 @@ def _workflow_action_target(request: Request) -> tuple[str, str | None, str | No
     if not path.startswith(prefix):
         return None
 
-    lifecycle_match = _WORKFLOW_ACTION_PATH.fullmatch(path)
-    if lifecycle_match:
+    # Prefer the matched route name so a dynamic start endpoint whose final
+    # segment equals a lifecycle verb is still classified as a workflow start.
+    route = request.scope.get("route")
+    route_name = getattr(route, "name", None)
+    if route_name in _LIFECYCLE_ACTIONS:
         return (
-            lifecycle_match.group("action"),
-            lifecycle_match.group("workflow_id"),
-            lifecycle_match.group("stage_name"),
+            route_name,
+            request.path_params.get("workflow_id"),
+            request.path_params.get("stage_name"),
             path,
         )
 
+    # Route metadata is unavailable for unmatched requests. Retain the path
+    # parser so failed lifecycle attempts still receive useful audit fields.
+    if route_name is None:
+        lifecycle_match = _WORKFLOW_ACTION_PATH.fullmatch(path)
+        if lifecycle_match:
+            return (
+                lifecycle_match.group("action"),
+                lifecycle_match.group("workflow_id"),
+                lifecycle_match.group("stage_name"),
+                path,
+            )
+
     target = path.removeprefix(prefix).rstrip("/")
+    if not target:
+        return None
     return target.rsplit("/", maxsplit=1)[-1], None, None, target
 
 
@@ -127,14 +145,19 @@ def install_workflow_audit_logging(app: FastAPI) -> None:
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         """Log the normalized result of each Workflow API POST action."""
-        action_target = _workflow_action_target(request)
-        if action_target is None:
+        is_workflow_action = request.method == "POST" and request.url.path.startswith(
+            "/v1/workflow/"
+        )
+        if not is_workflow_action:
             return await call_next(request)
 
-        action, path_workflow_id, stage_name, target = action_target
         try:
             response = await call_next(request)
         except Exception as exc:
+            action_target = _workflow_action_target(request)
+            if action_target is None:
+                raise
+            action, path_workflow_id, stage_name, target = action_target
             log_workflow_action(
                 request,
                 action=action,
@@ -147,6 +170,10 @@ def install_workflow_audit_logging(app: FastAPI) -> None:
             )
             raise
 
+        action_target = _workflow_action_target(request)
+        if action_target is None:
+            return response
+        action, path_workflow_id, stage_name, target = action_target
         outcome = _audit_outcome(response.status_code)
         log_workflow_action(
             request,

--- a/src/nv_config_manager/temporal/api/audit.py
+++ b/src/nv_config_manager/temporal/api/audit.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structured audit logging for Workflow API actions."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import FastAPI, Request, Response
+
+from nv_config_manager.common.log import LogCategory, escape_log_newlines, get_logger
+
+logger = get_logger(__name__, category=LogCategory.TEMPORAL_AUDIT)
+
+AuditOutcome = Literal["success", "denied", "failure"]
+
+_WORKFLOW_ACTION_PATH = re.compile(
+    r"^/v1/workflow/(?P<workflow_id>[^/]+)/"
+    r"(?P<action>approve|reject|retry|terminate)"
+    r"(?:/(?P<stage_name>[^/]+))?/?$"
+)
+
+
+def request_auth_source(request: Request) -> str:
+    """Return the trusted authentication source populated by auth middleware."""
+    source = getattr(request.state, "auth_source", "unknown")
+    return source if isinstance(source, str) else "unknown"
+
+
+def log_workflow_action(
+    request: Request,
+    *,
+    action: str,
+    outcome: AuditOutcome,
+    workflow_id: str | None = None,
+    workflow_type: str | None = None,
+    stage_name: str | None = None,
+    target: str | None = None,
+    detail: str | None = None,
+) -> None:
+    """Emit a consistent structured audit event for a Workflow API action."""
+    actor = getattr(request.state, "user", "unknown")
+    if not isinstance(actor, str):
+        actor = "unknown"
+
+    request_roles: object = getattr(request.state, "roles", set())
+    roles = (
+        sorted(str(role) for role in request_roles)
+        if isinstance(request_roles, (set, frozenset, list, tuple))
+        else []
+    )
+
+    logger.info(
+        "Workflow action %s finished with outcome %s",
+        action,
+        outcome,
+        extra={
+            "event_type": "workflow_action",
+            "action": action,
+            "outcome": outcome,
+            "actor": escape_log_newlines(actor),
+            "roles": [escape_log_newlines(role) for role in roles],
+            "source": escape_log_newlines(request_auth_source(request)),
+            "timestamp": datetime.now(UTC).isoformat(),
+            "workflow_id": escape_log_newlines(workflow_id) if workflow_id else None,
+            "workflow_type": escape_log_newlines(workflow_type) if workflow_type else None,
+            "stage_name": escape_log_newlines(stage_name) if stage_name else None,
+            "target": escape_log_newlines(target) if target else None,
+            "detail": escape_log_newlines(detail) if detail else None,
+        },
+    )
+
+
+def _workflow_action_target(request: Request) -> tuple[str, str | None, str | None, str] | None:
+    """Parse a Workflow API POST into action, workflow ID, stage, and target."""
+    if request.method != "POST":
+        return None
+
+    path = request.url.path
+    prefix = "/v1/workflow/"
+    if not path.startswith(prefix):
+        return None
+
+    lifecycle_match = _WORKFLOW_ACTION_PATH.fullmatch(path)
+    if lifecycle_match:
+        return (
+            lifecycle_match.group("action"),
+            lifecycle_match.group("workflow_id"),
+            lifecycle_match.group("stage_name"),
+            path,
+        )
+
+    target = path.removeprefix(prefix).rstrip("/")
+    return target.rsplit("/", maxsplit=1)[-1], None, None, target
+
+
+def _audit_outcome(status_code: int) -> AuditOutcome:
+    """Map an HTTP response status to a stable audit outcome."""
+    if 200 <= status_code < 300:
+        return "success"
+    if status_code in (401, 403):
+        return "denied"
+    return "failure"
+
+
+def install_workflow_audit_logging(app: FastAPI) -> None:
+    """Install centralized structured logging for Workflow API actions."""
+
+    @app.middleware("http")
+    async def audit_workflow_actions(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        action_target = _workflow_action_target(request)
+        if action_target is None:
+            return await call_next(request)
+
+        action, path_workflow_id, stage_name, target = action_target
+        try:
+            response = await call_next(request)
+        except Exception as exc:
+            log_workflow_action(
+                request,
+                action=action,
+                outcome="failure",
+                workflow_id=path_workflow_id,
+                workflow_type=getattr(request.state, "audit_workflow_type", None),
+                stage_name=stage_name,
+                target=target,
+                detail=type(exc).__name__,
+            )
+            raise
+
+        outcome = _audit_outcome(response.status_code)
+        log_workflow_action(
+            request,
+            action=action,
+            outcome=outcome,
+            workflow_id=(path_workflow_id or getattr(request.state, "audit_workflow_id", None)),
+            workflow_type=getattr(request.state, "audit_workflow_type", None),
+            stage_name=stage_name,
+            target=target,
+            detail=f"HTTP {response.status_code}" if outcome != "success" else None,
+        )
+        return response

--- a/src/nv_config_manager/temporal/api/main.py
+++ b/src/nv_config_manager/temporal/api/main.py
@@ -84,6 +84,8 @@ def healthcheck() -> Literal["OK"]:
     return "OK"
 
 
+# Starlette executes the last-added HTTP middleware first. Install identity
+# second so it populates request.state before audit logging reads those fields.
 install_workflow_audit_logging(app)
 install_identity_probe(app)
 

--- a/src/nv_config_manager/temporal/api/main.py
+++ b/src/nv_config_manager/temporal/api/main.py
@@ -29,6 +29,7 @@ from nv_config_manager.common.auth import install_identity_probe
 from nv_config_manager.common.config import load_config
 from nv_config_manager.common.log import LogCategory, configure_logging, get_logger
 from nv_config_manager.temporal.api import codec_server, parameter_v1, workflow_v1
+from nv_config_manager.temporal.api.audit import install_workflow_audit_logging
 from nv_config_manager.temporal.common.rbac_config import RBACConfig
 from nv_config_manager.temporal.telemetry import setup_telemetry
 
@@ -83,6 +84,7 @@ def healthcheck() -> Literal["OK"]:
     return "OK"
 
 
+install_workflow_audit_logging(app)
 install_identity_probe(app)
 
 

--- a/src/nv_config_manager/temporal/api/workflow_v1.py
+++ b/src/nv_config_manager/temporal/api/workflow_v1.py
@@ -489,6 +489,7 @@ async def start_workflow(
 ) -> str:
     """Start a workflow with the given input."""
 
+    request.state.audit_workflow_type = workflow_class.__name__
     user, roles = get_user_info(request)
 
     # Check if the user is authorized to execute the workflow
@@ -534,6 +535,7 @@ async def start_workflow(
         task_queue="default-task-queue",
         search_attributes=search_attributes,
     )
+    request.state.audit_workflow_id = handle.id
     try:
         await cache_workflow_input(handle.id, body)
     except Exception:

--- a/src/tests/common/test_auth.py
+++ b/src/tests/common/test_auth.py
@@ -279,6 +279,7 @@ class TestInstallIdentityProbe:
 
         @app.get("/state-user")
         async def state_user(request: Request):
+            """Expose normalized request identity fields for middleware tests."""
             return {
                 "user": request.state.user,
                 "auth_source": request.state.auth_source,

--- a/src/tests/common/test_auth.py
+++ b/src/tests/common/test_auth.py
@@ -279,7 +279,10 @@ class TestInstallIdentityProbe:
 
         @app.get("/state-user")
         async def state_user(request: Request):
-            return {"user": request.state.user}
+            return {
+                "user": request.state.user,
+                "auth_source": request.state.auth_source,
+            }
 
         install_identity_probe(app)
         return app
@@ -296,6 +299,10 @@ class TestInstallIdentityProbe:
         resp = client.get("/protected", headers={"X-Auth-Request-Email": "alice@example.com"})
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
+
+        resp = client.get("/state-user", headers={"X-Auth-Request-Email": "alice@example.com"})
+        assert resp.status_code == 200
+        assert resp.json() == {"user": "alice", "auth_source": "sso"}
 
     def test_docs_are_protected(self):
         auth_mod._auth_config = load_auth_config(
@@ -315,7 +322,7 @@ class TestInstallIdentityProbe:
 
         resp = client.get("/state-user")
         assert resp.status_code == 200
-        assert resp.json() == {"user": "anonymous"}
+        assert resp.json() == {"user": "anonymous", "auth_source": "anonymous"}
 
     def test_openapi_describes_default_bearer_auth_and_public_paths(self):
         schema = self._make_app().openapi()

--- a/src/tests/common/test_log.py
+++ b/src/tests/common/test_log.py
@@ -198,3 +198,30 @@ def test_logger_adapter_merges_per_call_structured_fields(
     assert record.category == "temporal.audit"
     assert record.action == "terminate"
     assert record.actor == "operator"
+
+
+def test_configure_logging_replaces_fallback_handler_without_duplicate_output(
+    _restore_logging: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A logger created during imports emits once after root configuration."""
+    logger_name = "test.preconfiguration-fallback"
+    raw_logger = logging.getLogger(logger_name)
+    original_handlers = raw_logger.handlers[:]
+    original_level = raw_logger.level
+
+    try:
+        raw_logger.handlers.clear()
+        log._logging_configured = False
+        logger = get_logger(logger_name, category="temporal.audit")
+
+        assert len(raw_logger.handlers) == 1
+
+        log.configure_logging(service="test-svc")
+        logger.info("unique workflow audit event")
+
+        assert raw_logger.handlers == []
+        assert capsys.readouterr().err.count("unique workflow audit event") == 1
+    finally:
+        raw_logger.handlers[:] = original_handlers
+        raw_logger.setLevel(original_level)

--- a/src/tests/common/test_log.py
+++ b/src/tests/common/test_log.py
@@ -183,3 +183,18 @@ def test_logger_adapter_recursively_escapes_collection_arguments(
     assert caplog.messages[-1] == (
         r"nested={'bad\\n\\x1bkey': ['before\\nafter', ('bad\\rvalue',)]}"
     )
+
+
+def test_logger_adapter_merges_per_call_structured_fields(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Structured audit fields are retained alongside the adapter category."""
+    logger = get_logger("test.structured", category="temporal.audit")
+
+    with caplog.at_level(logging.INFO, logger="test.structured"):
+        logger.info("workflow action", extra={"action": "terminate", "actor": "operator"})
+
+    record = caplog.records[-1]
+    assert record.category == "temporal.audit"
+    assert record.action == "terminate"
+    assert record.actor == "operator"

--- a/src/tests/temporal/api/test_audit.py
+++ b/src/tests/temporal/api/test_audit.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from nv_config_manager.temporal.api.audit import (
+    install_workflow_audit_logging,
+    log_workflow_action,
+)
+
+
+def test_log_workflow_action_emits_consistent_structured_fields(mocker):
+    """Audit logs contain actor, timestamp, roles, source, and target."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+    request = MagicMock()
+    request.state.user = "operator@example.com"
+    request.state.roles = {"nvcm-network", "all"}
+    request.state.auth_source = "jwt"
+
+    log_workflow_action(
+        request,
+        action="terminate",
+        outcome="success",
+        workflow_id="workflow-1",
+        workflow_type="DeployWorkflow",
+        stage_name="apply_configuration",
+    )
+
+    audit_logger.info.assert_called_once()
+    fields = audit_logger.info.call_args.kwargs["extra"]
+    assert fields["event_type"] == "workflow_action"
+    assert fields["action"] == "terminate"
+    assert fields["outcome"] == "success"
+    assert fields["actor"] == "operator@example.com"
+    assert fields["roles"] == ["all", "nvcm-network"]
+    assert fields["source"] == "jwt"
+    assert fields["workflow_id"] == "workflow-1"
+    assert fields["workflow_type"] == "DeployWorkflow"
+    assert fields["stage_name"] == "apply_configuration"
+    assert fields["timestamp"].endswith("+00:00")
+
+
+def _audit_test_app() -> FastAPI:
+    app = FastAPI()
+    install_workflow_audit_logging(app)
+
+    @app.middleware("http")
+    async def set_identity(request: Request, call_next):
+        request.state.user = "operator@example.com"
+        request.state.roles = {"nvcm-network"}
+        request.state.auth_source = "jwt"
+        return await call_next(request)
+
+    @app.post("/v1/workflow/ngc/{workflow_name}")
+    async def start(request: Request, workflow_name: str, denied: bool = False):
+        request.state.audit_workflow_type = f"{workflow_name.title()}Workflow"
+        if denied:
+            return Response(status_code=403)
+        request.state.audit_workflow_id = "workflow-1"
+        return {"id": "workflow-1"}
+
+    @app.post("/v1/workflow/{workflow_id}/{action}")
+    @app.post("/v1/workflow/{workflow_id}/{action}/{stage_name}")
+    async def lifecycle(workflow_id: str, action: str, stage_name: str | None = None):
+        return {"id": workflow_id, "action": action, "stage_name": stage_name}
+
+    return app
+
+
+@pytest.mark.parametrize(
+    ("path", "action", "stage_name"),
+    [
+        ("/v1/workflow/workflow-1/approve/prompt", "approve", "prompt"),
+        ("/v1/workflow/workflow-1/reject/prompt", "reject", "prompt"),
+        ("/v1/workflow/workflow-1/retry/apply", "retry", "apply"),
+        ("/v1/workflow/workflow-1/terminate", "terminate", None),
+    ],
+)
+def test_audit_middleware_logs_lifecycle_action(mocker, path, action, stage_name):
+    """Lifecycle routes are logged with their workflow target and outcome."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+
+    response = TestClient(_audit_test_app()).post(path)
+
+    assert response.status_code == 200
+    fields = audit_logger.info.call_args.kwargs["extra"]
+    assert fields["action"] == action
+    assert fields["outcome"] == "success"
+    assert fields["workflow_id"] == "workflow-1"
+    assert fields["stage_name"] == stage_name
+    assert fields["target"] == path
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["deploy", "reprovision", "device_password_rotation", "site_password_rotation"],
+)
+def test_audit_middleware_logs_workflow_start_and_denial(mocker, action):
+    """Dynamic workflow starts include workflow type and HTTP denial outcome."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+    client = TestClient(_audit_test_app())
+
+    success = client.post(f"/v1/workflow/ngc/{action}")
+    success_fields = audit_logger.info.call_args.kwargs["extra"]
+    denied = client.post(f"/v1/workflow/ngc/{action}?denied=true")
+    denied_fields = audit_logger.info.call_args.kwargs["extra"]
+
+    assert success.status_code == 200
+    assert success_fields["action"] == action
+    assert success_fields["outcome"] == "success"
+    assert success_fields["workflow_id"] == "workflow-1"
+    assert success_fields["target"] == f"ngc/{action}"
+
+    assert denied.status_code == 403
+    assert denied_fields["action"] == action
+    assert denied_fields["outcome"] == "denied"
+    assert denied_fields["workflow_id"] is None
+    assert denied_fields["detail"] == "HTTP 403"

--- a/src/tests/temporal/api/test_audit.py
+++ b/src/tests/temporal/api/test_audit.py
@@ -88,11 +88,25 @@ def _audit_test_app() -> FastAPI:
         request.state.audit_workflow_id = "workflow-1"
         return {"id": "workflow-1"}
 
-    @app.post("/v1/workflow/{workflow_id}/{action}")
-    @app.post("/v1/workflow/{workflow_id}/{action}/{stage_name}")
-    async def lifecycle(workflow_id: str, action: str, stage_name: str | None = None):
-        """Return lifecycle path parameters after middleware classification."""
-        return {"id": workflow_id, "action": action, "stage_name": stage_name}
+    @app.post("/v1/workflow/{workflow_id}/approve/{stage_name}")
+    async def approve(workflow_id: str, stage_name: str):
+        """Return an approved lifecycle action."""
+        return {"id": workflow_id, "stage_name": stage_name}
+
+    @app.post("/v1/workflow/{workflow_id}/reject/{stage_name}")
+    async def reject(workflow_id: str, stage_name: str):
+        """Return a rejected lifecycle action."""
+        return {"id": workflow_id, "stage_name": stage_name}
+
+    @app.post("/v1/workflow/{workflow_id}/retry/{stage_name}")
+    async def retry(workflow_id: str, stage_name: str):
+        """Return a retried lifecycle action."""
+        return {"id": workflow_id, "stage_name": stage_name}
+
+    @app.post("/v1/workflow/{workflow_id}/terminate")
+    async def terminate(workflow_id: str):
+        """Return a terminated lifecycle action."""
+        return {"id": workflow_id}
 
     return app
 
@@ -146,6 +160,48 @@ def test_audit_middleware_logs_workflow_start_and_denial(mocker, action):
     assert denied_fields["outcome"] == "denied"
     assert denied_fields["workflow_id"] is None
     assert denied_fields["detail"] == "HTTP 403"
+
+
+def test_log_workflow_action_escapes_action(mocker):
+    """Line breaks are escaped in the structured action field."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+    request = MagicMock()
+    request.state.user = "operator@example.com"
+    request.state.roles = {"nvcm-network"}
+    request.state.auth_source = "jwt"
+
+    log_workflow_action(
+        request,
+        action="deploy\nforged",
+        outcome="success",
+    )
+
+    fields = audit_logger.info.call_args.kwargs["extra"]
+    assert fields["action"] == r"deploy\nforged"
+
+
+def test_dynamic_start_named_like_lifecycle_verb_is_not_misclassified(mocker):
+    """Matched route metadata distinguishes starts from lifecycle actions."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+
+    response = TestClient(_audit_test_app()).post("/v1/workflow/ngc/retry")
+
+    assert response.status_code == 200
+    fields = audit_logger.info.call_args.kwargs["extra"]
+    assert fields["action"] == "retry"
+    assert fields["workflow_id"] == "workflow-1"
+    assert fields["stage_name"] is None
+    assert fields["target"] == "ngc/retry"
+
+
+def test_bare_workflow_path_does_not_emit_empty_action(mocker):
+    """A bare workflow collection POST is not recorded as an empty action."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+
+    response = TestClient(_audit_test_app()).post("/v1/workflow/")
+
+    assert response.status_code == 404
+    audit_logger.info.assert_not_called()
 
 
 def test_audit_middleware_logs_workflow_failure_response(mocker):

--- a/src/tests/temporal/api/test_audit.py
+++ b/src/tests/temporal/api/test_audit.py
@@ -57,27 +57,41 @@ def test_log_workflow_action_emits_consistent_structured_fields(mocker):
 
 
 def _audit_test_app() -> FastAPI:
+    """Build a small app that exercises audit middleware outcomes."""
     app = FastAPI()
     install_workflow_audit_logging(app)
 
     @app.middleware("http")
     async def set_identity(request: Request, call_next):
+        """Populate the normalized identity fields normally supplied by auth middleware."""
         request.state.user = "operator@example.com"
         request.state.roles = {"nvcm-network"}
         request.state.auth_source = "jwt"
         return await call_next(request)
 
     @app.post("/v1/workflow/ngc/{workflow_name}")
-    async def start(request: Request, workflow_name: str, denied: bool = False):
+    async def start(
+        request: Request,
+        workflow_name: str,
+        denied: bool = False,
+        failure: bool = False,
+        raises: bool = False,
+    ):
+        """Return selectable workflow-start outcomes for audit tests."""
         request.state.audit_workflow_type = f"{workflow_name.title()}Workflow"
+        if raises:
+            raise RuntimeError("workflow start failed")
         if denied:
             return Response(status_code=403)
+        if failure:
+            return Response(status_code=500)
         request.state.audit_workflow_id = "workflow-1"
         return {"id": "workflow-1"}
 
     @app.post("/v1/workflow/{workflow_id}/{action}")
     @app.post("/v1/workflow/{workflow_id}/{action}/{stage_name}")
     async def lifecycle(workflow_id: str, action: str, stage_name: str | None = None):
+        """Return lifecycle path parameters after middleware classification."""
         return {"id": workflow_id, "action": action, "stage_name": stage_name}
 
     return app
@@ -132,3 +146,31 @@ def test_audit_middleware_logs_workflow_start_and_denial(mocker, action):
     assert denied_fields["outcome"] == "denied"
     assert denied_fields["workflow_id"] is None
     assert denied_fields["detail"] == "HTTP 403"
+
+
+def test_audit_middleware_logs_workflow_failure_response(mocker):
+    """A 5xx response records a failure outcome and HTTP status detail."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+
+    response = TestClient(_audit_test_app()).post("/v1/workflow/ngc/deploy?failure=true")
+
+    assert response.status_code == 500
+    fields = audit_logger.info.call_args.kwargs["extra"]
+    assert fields["action"] == "deploy"
+    assert fields["outcome"] == "failure"
+    assert fields["workflow_type"] == "DeployWorkflow"
+    assert fields["detail"] == "HTTP 500"
+
+
+def test_audit_middleware_logs_and_reraises_workflow_exception(mocker):
+    """An endpoint exception is logged as a failure before being re-raised."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+
+    with pytest.raises(RuntimeError, match="workflow start failed"):
+        TestClient(_audit_test_app()).post("/v1/workflow/ngc/deploy?raises=true")
+
+    fields = audit_logger.info.call_args.kwargs["extra"]
+    assert fields["action"] == "deploy"
+    assert fields["outcome"] == "failure"
+    assert fields["workflow_type"] == "DeployWorkflow"
+    assert fields["detail"] == "RuntimeError"

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -289,7 +289,7 @@ async def test_approve(mock_signal):
 
 @pytest.mark.asyncio
 async def test_approve_emits_identity_aware_audit_log(mocker):
-    """Workflow action middleware logs the normalized caller identity."""
+    """Identity-aware audit fields guard the required middleware ordering."""
     mocker.patch("nv_config_manager.temporal.api.workflow_v1.signal_workflow")
     audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
     workflow_id = str(uuid4())

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -210,8 +210,9 @@ async def test_cache_workflow_input(mock_redis, mock_load_config):
 @patch("nv_config_manager.temporal.api.workflow_v1.get_client")
 @patch("nv_config_manager.temporal.api.workflow_v1.uuid4", return_value="mockuuid")
 @patch("nv_config_manager.temporal.api.workflow_v1.RBACConfig")
-async def test_hello_world_workflow(mock_rbac_config, mock_uuid, mock_get_client):
+async def test_hello_world_workflow(mock_rbac_config, mock_uuid, mock_get_client, mocker):
     """Verify HelloWorld Workflow API."""
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
     # Mock Temporal client
     handle = MagicMock()
     handle.id = "mockuuid"
@@ -231,6 +232,11 @@ async def test_hello_world_workflow(mock_rbac_config, mock_uuid, mock_get_client
         "id": "mockuuid",
         "href": f"{TEMPORAL_UI_WORKFLOW_BASE}/mockuuid",
     }
+    audit_fields = audit_logger.info.call_args.kwargs["extra"]
+    assert audit_fields["action"] == "hello_world"
+    assert audit_fields["outcome"] == "success"
+    assert audit_fields["workflow_id"] == "mockuuid"
+    assert audit_fields["workflow_type"] == "HelloWorld"
 
 
 @pytest.mark.asyncio
@@ -279,6 +285,32 @@ async def test_approve(mock_signal):
         "approve",
         ReviewSignalInput(stage_name="prompt", user="anonymous"),
     )
+
+
+@pytest.mark.asyncio
+async def test_approve_emits_identity_aware_audit_log(mocker):
+    """Workflow action middleware logs the normalized caller identity."""
+    mocker.patch("nv_config_manager.temporal.api.workflow_v1.signal_workflow")
+    audit_logger = mocker.patch("nv_config_manager.temporal.api.audit.logger")
+    workflow_id = str(uuid4())
+
+    rsp = TestClient(app).post(
+        f"/v1/workflow/{workflow_id}/approve/prompt",
+        headers={
+            "X-Auth-Request-Email": "operator@example.com",
+            "X-Auth-Request-User": "operator",
+            "X-Auth-Request-Groups": "nvcm-network",
+        },
+    )
+
+    assert rsp.status_code == 200
+    audit_fields = audit_logger.info.call_args.kwargs["extra"]
+    assert audit_fields["action"] == "approve"
+    assert audit_fields["actor"] == "operator"
+    assert audit_fields["roles"] == ["all", "nvcm-network"]
+    assert audit_fields["source"] == "sso"
+    assert audit_fields["workflow_id"] == workflow_id
+    assert audit_fields["stage_name"] == "prompt"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Add centralized structured audit logging for Workflow API actions so operational accounting is consistent without changing RBAC policy or API behavior.

The audit event captures the actor, UTC timestamp, normalized roles, authentication source, action target, workflow metadata, and outcome for:

- approve, reject, retry, and terminate lifecycle actions
- workflow starts, including deploy, reprovision, and device/site password rotation

The authentication middleware now exposes the trusted identity source on request state, and the logging adapter preserves per-call structured fields alongside its category. Reason capture is intentionally out of scope.

## Validation

- Launch an approval workflow with auth, approve it, confirm logs
```
{"message": "Workflow action hello_world_approval finished with outcome success", "levelname": "INFO", "name": "nv_config_manager.temporal.api.audit", "asctime": "2026-07-22 20:03:04,741", "module": "log", "lineno": 229, "level": "info", "service": "temporal-api", "category": "temporal.audit", "event_type": "workflow_action", "action": "hello_world_approval", "outcome": "success", "actor": "nvcm-admin", "roles": ["all", "default-roles-nv-config-manager", "nvcm-admin", "nvcm-network", "offline_access", "uma_authorization"], "source": "jwt", "timestamp": "2026-07-22T20:03:04.741680+00:00", "workflow_id": "bbd6d1cb-8e5d-4238-a878-65d6ce6adb42", "workflow_type": "HelloWorldApproval", "stage_name": null, "target": "hello_world_approval", "detail": null}
{"message": "Workflow action approve finished with outcome success", "levelname": "INFO", "name": "nv_config_manager.temporal.api.audit", "asctime": "2026-07-22 20:04:30,467", "module": "log", "lineno": 229, "level": "info", "service": "temporal-api", "category": "temporal.audit", "event_type": "workflow_action", "action": "approve", "outcome": "success", "actor": "nvcm-admin", "roles": ["all", "default-roles-nv-config-manager", "nvcm-admin", "nvcm-network", "offline_access", "uma_authorization"], "source": "jwt", "timestamp": "2026-07-22T20:04:30.467835+00:00", "workflow_id": "bbd6d1cb-8e5d-4238-a878-65d6ce6adb42", "workflow_type": null, "stage_name": "prompt", "target": "/v1/workflow/bbd6d1cb-8e5d-4238-a878-65d6ce6adb42/approve/prompt", "detail": null}
```
- Reject a workflow:
```
{"message": "Workflow action hello_world_approval finished with outcome success", "levelname": "INFO", "name": "nv_config_manager.temporal.api.audit", "asctime": "2026-07-22 20:03:11,591", "module": "log", "lineno": 229, "level": "info", "service": "temporal-api", "category": "temporal.audit", "event_type": "workflow_action", "action": "hello_world_approval", "outcome": "success", "actor": "nvcm-admin", "roles": ["all", "default-roles-nv-config-manager", "nvcm-admin", "nvcm-network", "offline_access", "uma_authorization"], "source": "jwt", "timestamp": "2026-07-22T20:03:11.591615+00:00", "workflow_id": "2d81f583-b19e-4a43-833e-94732522471f", "workflow_type": "HelloWorldApproval", "stage_name": null, "target": "hello_world_approval", "detail": null}
{"message": "Workflow action reject finished with outcome success", "levelname": "INFO", "name": "nv_config_manager.temporal.api.audit", "asctime": "2026-07-22 20:05:07,095", "module": "log", "lineno": 229, "level": "info", "service": "temporal-api", "category": "temporal.audit", "event_type": "workflow_action", "action": "reject", "outcome": "success", "actor": "nvcm-admin", "roles": ["all", "default-roles-nv-config-manager", "nvcm-admin", "nvcm-network", "offline_access", "uma_authorization"], "source": "jwt", "timestamp": "2026-07-22T20:05:07.095176+00:00", "workflow_id": "2d81f583-b19e-4a43-833e-94732522471f", "workflow_type": null, "stage_name": "prompt", "target": "/v1/workflow/2d81f583-b19e-4a43-833e-94732522471f/reject/prompt", "detail": null}
```
- Retry a stage
```
{"message": "Workflow action hello_world_approval finished with outcome success", "levelname": "INFO", "name": "nv_config_manager.temporal.api.audit", "asctime": "2026-07-22 20:03:18,423", "module": "log", "lineno": 229, "level": "info", "service": "temporal-api", "category": "temporal.audit", "event_type": "workflow_action", "action": "hello_world_approval", "outcome": "success", "actor": "nvcm-admin", "roles": ["all", "default-roles-nv-config-manager", "nvcm-admin", "nvcm-network", "offline_access", "uma_authorization"], "source": "jwt", "timestamp": "2026-07-22T20:03:18.423695+00:00", "workflow_id": "c0231514-fa4f-4a8d-898d-1c4228926763", "workflow_type": "HelloWorldApproval", "stage_name": null, "target": "hello_world_approval", "detail": null}
{"message": "Workflow action retry finished with outcome success", "levelname": "INFO", "name": "nv_config_manager.temporal.api.audit", "asctime": "2026-07-22 20:06:51,602", "module": "log", "lineno": 229, "level": "info", "service": "temporal-api", "category": "temporal.audit", "event_type": "workflow_action", "action": "retry", "outcome": "success", "actor": "nvcm-admin", "roles": ["all", "default-roles-nv-config-manager", "nvcm-admin", "nvcm-network", "offline_access", "uma_authorization"], "source": "jwt", "timestamp": "2026-07-22T20:06:51.602006+00:00", "workflow_id": "c0231514-fa4f-4a8d-898d-1c4228926763", "workflow_type": null, "stage_name": "prompt", "target": "/v1/workflow/c0231514-fa4f-4a8d-898d-1c4228926763/retry/prompt", "detail": null}
```
- Request rejected
```
{"message": "Workflow action terminate finished with outcome failure", "levelname": "INFO", "name": "nv_config_manager.temporal.api.audit", "asctime": "2026-07-22 20:07:33,804", "module": "log", "lineno": 229, "level": "info", "service": "temporal-api", "category": "temporal.audit", "event_type": "workflow_action", "action": "terminate", "outcome": "failure", "actor": "nvcm-admin", "roles": ["all", "default-roles-nv-config-manager", "nvcm-admin", "nvcm-network", "offline_access", "uma_authorization"], "source": "jwt", "timestamp": "2026-07-22T20:07:33.804348+00:00", "workflow_id": "not-a-real-workflow", "workflow_type": null, "stage_name": null, "target": "/v1/workflow/not-a-real-workflow/terminate", "detail": "HTTP 404"}
```
- RBAC denial
```
{"message": "Workflow action hello_world finished with outcome denied", "levelname": "INFO", "name": "nv_config_manager.temporal.api.audit", "asctime": "2026-07-22 20:08:37,563", "module": "log", "lineno": 229, "level": "info", "service": "temporal-api", "category": "temporal.audit", "event_type": "workflow_action", "action": "hello_world", "outcome": "denied", "actor": "nvcm-readonly", "roles": ["all", "default-roles-nv-config-manager", "nvcm-readonly", "offline_access", "uma_authorization"], "source": "jwt", "timestamp": "2026-07-22T20:08:37.563517+00:00", "workflow_id": null, "workflow_type": "HelloWorld", "stage_name": null, "target": "hello_world", "detail": "HTTP 403"}
```

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`a82dc7c`](https://github.com/NVIDIA/nv-config-manager/commit/a82dc7c0eab2e7b240d07ba3acfbc18d88f74078) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/29954232070).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. (Not applicable: structured server logging only.)
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs. (No generated contract changes.)
