### PR TITLE
fix(common): time out in-cluster Nautobot requests

### DIFF
--- a/src/nv_config_manager/common/config.py
+++ b/src/nv_config_manager/common/config.py
@@ -26,7 +26,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from configparser import ConfigParser, SectionProxy
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import certifi
 import nats
@@ -653,7 +653,13 @@ def pynautobot_client() -> Any:
         kwargs["verify"] = nb_config["ca_cert_path"]
 
     connection = pynautobot.api(**kwargs)
-    connection.http_session.mount("https://", TimeoutHTTPAdapter(timeout=10))
+    for protocol in ("http://", "https://"):
+        existing_adapter = cast(HTTPAdapter, connection.http_session.get_adapter(protocol))
+        retry_policy = existing_adapter.max_retries
+        connection.http_session.mount(
+            protocol,
+            TimeoutHTTPAdapter(timeout=10, max_retries=retry_policy),
+        )
     return connection
 
 

--- a/src/tests/common/test_config.py
+++ b/src/tests/common/test_config.py
@@ -19,10 +19,12 @@ from configparser import ConfigParser
 from unittest.mock import patch
 
 from nv_config_manager.common.config import (
+    TimeoutHTTPAdapter,
     _read_spiffe_jwt,
     clear_config_cache,
     get_internal_auth_headers,
     load_config,
+    pynautobot_client,
     reload_config,
 )
 
@@ -117,6 +119,27 @@ class TestLoadConfig:
 
         assert second is not first
         assert second["dynamic"]["value"] == "one"
+
+
+class TestPynautobotClient:
+    """Tests for the synchronous Nautobot API client."""
+
+    def test_configures_timeout_and_retries_for_http_and_https(self):
+        config = ConfigParser()
+        config["nautobot"] = {
+            "server": "http://nautobot",
+            "token": "test-token",
+            "retries": "3",
+        }
+
+        with patch("nv_config_manager.common.config.load_config", return_value=config):
+            connection = pynautobot_client()
+
+        for protocol in ("http://", "https://"):
+            adapter = connection.http_session.get_adapter(protocol)
+            assert isinstance(adapter, TimeoutHTTPAdapter)
+            assert adapter.timeout == 10
+            assert adapter.max_retries.total == 3
 
 
 class TestGetInternalAuthHeaders:


### PR DESCRIPTION
## Description

Prevent the render template-updater from hanging indefinitely when it calls an in-cluster Nautobot service over HTTP.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run. It does not simulate a Nautobot worker accepting a connection without returning a response; the focused unit test directly verifies the timeout adapter on the affected HTTP and HTTPS transports.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. Not applicable; this is an internal resilience fix.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs. Not applicable; no generated inputs changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applied consistent 10-second request timeouts to both HTTP and HTTPS connections.
  * Preserved the configured retry settings for each protocol when applying the timeout adapter.

* **Tests**
  * Added coverage to verify timeout and retry behavior for both HTTP and HTTPS connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->