### PR TITLE
fix(ci): publish Temporal release images

### DIFF
--- a/.gitlab/ci/deploy.yml
+++ b/.gitlab/ci/deploy.yml
@@ -80,6 +80,9 @@ update-image-tags:
     - yq -i '.global.images.keaAdmin.tag = "'$NEW_VERSION'"' $VALUES_FILE_PATH
     - yq -i '.global.images.nautobot.tag = "'$NEW_VERSION'"' $VALUES_FILE_PATH
     - yq -i '.global.images.natsReady.tag = "'$NEW_VERSION'"' $VALUES_FILE_PATH
+    - yq -i '.global.images.temporalServer.tag = "'$NEW_VERSION'"' $VALUES_FILE_PATH
+    - yq -i '.global.images.temporalBootstrap.tag = "'$NEW_VERSION'"' $VALUES_FILE_PATH
+    - yq -i '.global.images.temporalUi.tag = "'$NEW_VERSION'"' $VALUES_FILE_PATH
     - git diff -- deploy/helm/Chart.yaml $VALUES_FILE_PATH
     - echo "Skipping commit/push so the mirror does not diverge from upstream."
 

--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -112,6 +112,9 @@ include:
             - nv-config-manager-ui
             - nv-config-manager-nautobot
             - nv-config-manager-nats-ready
+            - nv-config-manager-temporal
+            - nv-config-manager-temporal-bootstrap
+            - nv-config-manager-temporal-ui
           PULSE_CONTAINER_SCANNER_PLATFORM:
             - linux/amd64
             - linux/arm64

--- a/.gitlab/ci/release.yml
+++ b/.gitlab/ci/release.yml
@@ -265,6 +265,9 @@ update-version:
     - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-ui:$NEW_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-ui:$CI_COMMIT_SHORT_SHA
     - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-nautobot:$NEW_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-nautobot:$CI_COMMIT_SHORT_SHA
     - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-nats-ready:$NEW_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-nats-ready:$CI_COMMIT_SHORT_SHA
+    - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal:$NEW_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal:$CI_COMMIT_SHORT_SHA
+    - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-bootstrap:$NEW_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-bootstrap:$CI_COMMIT_SHORT_SHA
+    - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-ui:$NEW_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-ui:$CI_COMMIT_SHORT_SHA
     - |
       if [ "${NEW_VERSION#*-}" = "$NEW_VERSION" ]; then
         echo "Creating latest tags for stable release $NEW_VERSION..."
@@ -274,6 +277,9 @@ update-version:
         docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-ui:latest $IMAGE_REPOSITORY_BASE/nv-config-manager-ui:$NEW_VERSION
         docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-nautobot:latest $IMAGE_REPOSITORY_BASE/nv-config-manager-nautobot:$NEW_VERSION
         docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-nats-ready:latest $IMAGE_REPOSITORY_BASE/nv-config-manager-nats-ready:$NEW_VERSION
+        docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal:latest $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal:$NEW_VERSION
+        docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-bootstrap:latest $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-bootstrap:$NEW_VERSION
+        docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-ui:latest $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-ui:$NEW_VERSION
       else
         echo "Skipping latest tags for prerelease $NEW_VERSION"
       fi
@@ -286,6 +292,9 @@ update-version:
     - docker buildx imagetools inspect $IMAGE_REPOSITORY_BASE/nv-config-manager-ui:$NEW_VERSION
     - docker buildx imagetools inspect $IMAGE_REPOSITORY_BASE/nv-config-manager-nautobot:$NEW_VERSION
     - docker buildx imagetools inspect $IMAGE_REPOSITORY_BASE/nv-config-manager-nats-ready:$NEW_VERSION
+    - docker buildx imagetools inspect $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal:$NEW_VERSION
+    - docker buildx imagetools inspect $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-bootstrap:$NEW_VERSION
+    - docker buildx imagetools inspect $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-ui:$NEW_VERSION
   needs:
     - job: release-version
       artifacts: true
@@ -463,6 +472,9 @@ promote-docker-images:
     - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-ui:$PROMOTE_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-ui:$RC_VERSION
     - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-nautobot:$PROMOTE_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-nautobot:$RC_VERSION
     - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-nats-ready:$PROMOTE_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-nats-ready:$RC_VERSION
+    - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal:$PROMOTE_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal:$RC_VERSION
+    - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-bootstrap:$PROMOTE_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-bootstrap:$RC_VERSION
+    - docker buildx imagetools create -t $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-ui:$PROMOTE_VERSION $IMAGE_REPOSITORY_BASE/nv-config-manager-temporal-ui:$RC_VERSION
     - echo "✅ Docker images promoted to $PROMOTE_VERSION"
   needs:
     - job: determine-promote-version

--- a/.gitlab/ci/scripts/update_helm_image_values.sh
+++ b/.gitlab/ci/scripts/update_helm_image_values.sh
@@ -25,5 +25,11 @@ yq -i '
   .global.images.nautobot.repository = strenv(NVCM_IMAGE_REPOSITORY) + "/nv-config-manager-nautobot" |
   .global.images.nautobot.tag = strenv(NVCM_IMAGE_TAG) |
   .global.images.natsReady.repository = strenv(NVCM_IMAGE_REPOSITORY) + "/nv-config-manager-nats-ready" |
-  .global.images.natsReady.tag = strenv(NVCM_IMAGE_TAG)
+  .global.images.natsReady.tag = strenv(NVCM_IMAGE_TAG) |
+  .global.images.temporalServer.repository = strenv(NVCM_IMAGE_REPOSITORY) + "/nv-config-manager-temporal" |
+  .global.images.temporalServer.tag = strenv(NVCM_IMAGE_TAG) |
+  .global.images.temporalBootstrap.repository = strenv(NVCM_IMAGE_REPOSITORY) + "/nv-config-manager-temporal-bootstrap" |
+  .global.images.temporalBootstrap.tag = strenv(NVCM_IMAGE_TAG) |
+  .global.images.temporalUi.repository = strenv(NVCM_IMAGE_REPOSITORY) + "/nv-config-manager-temporal-ui" |
+  .global.images.temporalUi.tag = strenv(NVCM_IMAGE_TAG)
 ' "$values_file"


### PR DESCRIPTION
## Description

Update helm charts for the new temporal images.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run because this is limited to release CI configuration and Helm value rewriting; it does not change application code, chart templates, or runtime behavior.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

No user-facing documentation or generated-artifact updates are required for this release-pipeline-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Temporal service image support across release, promotion, and deployment workflows.
  - Temporal Server, Bootstrap, and UI images now get consistent multi-architecture versioning and stable release tags.
  - Helm deployments now automatically align Temporal image repositories and tags.
- **Bug Fixes**
  - Expanded image scanning and manifest verification to include all Temporal service images, improving release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->