### PR TITLE
fix(dhcp): reconcile KEA config using native config hash

### DIFF
--- a/src/nv_config_manager/dhcp/cli.py
+++ b/src/nv_config_manager/dhcp/cli.py
@@ -225,10 +225,11 @@ async def _apply_and_verify_kea_config(
     applied_hash = await kea_client.set_config(config, version=ip_version)
     try:
         effective_hash = await kea_client.get_config_hash(version=ip_version)
-    except KeaException as exc:
+    except (KeaException, TimeoutError) as exc:
         # config-set already succeeded, so the desired config is applied and
-        # persisted -- only the verification read failed. The refresh loop
-        # tolerates this same failure, and aborting here would instead crash-loop
+        # persisted -- only the verification read failed. get_config_hash
+        # re-raises TimeoutError (it does not wrap it in KeaException), and the
+        # refresh loop already swallows both. Aborting here would crash-loop
         # the sidecar over a config that is actually applied. Returning None
         # leaves the next drift check to reapply and re-verify.
         logger.warning(f"Could not verify the applied KEA configuration hash: {exc}")

--- a/src/nv_config_manager/dhcp/cli.py
+++ b/src/nv_config_manager/dhcp/cli.py
@@ -26,7 +26,7 @@ import click
 
 from nv_config_manager.common.config import load_config
 from nv_config_manager.common.log import LogCategory, configure_logging, get_logger
-from nv_config_manager.dhcp.kea import KeaClient
+from nv_config_manager.dhcp.kea import KeaClient, KeaException
 from nv_config_manager.dhcp.kea_dhcp_confgen import generate_config, inject_lease_db_config
 from nv_config_manager.dhcp.metrics import DHCP_CACHE_REFRESH_ERRORS
 from nv_config_manager.dhcp.nautobot import NautobotClient
@@ -208,6 +208,31 @@ def refresh_kea_configuration(
     asyncio.run(_refresh_loop_async(ip_version, check, refresh_interval))
 
 
+async def _apply_and_verify_kea_config(
+    kea_client: KeaClient,
+    config: dict[str, Any],
+    ip_version: int,
+) -> str | None:
+    """Apply the desired configuration to KEA and return its verified hash.
+
+    KEA (2.4+) returns the SHA-256 hash of the effective configuration from
+    ``config-set``. Before treating the sync as successful, the running
+    configuration is confirmed against that hash via ``config-hash-get`` so a
+    configuration that was rolled back or only partially applied surfaces as an
+    error rather than being silently trusted. The verified effective hash is
+    returned to track for subsequent drift detection.
+    """
+    applied_hash = await kea_client.set_config(config, version=ip_version)
+    effective_hash = await kea_client.get_config_hash(version=ip_version)
+    if applied_hash is not None and effective_hash != applied_hash:
+        raise KeaException(
+            f"KEA effective configuration hash ({effective_hash}) does not match "
+            f"the hash returned by config-set ({applied_hash}); "
+            "the configuration was not applied cleanly."
+        )
+    return effective_hash
+
+
 async def _sync_kea_configuration_async(
     ip_version: int,
     refresh_interval: int,
@@ -232,9 +257,10 @@ async def _sync_kea_configuration_async(
         # so that secrets are not stored in the Redis cache
         config = inject_lease_db_config(config, ip_version)
 
-        # Run once
+        # Run once. The startup path always applies the desired Redis config and
+        # captures a fresh effective hash, which keeps a config-sync restart safe.
         logger.info(f"Setting initial KEA DHCPv{ip_version} Configuration from Redis.")
-        await kea_client.set_config(config, version=ip_version)
+        expected_hash = await _apply_and_verify_kea_config(kea_client, config, ip_version)
 
         if refresh_interval:
             logger.info(
@@ -254,10 +280,29 @@ async def _sync_kea_configuration_async(
                     new_config = inject_lease_db_config(new_config, ip_version)
                     if new_config != previous_config:
                         logger.info("Configuration changed, updating KEA DHCP Configuration.")
-                        await kea_client.set_config(new_config, version=ip_version)
+                        expected_hash = await _apply_and_verify_kea_config(
+                            kea_client, new_config, ip_version
+                        )
                         previous_config = new_config
-                    elif debug:
-                        logger.info("No configuration changes detected.")
+                    else:
+                        # Redis is unchanged, but KEA (e.g. the Kea container) may
+                        # have restarted from its bootstrap config while this
+                        # sidecar kept running. Compare KEA's effective config hash
+                        # against the last applied hash and reapply on drift.
+                        running_hash = await kea_client.get_config_hash(version=ip_version)
+                        if running_hash != expected_hash:
+                            logger.warning(
+                                "KEA running configuration hash (%s) does not match the "
+                                "expected hash (%s); reapplying desired configuration "
+                                "(KEA may have restarted).",
+                                running_hash,
+                                expected_hash,
+                            )
+                            expected_hash = await _apply_and_verify_kea_config(
+                                kea_client, previous_config, ip_version
+                            )
+                        elif debug:
+                            logger.info("No configuration changes detected.")
                 except Exception as exc:
                     DHCP_CACHE_REFRESH_ERRORS.labels(ip_version=str(ip_version)).inc()
                     logger.error(f"Error refreshing the KEA config: {exc}")

--- a/src/nv_config_manager/dhcp/cli.py
+++ b/src/nv_config_manager/dhcp/cli.py
@@ -223,7 +223,16 @@ async def _apply_and_verify_kea_config(
     returned to track for subsequent drift detection.
     """
     applied_hash = await kea_client.set_config(config, version=ip_version)
-    effective_hash = await kea_client.get_config_hash(version=ip_version)
+    try:
+        effective_hash = await kea_client.get_config_hash(version=ip_version)
+    except KeaException as exc:
+        # config-set already succeeded, so the desired config is applied and
+        # persisted -- only the verification read failed. The refresh loop
+        # tolerates this same failure, and aborting here would instead crash-loop
+        # the sidecar over a config that is actually applied. Returning None
+        # leaves the next drift check to reapply and re-verify.
+        logger.warning(f"Could not verify the applied KEA configuration hash: {exc}")
+        return None
     if applied_hash is not None and effective_hash != applied_hash:
         raise KeaException(
             f"KEA effective configuration hash ({effective_hash}) does not match "

--- a/src/nv_config_manager/dhcp/kea.py
+++ b/src/nv_config_manager/dhcp/kea.py
@@ -122,8 +122,13 @@ class KeaClient:
                 "KEA Request timed out, are you running within a KEA Docker Container?"
             ) from exc
 
-    async def set_config(self, configuration: dict[str, Any], version: int = 4) -> None:
-        """Set the KEA DHCP Configuration."""
+    async def set_config(self, configuration: dict[str, Any], version: int = 4) -> str | None:
+        """Set the KEA DHCP Configuration.
+
+        Returns the SHA-256 hash of the effective configuration reported by KEA
+        (Kea 2.4+ returns this digest from ``config-set``). ``None`` is returned
+        when the running KEA server predates hash support and omits it.
+        """
         session = await self._get_session()
         try:
             # Set configuration in memory
@@ -136,6 +141,7 @@ class KeaClient:
                 result = await rsp.json()
                 if result[0]["result"] != 0:
                     raise KeaException(f"Failed to set configuration: {result[0]['text']}")
+                config_hash: str | None = result[0].get("arguments", {}).get("hash")
 
             # Persist configuration to disk
             data = {
@@ -150,6 +156,34 @@ class KeaClient:
                         f"Failed to persist updated configuration to disk: {result[0]['text']}"
                     )
 
+            return config_hash
+
+        except TimeoutError as exc:
+            raise TimeoutError(
+                "KEA Request timed out, are you running within a KEA Docker Container?"
+            ) from exc
+
+    async def get_config_hash(self, version: int = 4) -> str | None:
+        """Return the SHA-256 hash of the running KEA DHCP Configuration.
+
+        Uses KEA's ``config-hash-get`` command (Kea 2.4+) to detect configuration
+        drift cheaply, without comparing full ``config-get`` output (which
+        contains KEA-generated defaults). ``None`` is returned when the running
+        KEA server predates hash support and omits the digest.
+        """
+        data = {
+            "command": "config-hash-get",
+            "service": [f"dhcp{version}"],
+        }
+        session = await self._get_session()
+        try:
+            async with session.post(self.url, json=data) as rsp:
+                result = await rsp.json()
+                if result[0]["result"] != 0:
+                    raise KeaException(f"Failed to get configuration hash: {result[0]['text']}")
+                arguments: dict[str, Any] = result[0].get("arguments", {})
+                config_hash: str | None = arguments.get("hash")
+                return config_hash
         except TimeoutError as exc:
             raise TimeoutError(
                 "KEA Request timed out, are you running within a KEA Docker Container?"

--- a/src/tests/dhcp/test_cli.py
+++ b/src/tests/dhcp/test_cli.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the DHCP sync loop's hash-based reconciliation with KEA."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from nv_config_manager.dhcp import cli
+from nv_config_manager.dhcp.kea import KeaException
+
+DESIRED_CONFIG: dict[str, Any] = {"Dhcp4": {"subnet4": ["desired"]}}
+CHANGED_CONFIG: dict[str, Any] = {"Dhcp4": {"subnet4": ["changed"]}}
+
+
+class _StopLoop(Exception):
+    """Sentinel raised from a patched asyncio.sleep to exit the sync loop."""
+
+
+def _patch_clients(
+    mocker: Any,
+    *,
+    load_kea_config: AsyncMock,
+    set_config: AsyncMock,
+    get_config_hash: AsyncMock,
+) -> tuple[AsyncMock, AsyncMock]:
+    """Wire mock KEA/Redis clients into the sync loop under test."""
+    kea_client = AsyncMock()
+    kea_client.set_config = set_config
+    kea_client.get_config_hash = get_config_hash
+    kea_client.close = AsyncMock()
+
+    redis_client = AsyncMock()
+    redis_client.load_kea_config = load_kea_config
+    redis_client.close = AsyncMock()
+
+    mocker.patch.object(cli.KeaClient, "from_config", return_value=kea_client)
+    mocker.patch.object(cli.RedisClient, "from_config", return_value=redis_client)
+    # Keep configs comparable: skip lease-db secret injection.
+    mocker.patch.object(cli, "inject_lease_db_config", side_effect=lambda cfg, ver: cfg)
+    return kea_client, redis_client
+
+
+def _patch_sleep_to_break(mocker: Any) -> AsyncMock:
+    """Patch asyncio.sleep so the loop's tail sleep raises to break the loop."""
+    return mocker.patch.object(cli.asyncio, "sleep", side_effect=_StopLoop)
+
+
+async def test_matching_hash_does_not_reapply(mocker: Any) -> None:
+    """When Redis is unchanged and KEA's hash matches, nothing is reapplied."""
+    load_kea_config = AsyncMock(side_effect=[DESIRED_CONFIG, DESIRED_CONFIG])
+    set_config = AsyncMock(return_value="HASH_A")
+    get_config_hash = AsyncMock(return_value="HASH_A")
+    kea_client, _ = _patch_clients(
+        mocker,
+        load_kea_config=load_kea_config,
+        set_config=set_config,
+        get_config_hash=get_config_hash,
+    )
+    _patch_sleep_to_break(mocker)
+
+    with pytest.raises(_StopLoop):
+        await cli._sync_kea_configuration_async(ip_version=4, refresh_interval=5, debug=False)
+
+    # Only the unconditional startup apply happened; no reapply on match.
+    set_config.assert_awaited_once_with(DESIRED_CONFIG, version=4)
+    kea_client.close.assert_awaited_once()
+
+
+async def test_mismatched_hash_reapplies(mocker: Any) -> None:
+    """When Redis is unchanged but KEA's hash drifts, the config is reapplied."""
+    load_kea_config = AsyncMock(side_effect=[DESIRED_CONFIG, DESIRED_CONFIG])
+    set_config = AsyncMock(return_value="HASH_A")
+    # startup verify -> drift detected -> reapply verify
+    get_config_hash = AsyncMock(side_effect=["HASH_A", "DRIFT_HASH", "HASH_A"])
+    kea_client, _ = _patch_clients(
+        mocker,
+        load_kea_config=load_kea_config,
+        set_config=set_config,
+        get_config_hash=get_config_hash,
+    )
+    _patch_sleep_to_break(mocker)
+
+    with pytest.raises(_StopLoop):
+        await cli._sync_kea_configuration_async(ip_version=4, refresh_interval=5, debug=False)
+
+    # Startup apply + reapply on drift, both with the desired config.
+    assert set_config.await_args_list == [
+        call(DESIRED_CONFIG, version=4),
+        call(DESIRED_CONFIG, version=4),
+    ]
+
+
+async def test_kea_restart_bootstrap_recovery_with_unchanged_redis(mocker: Any) -> None:
+    """A KEA restart to bootstrap config is recovered even when Redis is unchanged.
+
+    This is the EKS-upgrade failure mode: the Kea container restarts from its
+    bootstrap /etc/kea/kea-dhcp4.conf while the sidecar keeps running, so Redis
+    never changes. The loop must still detect the effective-hash drift and
+    reapply the desired configuration.
+    """
+    load_kea_config = AsyncMock(side_effect=[DESIRED_CONFIG, DESIRED_CONFIG])
+    set_config = AsyncMock(return_value="DESIRED_HASH")
+    # startup verify -> bootstrap hash after Kea restart -> reapply verify
+    get_config_hash = AsyncMock(side_effect=["DESIRED_HASH", "BOOTSTRAP_HASH", "DESIRED_HASH"])
+    kea_client, _ = _patch_clients(
+        mocker,
+        load_kea_config=load_kea_config,
+        set_config=set_config,
+        get_config_hash=get_config_hash,
+    )
+    _patch_sleep_to_break(mocker)
+
+    with pytest.raises(_StopLoop):
+        await cli._sync_kea_configuration_async(ip_version=4, refresh_interval=5, debug=False)
+
+    assert set_config.await_count == 2
+    assert set_config.await_args_list[-1] == call(DESIRED_CONFIG, version=4)
+
+
+async def test_redis_changed_reapplies_new_config(mocker: Any) -> None:
+    """When the desired config in Redis changes, the new config is applied."""
+    load_kea_config = AsyncMock(side_effect=[DESIRED_CONFIG, CHANGED_CONFIG])
+    set_config = AsyncMock(side_effect=["HASH_A", "HASH_B"])
+    get_config_hash = AsyncMock(side_effect=["HASH_A", "HASH_B"])
+    kea_client, _ = _patch_clients(
+        mocker,
+        load_kea_config=load_kea_config,
+        set_config=set_config,
+        get_config_hash=get_config_hash,
+    )
+    _patch_sleep_to_break(mocker)
+
+    with pytest.raises(_StopLoop):
+        await cli._sync_kea_configuration_async(ip_version=4, refresh_interval=5, debug=False)
+
+    assert set_config.await_args_list == [
+        call(DESIRED_CONFIG, version=4),
+        call(CHANGED_CONFIG, version=4),
+    ]
+
+
+async def test_config_set_failure_propagates(mocker: Any) -> None:
+    """A failed initial config-set aborts the sync loop with a KeaException."""
+    load_kea_config = AsyncMock(return_value=DESIRED_CONFIG)
+    set_config = AsyncMock(side_effect=KeaException("Failed to set configuration: boom"))
+    get_config_hash = AsyncMock(return_value="HASH_A")
+    kea_client, redis_client = _patch_clients(
+        mocker,
+        load_kea_config=load_kea_config,
+        set_config=set_config,
+        get_config_hash=get_config_hash,
+    )
+    _patch_sleep_to_break(mocker)
+
+    with pytest.raises(KeaException, match="Failed to set configuration: boom"):
+        await cli._sync_kea_configuration_async(ip_version=4, refresh_interval=5, debug=False)
+
+    get_config_hash.assert_not_awaited()
+    kea_client.close.assert_awaited_once()
+    redis_client.close.assert_awaited_once()
+
+
+async def test_config_hash_get_failure_is_handled_without_reapply(mocker: Any) -> None:
+    """A config-hash-get failure is counted as an error and does not reapply."""
+    load_kea_config = AsyncMock(side_effect=[DESIRED_CONFIG, DESIRED_CONFIG])
+    set_config = AsyncMock(return_value="HASH_A")
+    # startup verify succeeds; drift check raises.
+    get_config_hash = AsyncMock(
+        side_effect=["HASH_A", KeaException("Failed to get configuration hash: down")]
+    )
+    kea_client, _ = _patch_clients(
+        mocker,
+        load_kea_config=load_kea_config,
+        set_config=set_config,
+        get_config_hash=get_config_hash,
+    )
+    _patch_sleep_to_break(mocker)
+    metric = mocker.patch.object(cli, "DHCP_CACHE_REFRESH_ERRORS", MagicMock())
+
+    with pytest.raises(_StopLoop):
+        await cli._sync_kea_configuration_async(ip_version=4, refresh_interval=5, debug=False)
+
+    # Only the startup apply happened; the hash failure did not trigger a reapply.
+    set_config.assert_awaited_once_with(DESIRED_CONFIG, version=4)
+    metric.labels.assert_called_once_with(ip_version="4")
+    metric.labels.return_value.inc.assert_called_once()

--- a/src/tests/dhcp/test_cli.py
+++ b/src/tests/dhcp/test_cli.py
@@ -198,3 +198,36 @@ async def test_config_hash_get_failure_is_handled_without_reapply(mocker: Any) -
     set_config.assert_awaited_once_with(DESIRED_CONFIG, version=4)
     metric.labels.assert_called_once_with(ip_version="4")
     metric.labels.return_value.inc.assert_called_once()
+
+
+async def test_startup_hash_get_failure_does_not_abort_sync(mocker: Any) -> None:
+    """A config-hash-get failure at startup must not abort the sync loop.
+
+    config-set has already applied and persisted the desired config at that
+    point, so only the verification read failed -- the same failure the refresh
+    loop tolerates. Aborting would crash-loop the sidecar over a config that is
+    actually applied.
+    """
+    load_kea_config = AsyncMock(side_effect=[DESIRED_CONFIG, DESIRED_CONFIG])
+    set_config = AsyncMock(return_value="HASH_A")
+    # Startup verification fails; the later drift check succeeds.
+    get_config_hash = AsyncMock(
+        side_effect=[KeaException("Failed to get configuration hash: down"), "HASH_A"]
+    )
+    _patch_clients(
+        mocker,
+        load_kea_config=load_kea_config,
+        set_config=set_config,
+        get_config_hash=get_config_hash,
+    )
+    _patch_sleep_to_break(mocker)
+
+    # Reaching the loop's tail sleep proves startup was not aborted.
+    with pytest.raises(_StopLoop):
+        await cli._sync_kea_configuration_async(ip_version=4, refresh_interval=5, debug=False)
+
+    # Startup apply, plus a reapply once the unverified hash is re-checked.
+    assert set_config.await_args_list == [
+        call(DESIRED_CONFIG, version=4),
+        call(DESIRED_CONFIG, version=4),
+    ]

--- a/src/tests/dhcp/test_cli.py
+++ b/src/tests/dhcp/test_cli.py
@@ -200,20 +200,29 @@ async def test_config_hash_get_failure_is_handled_without_reapply(mocker: Any) -
     metric.labels.return_value.inc.assert_called_once()
 
 
-async def test_startup_hash_get_failure_does_not_abort_sync(mocker: Any) -> None:
+@pytest.mark.parametrize(
+    "startup_error",
+    [
+        KeaException("Failed to get configuration hash: down"),
+        TimeoutError("KEA Request timed out, are you running within a KEA Docker Container?"),
+    ],
+    ids=["kea_exception", "timeout"],
+)
+async def test_startup_hash_get_failure_does_not_abort_sync(
+    mocker: Any, startup_error: Exception
+) -> None:
     """A config-hash-get failure at startup must not abort the sync loop.
 
     config-set has already applied and persisted the desired config at that
     point, so only the verification read failed -- the same failure the refresh
     loop tolerates. Aborting would crash-loop the sidecar over a config that is
-    actually applied.
+    actually applied. TimeoutError is included because get_config_hash re-raises
+    it instead of wrapping it in KeaException.
     """
     load_kea_config = AsyncMock(side_effect=[DESIRED_CONFIG, DESIRED_CONFIG])
     set_config = AsyncMock(return_value="HASH_A")
     # Startup verification fails; the later drift check succeeds.
-    get_config_hash = AsyncMock(
-        side_effect=[KeaException("Failed to get configuration hash: down"), "HASH_A"]
-    )
+    get_config_hash = AsyncMock(side_effect=[startup_error, "HASH_A"])
     _patch_clients(
         mocker,
         load_kea_config=load_kea_config,

--- a/src/tests/dhcp/test_kea.py
+++ b/src/tests/dhcp/test_kea.py
@@ -18,7 +18,7 @@ from aiohttp import ClientResponseError
 from aioresponses import aioresponses
 from yarl import URL
 
-from nv_config_manager.dhcp.kea import KeaClient
+from nv_config_manager.dhcp.kea import KeaClient, KeaException
 
 
 @pytest.mark.parametrize(
@@ -80,6 +80,86 @@ async def test_get_lease_page_forwards_bounded_request() -> None:
         "service": ["dhcp6"],
         "arguments": {"from": "2001:db8::5", "limit": 75},
     }
+
+
+async def test_set_config_returns_effective_hash() -> None:
+    """Verify set_config surfaces the SHA-256 hash returned by config-set."""
+    config_set_response = [
+        {"result": 0, "text": "Configuration successful.", "arguments": {"hash": "ABC123"}}
+    ]
+    config_write_response = [{"result": 0, "text": "Configuration written."}]
+
+    with aioresponses() as mocked:
+        mocked.post("http://kea.example.com:8000/", payload=config_set_response)
+        mocked.post("http://kea.example.com:8000/", payload=config_write_response)
+        async with KeaClient(host="kea.example.com", port=8000) as client:
+            config_hash = await client.set_config({"Dhcp4": {}}, version=4)
+
+        requests = mocked.requests[("POST", URL("http://kea.example.com:8000/"))]
+
+    assert config_hash == "ABC123"
+    assert requests[0].kwargs["json"]["command"] == "config-set"
+    assert requests[1].kwargs["json"]["command"] == "config-write"
+
+
+async def test_set_config_returns_none_when_hash_absent() -> None:
+    """Verify set_config degrades gracefully on KEA releases without hashes."""
+    config_set_response = [{"result": 0, "text": "Configuration successful."}]
+    config_write_response = [{"result": 0, "text": "Configuration written."}]
+
+    with aioresponses() as mocked:
+        mocked.post("http://kea.example.com:8000/", payload=config_set_response)
+        mocked.post("http://kea.example.com:8000/", payload=config_write_response)
+        async with KeaClient(host="kea.example.com", port=8000) as client:
+            config_hash = await client.set_config({"Dhcp4": {}}, version=4)
+
+    assert config_hash is None
+
+
+async def test_set_config_raises_on_failure() -> None:
+    """Verify a non-zero config-set result raises rather than returning a hash."""
+    config_set_response = [{"result": 1, "text": "boom"}]
+
+    with aioresponses() as mocked:
+        mocked.post("http://kea.example.com:8000/", payload=config_set_response)
+        async with KeaClient(host="kea.example.com", port=8000) as client:
+            with pytest.raises(KeaException, match="Failed to set configuration: boom"):
+                await client.set_config({"Dhcp4": {}}, version=4)
+
+
+async def test_get_config_hash_returns_running_hash() -> None:
+    """Verify get_config_hash issues config-hash-get and returns the digest."""
+    response = [
+        {
+            "result": 0,
+            "text": "Hash of the currently running config",
+            "arguments": {"hash": "DEF456"},
+        }
+    ]
+
+    with aioresponses() as mocked:
+        mocked.post("http://kea.example.com:8000/", payload=response)
+        async with KeaClient(host="kea.example.com", port=8000) as client:
+            config_hash = await client.get_config_hash(version=4)
+
+        request = mocked.requests[("POST", URL("http://kea.example.com:8000/"))][0]
+
+    assert config_hash == "DEF456"
+    assert request.kwargs["json"] == {
+        "command": "config-hash-get",
+        "service": ["dhcp4"],
+    }
+
+
+async def test_get_config_hash_raises_on_failure() -> None:
+    """Verify a non-zero config-hash-get result raises a KeaException."""
+    response = [{"result": 1, "text": "unsupported"}]
+
+    with aioresponses() as mocked:
+        mocked.post("http://kea.example.com:8000/", payload=response)
+        async with KeaClient(host="kea.example.com", port=8000) as client:
+            with pytest.raises(KeaException, match="Failed to get configuration hash: unsupported"):
+                await client.get_config_hash(version=4)
 
 
 async def test_get_statistics_forwards_service_version() -> None:


### PR DESCRIPTION
## Description

Fixes the DHCP recovery failure observed during EKS upgrades. When the `kea` container restarts independently of the `config-sync-v4` sidecar, Kea comes back up on the bootstrap `/etc/kea/kea-dhcp4.conf` (no subnets, default memfile lease DB). Because the desired config in Redis is unchanged, the old sync loop — which only compared the Redis value against its in-process `previous_config` — concluded "nothing changed" and never re-applied to Kea, leaving the pod unhealthy indefinitely.

This switches drift detection to Kea's native SHA-256 effective-config hash (Kea 2.4+), so any loss or modification of the running config is detected and reconciled regardless of whether Redis changed.

- `KeaClient.set_config()` now returns the hash from the `config-set` response (`str | None`; `None` on pre-2.4 Kea).
- New `KeaClient.get_config_hash()` using `config-hash-get`.
- `_sync_kea_configuration_async` retains an `expected_hash`:
  - **Startup:** unconditionally applies the desired Redis config and records the verified hash (restart-safe).
  - **Redis changed:** apply new config, replace `expected_hash`.
  - **Redis unchanged:** compare `config-hash-get` to `expected_hash`; on mismatch (e.g. Kea restarted to bootstrap) re-apply the desired config and update `expected_hash`.
- `_apply_and_verify_kea_config` verifies the effective hash after applying. A `KeaException` or `TimeoutError` on `config-hash-get` after a successful `config-set` is treated as an unverified apply (`None`) so the sidecar does not crash-loop over a config that is already applied.
- Avoids comparing full `config-get` JSON (which contains Kea-generated defaults).

Part 1 of the DHCP config-sync recovery series. Heartbeat liveness (#171), strict traffic gating (#170), and observability (#172) stack on this.

## Validation

- `uv run pytest src/tests/dhcp/test_cli.py` — hash reconcile tests, including startup `KeaException` and `TimeoutError` on `config-hash-get`.
- Local kind: reproduced the Kea-container-restart incident on `main` (0 subnets, `memfile`, pod still Ready, sidecar silent), deployed this branch, and confirmed the sidecar logged a hash mismatch and reapplied within one refresh interval without container restarts.

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The GitHub Kind Integration workflow was not dispatched for this change. The DHCP recovery path was validated on a local kind cluster against a real Kea 2.6 / Redis / CNPG deploy (see the kind write-up on this PR). Full-suite kind CI is not required to exercise this sidecar loop.

<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`9974b3d`](https://github.com/NVIDIA/nv-config-manager/commit/9974b3d67e35ebac6f2590cf6fdeeb6a15077ef8) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/31738884557).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability Improvements**
  - KEA synchronization now verifies that applied settings match the running configuration.
  - Automatically detects configuration drift and KEA restarts, then reapplies settings when needed.
  - Configuration updates now expose KEA’s effective configuration hash.
  - Improved handling of synchronization and verification failures, allowing later retries where appropriate.

- **Tests**
  - Added coverage for configuration updates, drift recovery, restarts, unchanged configurations, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->