### PR TITLE
fix(helm): apply image pull secrets to Temporal pods

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -276,6 +276,53 @@ jobs:
             grep -nE 'temporal\.api|cors_origins' /tmp/nvcm-helm.yaml || true
             exit 1
           fi
+      - name: Project-owned image pull secrets render
+        run: |
+          set -euo pipefail
+          image_args=()
+          for image_name in nvConfigManager nvConfigManagerUi kea keaAdmin nautobot natsReady temporalServer temporalBootstrap temporalUi; do
+            image_args+=(--set-string "global.images.${image_name}.repository=private.registry.test/${image_name}")
+          done
+          helm template test deploy/helm/ \
+            --values deploy/helm/values-ci.yaml \
+            --set-string 'global.imagePullSecrets[0]=image-pull-secret-test' \
+            "${image_args[@]}" >/tmp/nvcm-private-images.yaml
+          awk '
+            BEGIN { RS = "---"; checked = 0; failed = 0 }
+            {
+              if ($0 !~ /kind: (Pod|Deployment|StatefulSet|DaemonSet|Job|CronJob)/) next
+              if ($0 !~ /image:[[:space:]]*"?private\.registry\.test\//) next
+              checked++
+              kind = "unknown"
+              name = "unknown"
+              line_count = split($0, lines, "\n")
+              in_metadata = 0
+              for (i = 1; i <= line_count; i++) {
+                if (lines[i] ~ /^kind:[[:space:]]+/) {
+                  kind = lines[i]
+                  sub(/^kind:[[:space:]]+/, "", kind)
+                }
+                if (lines[i] == "metadata:") {
+                  in_metadata = 1
+                  continue
+                }
+                if (in_metadata && lines[i] ~ /^  name:[[:space:]]+/) {
+                  name = lines[i]
+                  sub(/^  name:[[:space:]]+/, "", name)
+                  break
+                }
+                if (in_metadata && lines[i] ~ /^[^[:space:]]/) in_metadata = 0
+              }
+              if ($0 !~ /imagePullSecrets:/ || $0 !~ /- name: image-pull-secret-test/) {
+                printf "ERROR: %s/%s uses a project-owned image without imagePullSecrets\n", kind, name
+                failed++
+              }
+            }
+            END {
+              printf "%d workload(s) using project-owned images checked; %d missing imagePullSecrets\n", checked, failed
+              if (checked == 0 || failed != 0) exit 1
+            }
+          ' /tmp/nvcm-private-images.yaml
       - name: Probe SLO customLabels render
         run: |
           # Blackbox Probe samples don't inherit the CR's metadata.labels, so

--- a/deploy/helm/templates/temporal.yaml
+++ b/deploy/helm/templates/temporal.yaml
@@ -74,6 +74,12 @@ spec:
         {{- include "nv-config-manager.spiffe.annotations" (dict "root" $ "app" $temporalName) | nindent 8 }}
         {{- end }}
     spec:
+      {{- if $.Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
@@ -744,6 +750,12 @@ spec:
         {{- include "nv-config-manager.spiffe.annotations" (dict "root" . "app" (printf "%s-web" $temporalName)) | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       {{- include "nv-config-manager.podSecurityContext" . | nindent 6 }}
       {{- include "nv-config-manager.scheduling" .Values.temporal.devUi | nindent 6 }}
       containers:


### PR DESCRIPTION
## Description

Render `global.imagePullSecrets` on the Temporal server and web pod specs. 

Add a regression test to check that all pods that reference an NVCM image have a configured secret.

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run locally because it loads local images into Kind and does not exercise authenticated pulls from the private registry. Helm lint plus the new render assertion directly validate the changed pod specs.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

No user-facing documentation or generated-artifact updates are required for this chart-template fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Helm deployments for Temporal services and the Web UI now honor configured image pull secrets.
  - Improved deployment reliability in environments requiring private container registry credentials.

- **Tests**
  - Added automated validation that the rendered Temporal workloads include the required image pull secret configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->