### PR TITLE
fix: improve jwks caching behavior when multiple JWT providers present

### DIFF
--- a/components/nautobot/nv_config_manager_auth/jwt_authentication.py
+++ b/components/nautobot/nv_config_manager_auth/jwt_authentication.py
@@ -162,6 +162,13 @@ def _load_jwt_providers() -> list[JwtProviderConfig]:
 
 _jwks_clients: dict[str, pyjwt.PyJWKClient] = {}
 _jwks_lock = threading.Lock()
+_jwks_signing_key_locks: dict[str, threading.Lock] = {}
+
+# PyJWT owns the cached response and refreshes immediately for a previously
+# unseen key ID, so key rotation does not wait for this normal cache lifetime.
+# A per-URI lock prevents a cold or expired cache from stampeding a rate-limited
+# issuer before its first response repopulates the shared key-set cache.
+JWKS_KEYSET_CACHE_LIFESPAN_SECONDS = 600
 
 
 def _get_jwks_client(jwks_uri: str) -> pyjwt.PyJWKClient:
@@ -178,9 +185,23 @@ def _get_jwks_client(jwks_uri: str) -> pyjwt.PyJWKClient:
         client = _jwks_clients.get(jwks_uri)
         if client is not None:
             return client
-        client = pyjwt.PyJWKClient(jwks_uri, cache_jwk_set=True, lifespan=600)
+        client = pyjwt.PyJWKClient(
+            jwks_uri,
+            cache_jwk_set=True,
+            lifespan=JWKS_KEYSET_CACHE_LIFESPAN_SECONDS,
+        )
         _jwks_clients[jwks_uri] = client
         return client
+
+
+def _get_jwks_signing_key_lock(jwks_uri: str) -> threading.Lock:
+    """Return the lock that serializes a JWKS cache miss for one URI."""
+    with _jwks_lock:
+        lock = _jwks_signing_key_locks.get(jwks_uri)
+        if lock is None:
+            lock = threading.Lock()
+            _jwks_signing_key_locks[jwks_uri] = lock
+        return lock
 
 
 def _get_spiffe_jwks_uri() -> str:
@@ -201,7 +222,9 @@ def _get_signing_key_from_jwks(jwks_uri: str, token: str) -> pyjwt.PyJWK:
     re-read on each call so key rotations are picked up immediately.
     """
     if jwks_uri.startswith(("http://", "https://")):
-        return _get_jwks_client(jwks_uri).get_signing_key_from_jwt(token)
+        client = _get_jwks_client(jwks_uri)
+        with _get_jwks_signing_key_lock(jwks_uri):
+            return client.get_signing_key_from_jwt(token)
 
     bundle_path = Path(jwks_uri)
     jwks_data = json.loads(bundle_path.read_text())
@@ -437,6 +460,44 @@ def _extract_token(request: Request) -> str | None:
     return request.COOKIES.get(cookie_name)
 
 
+def _unverified_jwt_claims(token: str) -> dict[str, Any] | None:
+    """Return unverified claims used only to select a configured validator.
+
+    The selected validator still verifies the signature, issuer, audience, and
+    expiry.  Issuer selection stops a token from forcing PyJWT to refresh every
+    unrelated provider's JWKS key set when its ``kid`` is absent there.
+    """
+    try:
+        claims = pyjwt.decode(
+            token,
+            options={
+                "verify_signature": False,
+                "verify_aud": False,
+                "verify_exp": False,
+                "verify_iat": False,
+                "verify_iss": False,
+                "verify_nbf": False,
+            },
+        )
+    except pyjwt.exceptions.PyJWTError:
+        return None
+    return claims if isinstance(claims, dict) else None
+
+
+def _unverified_jwt_issuer(token: str) -> str | None:
+    """Return a token issuer for provider selection, without trusting it."""
+    claims = _unverified_jwt_claims(token)
+    issuer = claims.get("iss") if claims else None
+    return issuer if isinstance(issuer, str) and issuer else None
+
+
+def _is_spiffe_jwt(token: str) -> bool:
+    """Return whether an unverified token has the required SPIFFE subject shape."""
+    claims = _unverified_jwt_claims(token)
+    subject = claims.get("sub") if claims else None
+    return isinstance(subject, str) and subject.startswith("spiffe://")
+
+
 # ── Validation methods ────────────────────────────────────────────────────
 
 
@@ -448,6 +509,8 @@ def _try_spiffe(token: str) -> tuple[Any, str] | None:
 
     audiences = _get_spiffe_audiences()
     if not audiences:
+        return None
+    if not _is_spiffe_jwt(token):
         return None
 
     try:
@@ -476,8 +539,7 @@ def _try_spiffe(token: str) -> tuple[Any, str] | None:
 def _try_jwt_provider(token: str, provider: JwtProviderConfig) -> tuple[Any, str] | None:
     """Validate *token* against a single JWT provider."""
     try:
-        jwks_client = _get_jwks_client(provider.jwks_uri)
-        signing_key = jwks_client.get_signing_key_from_jwt(token)
+        signing_key = _get_signing_key_from_jwks(provider.jwks_uri, token)
 
         options: dict[str, Any] = {}
         if not provider.audiences:
@@ -553,7 +615,8 @@ class NVConfigManagerJWTAuthentication(BaseAuthentication):
     Validation (in order):
 
       1. SPIFFE JWT-SVID (via PyJWT + JWKS)
-      2. Each configured JWT provider (via PyJWT + JWKS)
+      2. The configured JWT provider matching the token's unverified issuer
+         (via PyJWT + JWKS)
 
     Providers with ``user_provider: true`` create individual Django users
     from JWT claims (for OIDC / browser users).  All other providers map
@@ -567,7 +630,7 @@ class NVConfigManagerJWTAuthentication(BaseAuthentication):
     keyword = "Bearer"
 
     def authenticate(self, request: Request) -> tuple[Any, str] | None:
-        """Authenticate *request*, trying SPIFFE then each configured JWT provider.
+        """Authenticate *request*, trying SPIFFE then the issuer-matched JWT provider.
 
         Returns a ``(user, auth)`` tuple on success, or ``None`` to fall
         through to the next authenticator when no token is present or no
@@ -582,9 +645,18 @@ class NVConfigManagerJWTAuthentication(BaseAuthentication):
         if result is not None:
             return result
 
-        # 2. Try each JWT provider
+        # 2. Try only the provider named by the unverified issuer. The
+        # selected provider still verifies the issuer and signature; this only
+        # avoids refreshing unrelated JWKS endpoints for every request.
         providers = _get_providers()
+        if not providers:
+            return None
+        issuer = _unverified_jwt_issuer(token)
+        if issuer is None:
+            return None
         for provider in providers:
+            if provider.issuer != issuer:
+                continue
             result = _try_jwt_provider(token, provider)
             if result is not None:
                 return result

--- a/components/nautobot/nv_config_manager_auth/jwt_authentication.py
+++ b/components/nautobot/nv_config_manager_auth/jwt_authentication.py
@@ -195,7 +195,7 @@ def _get_jwks_client(jwks_uri: str) -> pyjwt.PyJWKClient:
 
 
 def _get_jwks_signing_key_lock(jwks_uri: str) -> threading.Lock:
-    """Return the lock that serializes a JWKS cache miss for one URI."""
+    """Return the lock that serializes signing-key resolution for one URI."""
     with _jwks_lock:
         lock = _jwks_signing_key_locks.get(jwks_uri)
         if lock is None:

--- a/components/nautobot/tests/test_jwt_authentication.py
+++ b/components/nautobot/tests/test_jwt_authentication.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 import contextlib
 import json
 import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -878,12 +881,47 @@ class TestGetJwksClient:
         mod = _import_module()
         mod._jwks_clients.clear()
 
+    def test_serializes_cold_keyset_fetches(self):
+        mod = _import_module()
+        mod._jwks_signing_key_locks.clear()
+
+        class ColdCacheClient:
+            def __init__(self):
+                self.cached = False
+                self.fetches = 0
+                self.lock = Lock()
+
+            def get_signing_key_from_jwt(self, token):
+                if not self.cached:
+                    with self.lock:
+                        self.fetches += 1
+                    time.sleep(0.01)
+                    self.cached = True
+                return MagicMock()
+
+        client = ColdCacheClient()
+        with patch.object(mod, "_get_jwks_client", return_value=client):
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                list(
+                    executor.map(
+                        lambda _: mod._get_signing_key_from_jwks("https://idp.example.com/jwks", "token"),
+                        range(8),
+                    )
+                )
+
+        assert client.fetches == 1
+        mod._jwks_signing_key_locks.clear()
+
         with patch.object(mod.pyjwt, "PyJWKClient") as mock_cls:
             mock_cls.return_value = MagicMock()
             c1 = mod._get_jwks_client("https://example.com/jwks")
             c2 = mod._get_jwks_client("https://example.com/jwks")
             assert c1 is c2
-            mock_cls.assert_called_once()
+            mock_cls.assert_called_once_with(
+                "https://example.com/jwks",
+                cache_jwk_set=True,
+                lifespan=mod.JWKS_KEYSET_CACHE_LIFESPAN_SECONDS,
+            )
 
         mod._jwks_clients.clear()
 
@@ -1058,6 +1096,7 @@ class TestNVConfigManagerJWTAuthentication:
         monkeypatch.setattr(mod, "_extract_token", lambda r: "token")
         monkeypatch.setattr(mod, "_try_spiffe", lambda t: None)
         monkeypatch.setattr(mod, "_get_providers", lambda: [provider])
+        monkeypatch.setattr(mod, "_unverified_jwt_issuer", lambda t: provider.issuer)
         monkeypatch.setattr(
             mod,
             "_try_jwt_provider",
@@ -1067,6 +1106,39 @@ class TestNVConfigManagerJWTAuthentication:
         auth = mod.NVConfigManagerJWTAuthentication()
         result = auth.authenticate(MagicMock())
         assert result == (mock_user, "oidc:jdoe")
+
+    def test_tries_only_provider_matching_unverified_issuer(self, monkeypatch, mock_user):
+        mod = _import_module()
+        other = mod.JwtProviderConfig(
+            name="other",
+            issuer="https://other.example.com",
+            audiences=["aud"],
+            jwks_uri="https://other.example.com/jwks",
+        )
+        starfleet = mod.JwtProviderConfig(
+            name="starfleet",
+            issuer="https://starfleet.example.com",
+            audiences=["aud"],
+            jwks_uri="https://starfleet.example.com/jwks",
+        )
+        attempted: list[str] = []
+
+        def try_provider(token, provider):
+            attempted.append(provider.name)
+            if provider is starfleet:
+                return (mock_user, "starfleet:operator")
+            return None
+
+        monkeypatch.setattr(mod, "_extract_token", lambda r: "token")
+        monkeypatch.setattr(mod, "_try_spiffe", lambda t: None)
+        monkeypatch.setattr(mod, "_get_providers", lambda: [other, starfleet])
+        monkeypatch.setattr(mod, "_unverified_jwt_issuer", lambda t: starfleet.issuer)
+        monkeypatch.setattr(mod, "_try_jwt_provider", try_provider)
+
+        result = mod.NVConfigManagerJWTAuthentication().authenticate(MagicMock())
+
+        assert result == (mock_user, "starfleet:operator")
+        assert attempted == ["starfleet"]
 
     def test_returns_none_when_no_provider_matches(self, monkeypatch):
         mod = _import_module()

--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -31,10 +31,10 @@ INI sections::
     claim_user = preferred_username
     claim_groups = roles
 
-    [auth.jwt.ssa]
-    issuer = https://example.ssa.nvidia.com
-    audiences = s:my-audience
-    jwks_uri = https://example.ssa.nvidia.com/.well-known/jwks.json
+    [auth.jwt.service]
+    issuer = https://service-idp.example.com
+    audiences = service-api
+    jwks_uri = https://service-idp.example.com/.well-known/jwks.json
     claim_email = sub
     claim_user = sub
     claim_groups = scopes
@@ -391,10 +391,56 @@ def _extract_bearer_token(request: Request) -> str | None:
     return request.cookies.get(cfg.cookie_name)
 
 
+def _unverified_jwt_claims(token: str) -> dict[str, Any] | None:
+    """Return unverified claims used only to select a configured validator.
+
+    The returned claims must never grant access.  Signature, issuer, audience,
+    and expiry validation still happens in the selected provider below.  Reading
+    the issuer first prevents a token from causing PyJWT to refresh every
+    unrelated provider's JWKS key set when its ``kid`` is absent there.
+    """
+    try:
+        claims = pyjwt.decode(
+            token,
+            options={
+                "verify_signature": False,
+                "verify_aud": False,
+                "verify_exp": False,
+                "verify_iat": False,
+                "verify_iss": False,
+                "verify_nbf": False,
+            },
+        )
+    except pyjwt.exceptions.PyJWTError:
+        return None
+    return claims if isinstance(claims, dict) else None
+
+
+def _unverified_jwt_issuer(token: str) -> str | None:
+    """Return a token issuer for provider selection, without trusting it."""
+    claims = _unverified_jwt_claims(token)
+    issuer = claims.get("iss") if claims else None
+    return issuer if isinstance(issuer, str) and issuer else None
+
+
+def _is_spiffe_jwt(token: str) -> bool:
+    """Return whether an unverified token has the required SPIFFE subject shape."""
+    claims = _unverified_jwt_claims(token)
+    subject = claims.get("sub") if claims else None
+    return isinstance(subject, str) and subject.startswith("spiffe://")
+
+
 # ── OIDC / JWT validation (multi-issuer) ─────────────────────────────────
 
 _jwks_clients: dict[str, pyjwt.PyJWKClient] = {}
 _jwks_lock = threading.Lock()
+_jwks_signing_key_locks: dict[str, threading.Lock] = {}
+
+# PyJWT owns the cached response and refreshes immediately for a previously
+# unseen key ID, so key rotation does not wait for this normal cache lifetime.
+# A per-URI lock prevents a cold or expired cache from stampeding a rate-limited
+# issuer before its first response repopulates the shared key-set cache.
+JWKS_KEYSET_CACHE_LIFESPAN_SECONDS = 600
 
 _JWT_ALGORITHMS = ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]
 
@@ -408,9 +454,23 @@ def _get_jwks_client(jwks_uri: str) -> pyjwt.PyJWKClient:
         client = _jwks_clients.get(jwks_uri)
         if client is not None:
             return client
-        client = pyjwt.PyJWKClient(jwks_uri, cache_jwk_set=True, lifespan=600)
+        client = pyjwt.PyJWKClient(
+            jwks_uri,
+            cache_jwk_set=True,
+            lifespan=JWKS_KEYSET_CACHE_LIFESPAN_SECONDS,
+        )
         _jwks_clients[jwks_uri] = client
         return client
+
+
+def _get_jwks_signing_key_lock(jwks_uri: str) -> threading.Lock:
+    """Return the lock that serializes a JWKS cache miss for one URI."""
+    with _jwks_lock:
+        lock = _jwks_signing_key_locks.get(jwks_uri)
+        if lock is None:
+            lock = threading.Lock()
+            _jwks_signing_key_locks[jwks_uri] = lock
+        return lock
 
 
 def _try_jwt_provider(
@@ -419,8 +479,7 @@ def _try_jwt_provider(
 ) -> SSOIdentity | None:
     """Attempt to validate *token* against a single JWT provider."""
     try:
-        jwks_client = _get_jwks_client(provider.jwks_uri)
-        signing_key = jwks_client.get_signing_key_from_jwt(token)
+        signing_key = _get_signing_key_from_jwks(provider.jwks_uri, token)
 
         options = JWTDecodeOptions()
         if not provider.audiences:
@@ -462,9 +521,10 @@ def _try_jwt_provider(
 def identity_from_jwt(request: Request) -> SSOIdentity | None:
     """Validate JWT from Authorization header or cookie against all providers.
 
-    Iterates through every configured ``[auth.jwt.*]`` provider and returns
-    the first successful match.  Returns ``None`` when no provider is
-    configured, no token is present, or no provider accepts the token.
+    The unverified issuer selects a configured ``[auth.jwt.*]`` provider;
+    that provider then verifies the token and returns the identity.  Returns
+    ``None`` when no provider is configured, no token is present, or no
+    provider accepts the token.
     """
     cfg = load_auth_config()
     if not cfg.jwt_providers:
@@ -474,7 +534,13 @@ def identity_from_jwt(request: Request) -> SSOIdentity | None:
     if not token:
         return None
 
+    issuer = _unverified_jwt_issuer(token)
+    if issuer is None:
+        return None
+
     for provider in cfg.jwt_providers:
+        if provider.issuer != issuer:
+            continue
         identity = _try_jwt_provider(token, provider)
         if identity is not None:
             return identity
@@ -491,7 +557,9 @@ def _get_signing_key_from_jwks(jwks_uri: str, token: str) -> pyjwt.PyJWK:
     re-read on each call so key rotations are picked up immediately.
     """
     if jwks_uri.startswith(("http://", "https://")):
-        return _get_jwks_client(jwks_uri).get_signing_key_from_jwt(token)
+        client = _get_jwks_client(jwks_uri)
+        with _get_jwks_signing_key_lock(jwks_uri):
+            return client.get_signing_key_from_jwt(token)
 
     bundle_path = Path(jwks_uri)
     jwks_data = json.loads(bundle_path.read_text())
@@ -547,6 +615,8 @@ def identity_from_spiffe(request: Request) -> SSOIdentity | None:
 
     token = _extract_bearer_token(request)
     if not token:
+        return None
+    if not _is_spiffe_jwt(token):
         return None
 
     try:

--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -464,7 +464,7 @@ def _get_jwks_client(jwks_uri: str) -> pyjwt.PyJWKClient:
 
 
 def _get_jwks_signing_key_lock(jwks_uri: str) -> threading.Lock:
-    """Return the lock that serializes a JWKS cache miss for one URI."""
+    """Return the lock that serializes signing-key resolution for one URI."""
     with _jwks_lock:
         lock = _jwks_signing_key_locks.get(jwks_uri)
         if lock is None:

--- a/src/tests/common/test_auth.py
+++ b/src/tests/common/test_auth.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 from configparser import ConfigParser
+from threading import Lock
 from unittest.mock import MagicMock, patch
 
 import jwt as pyjwt
@@ -30,9 +32,13 @@ from starlette.testclient import TestClient as StarletteClient
 
 import nv_config_manager.common.auth as auth_mod
 from nv_config_manager.common.auth import (
+    JWKS_KEYSET_CACHE_LIFESPAN_SECONDS,
     SSOIdentity,
     _derive_jwks_uri,
+    _get_jwks_client,
+    _get_signing_key_from_jwks,
     _jwks_clients,
+    _jwks_signing_key_locks,
     _spiffe_id_to_workload_name,
     extract_identity,
     identity_from_sso_headers,
@@ -79,11 +85,13 @@ def _inject_config(config: ConfigParser):
 def _clear_caches():
     """Reset module-level caches between tests."""
     _jwks_clients.clear()
+    _jwks_signing_key_locks.clear()
     auth_mod._auth_config = None
     auth_mod._auth_config_source = None
     auth_mod._auth_config_tracks_file = False
     yield
     _jwks_clients.clear()
+    _jwks_signing_key_locks.clear()
     auth_mod._auth_config = None
     auth_mod._auth_config_source = None
     auth_mod._auth_config_tracks_file = False
@@ -190,10 +198,10 @@ class TestConfigLoading:
                     "issuer": "https://login.microsoftonline.com/t/v2.0",
                     "audiences": "api://app1",
                 },
-                "auth.jwt.ssa": {
-                    "issuer": "https://ssa.example.com",
-                    "audiences": "s:my-aud",
-                    "jwks_uri": "https://ssa.example.com/.well-known/jwks.json",
+                "auth.jwt.service": {
+                    "issuer": "https://service-idp.example.com",
+                    "audiences": "service-api",
+                    "jwks_uri": "https://service-idp.example.com/.well-known/jwks.json",
                     "claim_email": "sub",
                     "claim_user": "sub",
                     "claim_groups": "scopes",
@@ -203,10 +211,10 @@ class TestConfigLoading:
         cfg = load_auth_config(cp)
         assert len(cfg.jwt_providers) == 2
         names = {p.name for p in cfg.jwt_providers}
-        assert names == {"azure", "ssa"}
-        ssa = next(p for p in cfg.jwt_providers if p.name == "ssa")
-        assert ssa.claim_email == "sub"
-        assert ssa.jwks_uri == "https://ssa.example.com/.well-known/jwks.json"
+        assert names == {"azure", "service"}
+        service = next(p for p in cfg.jwt_providers if p.name == "service")
+        assert service.claim_email == "sub"
+        assert service.jwks_uri == "https://service-idp.example.com/.well-known/jwks.json"
 
     def test_spiffe_section_parsed(self):
         """[auth.spiffe] section is parsed into SpiffeConfig."""
@@ -541,11 +549,11 @@ class TestIdentityFromJwt:
         assert "read" in data["groups"]
         assert "write" in data["groups"]
 
-    def test_multi_issuer_first_match_wins(self, rsa_keypair, make_jwt, client):
-        """With multiple providers, the first one whose issuer matches wins."""
+    def test_multi_issuer_only_fetches_matching_provider_jwks(self, rsa_keypair, make_jwt, client):
+        """A token must not refresh JWKS sets for providers with another issuer."""
         claims = {
-            "iss": "https://ssa.example.com",
-            "aud": "s:my-aud",
+            "iss": "https://service-idp.example.com",
+            "aud": "service-api",
             "sub": "bot-1",
             "scopes": ["deploy"],
             "exp": int(time.time()) + 300,
@@ -563,10 +571,10 @@ class TestIdentityFromJwt:
                     "audiences": "api://app",
                     "jwks_uri": "https://azure.jwks",
                 },
-                "auth.jwt.ssa": {
-                    "issuer": "https://ssa.example.com",
-                    "audiences": "s:my-aud",
-                    "jwks_uri": "https://ssa.example.com/jwks",
+                "auth.jwt.service": {
+                    "issuer": "https://service-idp.example.com",
+                    "audiences": "service-api",
+                    "jwks_uri": "https://service-idp.example.com/jwks",
                     "claim_email": "sub",
                     "claim_user": "sub",
                     "claim_groups": "scopes",
@@ -584,7 +592,7 @@ class TestIdentityFromJwt:
             mock_client_ok.get_signing_key_from_jwt.return_value = mock_jwk
 
             def _pick(uri):
-                if "ssa" in uri:
+                if "service-idp" in uri:
                     return mock_client_ok
                 return mock_client_fail
 
@@ -596,6 +604,78 @@ class TestIdentityFromJwt:
         assert data["email"] == "bot-1"
         assert data["source"] == "jwt"
         assert "deploy" in data["groups"]
+        mock_get_client.assert_called_once_with("https://service-idp.example.com/jwks")
+
+    def test_non_spiffe_jwt_does_not_fetch_spiffe_jwks(self, make_jwt, client):
+        """Ordinary JWTs do not force a SPIFFE JWKS lookup before JWT auth."""
+        token = make_jwt(
+            {
+                "iss": "https://idp.example.com",
+                "sub": "operator",
+                "exp": int(time.time()) + 300,
+                "iat": int(time.time()),
+            }
+        )
+        cp = _make_config(
+            **{
+                "auth.spiffe": {
+                    "jwks_uri": "https://spire.example.com/keys",
+                    "audiences": "spiffe://cluster.local",
+                },
+            }
+        )
+        auth_mod._auth_config = load_auth_config(cp)
+
+        with patch("nv_config_manager.common.auth._get_jwks_client") as mock_get_client:
+            response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+
+        assert response.json() == {"identity": None}
+        mock_get_client.assert_not_called()
+
+
+class TestJwksClientCache:
+    def test_enables_keyset_cache(self):
+        with patch.object(auth_mod.pyjwt, "PyJWKClient") as mock_client_class:
+            mock_client_class.return_value = MagicMock()
+
+            first = _get_jwks_client("https://idp.example.com/jwks")
+            second = _get_jwks_client("https://idp.example.com/jwks")
+
+        assert first is second
+        mock_client_class.assert_called_once_with(
+            "https://idp.example.com/jwks",
+            cache_jwk_set=True,
+            lifespan=JWKS_KEYSET_CACHE_LIFESPAN_SECONDS,
+        )
+
+    def test_serializes_cold_keyset_fetches(self):
+        class ColdCacheClient:
+            def __init__(self) -> None:
+                self.cached = False
+                self.fetches = 0
+                self.lock = Lock()
+
+            def get_signing_key_from_jwt(self, token: str) -> MagicMock:
+                if not self.cached:
+                    with self.lock:
+                        self.fetches += 1
+                    time.sleep(0.01)
+                    self.cached = True
+                return MagicMock()
+
+        client = ColdCacheClient()
+        with patch("nv_config_manager.common.auth._get_jwks_client", return_value=client):
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                list(
+                    executor.map(
+                        lambda _: _get_signing_key_from_jwks(
+                            "https://idp.example.com/jwks", "token"
+                        ),
+                        range(8),
+                    )
+                )
+
+        assert client.fetches == 1
 
 
 # ── identity_from_spiffe tests ───────────────────────────────────────────

--- a/src/tests/dhcp/test_api.py
+++ b/src/tests/dhcp/test_api.py
@@ -178,10 +178,10 @@ def make_auth_config_with_jwt_provider() -> AuthConfig:
     return AuthConfig(
         jwt_providers=(
             JwtProviderConfig(
-                name="ssa",
-                issuer="https://ssa.example.com",
+                name="service",
+                issuer="https://service-idp.example.com",
                 audiences=["s:nv-config-manager"],
-                jwks_uri="https://ssa.example.com/jwks",
+                jwks_uri="https://service-idp.example.com/jwks",
                 claim_email="sub",
                 claim_user="sub",
                 claim_groups="scopes",
@@ -436,7 +436,7 @@ def test_get_config_accepts_non_oidc_jwt_provider():
 
     token, public_key = make_jwt_token(
         {
-            "iss": "https://ssa.example.com",
+            "iss": "https://service-idp.example.com",
             "aud": "s:nv-config-manager",
             "sub": "service-account",
             "scopes": ["nv-config-manager"],


### PR DESCRIPTION
## Description

Resolve poor performance seen when validating JWT from a secondary provider

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`2efea8d`](https://github.com/NVIDIA/nv-config-manager/commit/2efea8d3b178e46807002dbecabb996117b3a51e) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30021161389).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved multi-provider JWT authentication by selecting the provider matching the token’s issuer.
  * Added early validation for SPIFFE tokens before performing full authentication.
* **Bug Fixes**
  * Prevented duplicate concurrent JWKS key fetches by serializing refreshes per JWKS endpoint.
  * Improved JWKS client caching with a configurable cache lifespan.
  * Avoided unnecessary JWKS lookups for non-SPIFFE tokens.
* **Documentation**
  * Added configuration examples for JWT service authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->