### PR TITLE
feat(auth): publish SPIFFE credential health metrics

### DIFF
--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -183,6 +183,7 @@ class SpiffeConfig:
     jwks_uri: str
     audiences: list[str]
     group_prefixes: tuple[tuple[str, str], ...] = ()
+    jwt_svid_path: str = ""
 
 
 @dataclass(frozen=True)
@@ -295,6 +296,7 @@ def _load_spiffe_from_ini(config: ConfigParser) -> SpiffeConfig | None:
         jwks_uri=jwks_uri,
         audiences=audiences,
         group_prefixes=tuple(group_prefixes),
+        jwt_svid_path=config.get(section, "jwt_svid_path", fallback=""),
     )
 
 
@@ -944,6 +946,13 @@ def install_identity_probe(
     any other middleware so call order is not important.
     """
     unauthenticated_path_set = frozenset(_normalize_request_path(p) for p in unauthenticated_paths)
+
+    # Register SPIFFE credential health metrics on the shared registry.
+    # Imported here (not at module top) to avoid a circular import: metrics
+    # imports this module for auth-config access.
+    from nv_config_manager.common.metrics import install_spiffe_bundle_metrics
+
+    install_spiffe_bundle_metrics()
 
     if enforce_auth:
         _install_openapi_auth_schema(

--- a/src/nv_config_manager/common/auth.py
+++ b/src/nv_config_manager/common/auth.py
@@ -952,7 +952,12 @@ def install_identity_probe(
     # imports this module for auth-config access.
     from nv_config_manager.common.metrics import install_spiffe_bundle_metrics
 
-    install_spiffe_bundle_metrics()
+    # Registration failure of an ancillary observability feature must never
+    # abort the primary auth wiring (middleware, /whoami, enforcement).
+    try:
+        install_spiffe_bundle_metrics()
+    except Exception:
+        logger.warning("Failed to register SPIFFE credential health metrics", exc_info=True)
 
     if enforce_auth:
         _install_openapi_auth_schema(

--- a/src/nv_config_manager/common/metrics.py
+++ b/src/nv_config_manager/common/metrics.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared Prometheus metrics for SPIFFE credential health.
+
+The spiffe-helper sidecar writes two files into a shared volume that every
+service reads:
+
+* ``bundle.json`` (``[auth.spiffe] jwks_uri``) -- the JWKS **trust bundle**
+  used to validate *inbound* JWT-SVIDs.  It is only rewritten when the SPIRE
+  signing keys rotate (infrequent), so its file age is *not* a useful
+  liveness signal.  What matters is that it is present and parseable.
+* ``jwt-svid`` (``[auth.spiffe] jwt_svid_path``) -- the short-lived JWT-SVID
+  **token** sent on *outbound* service-to-service calls.  spiffe-helper
+  refreshes it on a short cycle, so its ``exp`` claim decaying toward now is
+  the real "SPIFFE auth is about to break" signal (e.g. spiffe-helper died).
+
+These metrics are emitted by a lazy :class:`~prometheus_client.registry.Collector`
+that reads both files at scrape time, so no background poller is needed and
+values always reflect current on-disk state:
+
+Trust bundle (inbound validation health):
+
+* ``nv_config_manager_spiffe_trust_bundle_readable`` -- ``1`` if the bundle
+  file could be read and parsed at scrape time, else ``0``.
+* ``nv_config_manager_spiffe_trust_bundle_keys`` -- number of signing keys in
+  the bundle.  ``0`` means a broken/empty bundle.
+* ``nv_config_manager_spiffe_trust_bundle_earliest_cert_expiry_timestamp_seconds``
+  -- earliest X.509 ``notAfter`` across any key that carries an ``x5c`` chain.
+  Only emitted when the bundle actually contains certificate chains.
+
+JWT-SVID (outbound credential freshness / liveness):
+
+* ``nv_config_manager_spiffe_jwt_svid_readable`` -- ``1`` if the JWT-SVID file
+  could be read and decoded at scrape time, else ``0``.
+* ``nv_config_manager_spiffe_jwt_svid_expiry_timestamp_seconds`` -- unix
+  timestamp of the JWT-SVID ``exp`` claim.  Alert when this approaches now:
+  a healthy deployment shows a sawtooth well in the future, a dead
+  spiffe-helper decays through the current time.
+
+Each file is inspected independently and the collector no-ops for whichever
+source is unconfigured (or, for the trust bundle, served over HTTP with no
+local file to stat).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import jwt as pyjwt
+from cryptography import x509
+from prometheus_client import REGISTRY
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.registry import Collector, CollectorRegistry
+
+from nv_config_manager.common.auth import SpiffeConfig, load_auth_config
+from nv_config_manager.common.log import LogCategory, get_logger
+
+logger = get_logger(__name__, category=LogCategory.AUTH)
+
+_BUNDLE_PREFIX = "nv_config_manager_spiffe_trust_bundle"
+_SVID_PREFIX = "nv_config_manager_spiffe_jwt_svid"
+
+
+def _extract_jwks_keys(raw: str) -> list[dict[str, Any]]:
+    """Parse signing keys from a spiffe-helper trust bundle.
+
+    Mirrors :func:`nv_config_manager.common.auth._get_signing_key_from_jwks`:
+    the bundle is either a raw JWKS (``{"keys": [...]}``) or the Teleport-style
+    ``{domain: base64(JWKS), ...}`` wrapper whose values must be base64-decoded
+    and merged.
+    """
+    data = json.loads(raw)
+    if "keys" in data:
+        return list(data.get("keys") or [])
+
+    merged: list[dict[str, Any]] = []
+    for encoded_jwks in data.values():
+        domain_jwks = json.loads(base64.b64decode(encoded_jwks))
+        merged.extend(domain_jwks.get("keys", []))
+    return merged
+
+
+def _earliest_cert_expiry(keys: list[dict[str, Any]]) -> float | None:
+    """Return the earliest X.509 ``notAfter`` (unix seconds) across ``x5c`` chains.
+
+    Returns ``None`` when no key carries a parseable certificate chain, in
+    which case no expiry metric is emitted (a plain public-key JWKS has no
+    certificate to expire).
+    """
+    earliest: float | None = None
+    for key in keys:
+        chain = key.get("x5c")
+        if not chain:
+            continue
+        try:
+            cert = x509.load_der_x509_certificate(base64.b64decode(chain[0]))
+            not_after = cert.not_valid_after_utc.timestamp()
+        except Exception:
+            logger.debug("Failed to parse x5c certificate from trust bundle", exc_info=True)
+            continue
+        if earliest is None or not_after < earliest:
+            earliest = not_after
+    return earliest
+
+
+class SpiffeCredentialCollector(Collector):
+    """Lazily emits SPIFFE trust-bundle and JWT-SVID health metrics at scrape time."""
+
+    def collect(self) -> Iterator[GaugeMetricFamily]:
+        spiffe = load_auth_config().spiffe
+        if spiffe is None:
+            return
+        yield from self._collect_trust_bundle(spiffe)
+        yield from self._collect_jwt_svid(spiffe)
+
+    def _collect_trust_bundle(self, spiffe: SpiffeConfig) -> Iterator[GaugeMetricFamily]:
+        # Only file-based bundles (written by spiffe-helper) have a local file
+        # to inspect; HTTP JWKS endpoints produce no bundle metrics.
+        if spiffe.jwks_uri.startswith(("http://", "https://")):
+            return
+
+        readable = GaugeMetricFamily(
+            f"{_BUNDLE_PREFIX}_readable",
+            "1 if the SPIFFE trust bundle file could be read and parsed at scrape time, else 0.",
+        )
+        keys_count = GaugeMetricFamily(
+            f"{_BUNDLE_PREFIX}_keys",
+            "Number of signing keys currently present in the SPIFFE trust bundle.",
+        )
+
+        try:
+            keys = _extract_jwks_keys(Path(spiffe.jwks_uri).read_text())
+        except Exception:
+            logger.debug("SPIFFE trust bundle unreadable at %s", spiffe.jwks_uri, exc_info=True)
+            readable.add_metric([], 0.0)
+            yield readable
+            return
+
+        readable.add_metric([], 1.0)
+        keys_count.add_metric([], float(len(keys)))
+        yield readable
+        yield keys_count
+
+        earliest_expiry = _earliest_cert_expiry(keys)
+        if earliest_expiry is not None:
+            cert_expiry = GaugeMetricFamily(
+                f"{_BUNDLE_PREFIX}_earliest_cert_expiry_timestamp_seconds",
+                "Unix timestamp of the earliest x5c certificate notAfter in the trust bundle.",
+            )
+            cert_expiry.add_metric([], earliest_expiry)
+            yield cert_expiry
+
+    def _collect_jwt_svid(self, spiffe: SpiffeConfig) -> Iterator[GaugeMetricFamily]:
+        if not spiffe.jwt_svid_path:
+            return
+
+        readable = GaugeMetricFamily(
+            f"{_SVID_PREFIX}_readable",
+            "1 if the SPIFFE JWT-SVID file could be read and decoded at scrape time, else 0.",
+        )
+
+        try:
+            token = Path(spiffe.jwt_svid_path).read_text().strip()
+            claims = pyjwt.decode(token, options={"verify_signature": False})
+            exp = claims["exp"]
+        except Exception:
+            logger.debug(
+                "SPIFFE JWT-SVID unreadable/undecodable at %s",
+                spiffe.jwt_svid_path,
+                exc_info=True,
+            )
+            readable.add_metric([], 0.0)
+            yield readable
+            return
+
+        readable.add_metric([], 1.0)
+        yield readable
+
+        expiry = GaugeMetricFamily(
+            f"{_SVID_PREFIX}_expiry_timestamp_seconds",
+            "Unix timestamp of the current SPIFFE JWT-SVID 'exp' claim.",
+        )
+        expiry.add_metric([], float(exp))
+        yield expiry
+
+
+_collector: SpiffeCredentialCollector | None = None
+
+
+def install_spiffe_bundle_metrics(registry: CollectorRegistry = REGISTRY) -> None:
+    """Register the SPIFFE credential collector on ``registry`` (idempotent).
+
+    Safe to call from every FastAPI service's auth setup regardless of whether
+    SPIFFE is configured; the collector no-ops at scrape time when there is no
+    local credential to inspect.
+    """
+    global _collector
+    if _collector is not None:
+        return
+    _collector = SpiffeCredentialCollector()
+    registry.register(_collector)

--- a/src/nv_config_manager/common/metrics.py
+++ b/src/nv_config_manager/common/metrics.py
@@ -45,7 +45,8 @@ JWT-SVID (outbound credential freshness / liveness):
 * ``nv_config_manager_spiffe_jwt_svid_readable`` -- ``1`` if the JWT-SVID file
   could be read and decoded at scrape time, else ``0``.
 * ``nv_config_manager_spiffe_jwt_svid_expiry_timestamp_seconds`` -- unix
-  timestamp of the JWT-SVID ``exp`` claim.  Alert when this approaches now:
+  timestamp of the JWT-SVID ``exp`` claim, labelled by ``trust_domain``
+  (derived from the SPIFFE ID in ``sub``).  Alert when this approaches now:
   a healthy deployment shows a sawtooth well in the future, a dead
   spiffe-helper decays through the current time.
 
@@ -94,6 +95,20 @@ def _extract_jwks_keys(raw: str) -> list[dict[str, Any]]:
         domain_jwks = json.loads(base64.b64decode(encoded_jwks))
         merged.extend(domain_jwks.get("keys", []))
     return merged
+
+
+def _trust_domain_from_sub(sub: str) -> str:
+    """Extract the trust domain from a SPIFFE ID (``spiffe://<domain>/<path>``).
+
+    Returns a low-cardinality label value: the trust domain only, never the
+    full workload path, so the metric stays bounded and does not leak the
+    per-workload identity.  Falls back to ``"unknown"`` for a missing or
+    malformed ``sub``.
+    """
+    if not sub.startswith("spiffe://"):
+        return "unknown"
+    domain = sub[len("spiffe://") :].split("/", 1)[0]
+    return domain or "unknown"
 
 
 def _earliest_cert_expiry(keys: list[dict[str, Any]]) -> float | None:
@@ -179,6 +194,7 @@ class SpiffeCredentialCollector(Collector):
             token = Path(spiffe.jwt_svid_path).read_text().strip()
             claims = pyjwt.decode(token, options={"verify_signature": False})
             exp = claims["exp"]
+            trust_domain = _trust_domain_from_sub(str(claims.get("sub", "")))
         except Exception:
             logger.debug(
                 "SPIFFE JWT-SVID unreadable/undecodable at %s",
@@ -195,8 +211,9 @@ class SpiffeCredentialCollector(Collector):
         expiry = GaugeMetricFamily(
             f"{_SVID_PREFIX}_expiry_timestamp_seconds",
             "Unix timestamp of the current SPIFFE JWT-SVID 'exp' claim.",
+            labels=["trust_domain"],
         )
-        expiry.add_metric([], float(exp))
+        expiry.add_metric([trust_domain], float(exp))
         yield expiry
 
 

--- a/src/tests/common/test_metrics.py
+++ b/src/tests/common/test_metrics.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the SPIFFE credential health metrics collector."""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime, timedelta
+
+import jwt as pyjwt
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from prometheus_client import CollectorRegistry, generate_latest
+
+import nv_config_manager.common.metrics as metrics_mod
+from nv_config_manager.common.auth import AuthConfig, SpiffeConfig
+from nv_config_manager.common.metrics import (
+    SpiffeCredentialCollector,
+    install_spiffe_bundle_metrics,
+)
+
+_BUNDLE = "nv_config_manager_spiffe_trust_bundle"
+_SVID = "nv_config_manager_spiffe_jwt_svid"
+
+
+@pytest.fixture(autouse=True)
+def _reset_collector():
+    """Reset the module-level registration guard between tests."""
+    metrics_mod._collector = None
+    yield
+    metrics_mod._collector = None
+
+
+def _use_spiffe_config(monkeypatch: pytest.MonkeyPatch, spiffe: SpiffeConfig | None) -> None:
+    """Force ``metrics.collect()`` to see the given SPIFFE config."""
+    monkeypatch.setattr(
+        metrics_mod,
+        "load_auth_config",
+        lambda *a, **k: AuthConfig(spiffe=spiffe),
+    )
+
+
+def _samples(collector: SpiffeCredentialCollector) -> dict[str, float]:
+    """Flatten a collect() run into a ``{metric_name: value}`` map."""
+    out: dict[str, float] = {}
+    for family in collector.collect():
+        for sample in family.samples:
+            out[sample.name] = sample.value
+    return out
+
+
+def _raw_jwks(num_keys: int = 2) -> str:
+    keys = [{"kty": "RSA", "kid": f"k{i}", "n": "abc", "e": "AQAB"} for i in range(num_keys)]
+    return json.dumps({"keys": keys})
+
+
+def _teleport_bundle(domain: str = "example.org", num_keys: int = 3) -> str:
+    inner = json.dumps({"keys": [{"kty": "RSA", "kid": f"k{i}"} for i in range(num_keys)]}).encode()
+    return json.dumps({domain: base64.b64encode(inner).decode()})
+
+
+# ── No-op cases ───────────────────────────────────────────────────────────
+
+
+def test_no_metrics_when_spiffe_unconfigured(monkeypatch):
+    _use_spiffe_config(monkeypatch, None)
+    assert _samples(SpiffeCredentialCollector()) == {}
+
+
+def test_no_bundle_metrics_for_http_jwks(monkeypatch):
+    spiffe = SpiffeConfig(jwks_uri="https://spire:8443/keys", audiences=["spiffe://td"])
+    _use_spiffe_config(monkeypatch, spiffe)
+    assert _samples(SpiffeCredentialCollector()) == {}
+
+
+# ── Trust bundle (inbound validation health) ──────────────────────────────
+
+
+def test_raw_jwks_bundle_metrics(monkeypatch, tmp_path):
+    bundle = tmp_path / "bundle.json"
+    bundle.write_text(_raw_jwks(num_keys=2))
+    spiffe = SpiffeConfig(jwks_uri=str(bundle), audiences=["spiffe://td"])
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    assert samples[f"{_BUNDLE}_readable"] == 1.0
+    assert samples[f"{_BUNDLE}_keys"] == 2.0
+    # No x5c chains -> no expiry metric; no jwt_svid_path -> no SVID metrics.
+    assert f"{_BUNDLE}_earliest_cert_expiry_timestamp_seconds" not in samples
+    assert f"{_SVID}_readable" not in samples
+    # The misleading bundle-age metric must not be emitted.
+    assert f"{_BUNDLE}_age_seconds" not in samples
+
+
+def test_teleport_wrapped_bundle_key_count(monkeypatch, tmp_path):
+    bundle = tmp_path / "bundle.json"
+    bundle.write_text(_teleport_bundle(num_keys=3))
+    spiffe = SpiffeConfig(jwks_uri=str(bundle), audiences=["spiffe://td"])
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    assert samples[f"{_BUNDLE}_readable"] == 1.0
+    assert samples[f"{_BUNDLE}_keys"] == 3.0
+
+
+def test_missing_bundle_file_reports_unreadable(monkeypatch, tmp_path):
+    spiffe = SpiffeConfig(jwks_uri=str(tmp_path / "absent.json"), audiences=["spiffe://td"])
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    assert samples[f"{_BUNDLE}_readable"] == 0.0
+    assert f"{_BUNDLE}_keys" not in samples
+
+
+def test_malformed_bundle_reports_unreadable(monkeypatch, tmp_path):
+    bundle = tmp_path / "bundle.json"
+    bundle.write_text("not json {")
+    spiffe = SpiffeConfig(jwks_uri=str(bundle), audiences=["spiffe://td"])
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    assert samples[f"{_BUNDLE}_readable"] == 0.0
+
+
+def _make_jwks_with_cert(not_after: datetime) -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(days=1))
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    x5c = base64.b64encode(cert.public_bytes(encoding=serialization.Encoding.DER)).decode()
+    return json.dumps({"keys": [{"kty": "RSA", "kid": "k0", "x5c": [x5c]}]})
+
+
+def test_earliest_cert_expiry_emitted(monkeypatch, tmp_path):
+    not_after = datetime.now(UTC) + timedelta(days=30)
+    bundle = tmp_path / "bundle.json"
+    bundle.write_text(_make_jwks_with_cert(not_after))
+    spiffe = SpiffeConfig(jwks_uri=str(bundle), audiences=["spiffe://td"])
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    emitted = samples[f"{_BUNDLE}_earliest_cert_expiry_timestamp_seconds"]
+    assert emitted == pytest.approx(not_after.timestamp(), abs=1.0)
+
+
+# ── JWT-SVID (outbound credential freshness) ──────────────────────────────
+
+
+def _write_svid(path, exp: datetime) -> None:
+    token = pyjwt.encode(
+        {"sub": "spiffe://td/ns/x/sa/y", "exp": int(exp.timestamp())},
+        "x" * 32,
+        algorithm="HS256",
+    )
+    path.write_text(token)
+
+
+def test_jwt_svid_expiry_emitted(monkeypatch, tmp_path):
+    bundle = tmp_path / "bundle.json"
+    bundle.write_text(_raw_jwks(num_keys=1))
+    svid = tmp_path / "jwt-svid"
+    exp = datetime.now(UTC) + timedelta(minutes=30)
+    _write_svid(svid, exp)
+
+    spiffe = SpiffeConfig(jwks_uri=str(bundle), audiences=["spiffe://td"], jwt_svid_path=str(svid))
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    assert samples[f"{_SVID}_readable"] == 1.0
+    assert samples[f"{_SVID}_expiry_timestamp_seconds"] == pytest.approx(exp.timestamp(), abs=1.0)
+
+
+def test_jwt_svid_unreadable(monkeypatch, tmp_path):
+    svid = tmp_path / "jwt-svid"
+    svid.write_text("not-a-jwt")
+    spiffe = SpiffeConfig(
+        jwks_uri="https://spire:8443/keys", audiences=["spiffe://td"], jwt_svid_path=str(svid)
+    )
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    assert samples[f"{_SVID}_readable"] == 0.0
+    assert f"{_SVID}_expiry_timestamp_seconds" not in samples
+
+
+def test_jwt_svid_missing_file(monkeypatch, tmp_path):
+    spiffe = SpiffeConfig(
+        jwks_uri="https://spire:8443/keys",
+        audiences=["spiffe://td"],
+        jwt_svid_path=str(tmp_path / "absent"),
+    )
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    assert samples[f"{_SVID}_readable"] == 0.0
+
+
+def test_no_svid_metrics_when_path_unset(monkeypatch, tmp_path):
+    bundle = tmp_path / "bundle.json"
+    bundle.write_text(_raw_jwks(num_keys=1))
+    spiffe = SpiffeConfig(jwks_uri=str(bundle), audiences=["spiffe://td"])
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    samples = _samples(SpiffeCredentialCollector())
+    assert f"{_SVID}_readable" not in samples
+    assert f"{_SVID}_expiry_timestamp_seconds" not in samples
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+
+def test_install_is_idempotent_and_scrapeable(monkeypatch, tmp_path):
+    bundle = tmp_path / "bundle.json"
+    bundle.write_text(_raw_jwks(num_keys=1))
+    spiffe = SpiffeConfig(jwks_uri=str(bundle), audiences=["spiffe://td"])
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    registry = CollectorRegistry()
+    install_spiffe_bundle_metrics(registry)
+    first = metrics_mod._collector
+    install_spiffe_bundle_metrics(registry)
+    assert metrics_mod._collector is first  # not re-registered
+
+    output = generate_latest(registry).decode()
+    assert f"{_BUNDLE}_readable" in output
+    assert f"{_BUNDLE}_keys" in output

--- a/src/tests/common/test_metrics.py
+++ b/src/tests/common/test_metrics.py
@@ -65,6 +65,15 @@ def _samples(collector: SpiffeCredentialCollector) -> dict[str, float]:
     return out
 
 
+def _sample_labels(collector: SpiffeCredentialCollector, name: str) -> dict[str, str]:
+    """Return the labels of the (single) sample named ``name``."""
+    for family in collector.collect():
+        for sample in family.samples:
+            if sample.name == name:
+                return dict(sample.labels)
+    raise AssertionError(f"no sample named {name!r}")
+
+
 def _raw_jwks(num_keys: int = 2) -> str:
     keys = [{"kty": "RSA", "kid": f"k{i}", "n": "abc", "e": "AQAB"} for i in range(num_keys)]
     return json.dumps({"keys": keys})
@@ -170,9 +179,9 @@ def test_earliest_cert_expiry_emitted(monkeypatch, tmp_path):
 # ── JWT-SVID (outbound credential freshness) ──────────────────────────────
 
 
-def _write_svid(path, exp: datetime) -> None:
+def _write_svid(path, exp: datetime, sub: str = "spiffe://example.org/ns/x/sa/y") -> None:
     token = pyjwt.encode(
-        {"sub": "spiffe://td/ns/x/sa/y", "exp": int(exp.timestamp())},
+        {"sub": sub, "exp": int(exp.timestamp())},
         "x" * 32,
         algorithm="HS256",
     )
@@ -184,14 +193,32 @@ def test_jwt_svid_expiry_emitted(monkeypatch, tmp_path):
     bundle.write_text(_raw_jwks(num_keys=1))
     svid = tmp_path / "jwt-svid"
     exp = datetime.now(UTC) + timedelta(minutes=30)
-    _write_svid(svid, exp)
+    _write_svid(svid, exp, sub="spiffe://example.org/ns/x/sa/y")
 
     spiffe = SpiffeConfig(jwks_uri=str(bundle), audiences=["spiffe://td"], jwt_svid_path=str(svid))
     _use_spiffe_config(monkeypatch, spiffe)
 
-    samples = _samples(SpiffeCredentialCollector())
+    collector = SpiffeCredentialCollector()
+    samples = _samples(collector)
     assert samples[f"{_SVID}_readable"] == 1.0
     assert samples[f"{_SVID}_expiry_timestamp_seconds"] == pytest.approx(exp.timestamp(), abs=1.0)
+    # trust_domain label carries only the domain, never the workload path.
+    assert _sample_labels(collector, f"{_SVID}_expiry_timestamp_seconds") == {
+        "trust_domain": "example.org"
+    }
+
+
+def test_jwt_svid_trust_domain_unknown_for_malformed_sub(monkeypatch, tmp_path):
+    svid = tmp_path / "jwt-svid"
+    exp = datetime.now(UTC) + timedelta(minutes=30)
+    _write_svid(svid, exp, sub="not-a-spiffe-id")
+    spiffe = SpiffeConfig(
+        jwks_uri="https://spire:8443/keys", audiences=["spiffe://td"], jwt_svid_path=str(svid)
+    )
+    _use_spiffe_config(monkeypatch, spiffe)
+
+    labels = _sample_labels(SpiffeCredentialCollector(), f"{_SVID}_expiry_timestamp_seconds")
+    assert labels == {"trust_domain": "unknown"}
 
 
 def test_jwt_svid_unreadable(monkeypatch, tmp_path):

--- a/src/tests/integration/test_spiffe_metrics.py
+++ b/src/tests/integration/test_spiffe_metrics.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Live-cluster integration tests for the SPIFFE credential health metrics.
+
+These verify the collector wired in ``nv_config_manager.common.metrics`` (via
+``install_identity_probe``) actually surfaces on each service's unauthenticated
+``/metrics`` endpoint, reading the real spiffe-helper artifacts on disk:
+
+1.  ``spiffe_trust_bundle_readable`` / ``_keys`` reflect the JWKS trust bundle
+    that spiffe-helper writes to ``/var/run/secrets/spiffe/bundle.json``.
+2.  ``spiffe_jwt_svid_readable`` / ``_expiry_timestamp_seconds`` reflect the
+    JWT-SVID at ``/var/run/secrets/spiffe/jwt-svid``, and the expiry gauge
+    carries a ``trust_domain`` label matching the SVID's trust domain.
+
+Metrics are scraped *from inside* a nv-config-manager pod via ``kubectl exec`` so the
+scrape shares the same volumes and network path as production. ``/metrics`` is
+unauthenticated, so no token is injected.
+
+Enable with::
+
+    pytest src/tests/integration/test_spiffe_metrics.py \\
+        --spiffe \\
+        --nv-config-manager-namespace nv-config-manager-test01 \\
+        --spiffe-release nv-config-manager-test01
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from collections.abc import Callable
+
+import pytest
+from prometheus_client.parser import text_string_to_metric_families
+
+pytestmark = [pytest.mark.integration, pytest.mark.spiffe]
+
+
+_BUNDLE = "nv_config_manager_spiffe_trust_bundle"
+_SVID = "nv_config_manager_spiffe_jwt_svid"
+
+
+# Every FastAPI service wires the collector through install_identity_probe and
+# exposes it on its own /metrics, so we assert coverage across all of them.
+_SERVICE_CASES = [
+    pytest.param("temporal", "spiffe_temporal_url", id="temporal"),
+    pytest.param("render", "spiffe_render_url", id="render"),
+    pytest.param("ztp", "spiffe_ztp_url", id="ztp"),
+    pytest.param("dhcp", "spiffe_dhcp_url", id="dhcp"),
+    pytest.param("config-store", "spiffe_config_store_url", id="config-store"),
+]
+
+
+def _fetch_script(url: str) -> str:
+    """Return a python snippet that GETs ``url`` and prints the response body."""
+    return (
+        "import urllib.request, sys\n"
+        f"url = {url!r}\n"
+        "req = urllib.request.Request(url)\n"
+        "try:\n"
+        "    with urllib.request.urlopen(req, timeout=8) as r:\n"
+        "        sys.stdout.write('OK\\n')\n"
+        "        sys.stdout.write(r.read().decode())\n"
+        "except urllib.error.HTTPError as e:\n"
+        "    sys.stdout.write(str(e.code) + '\\n')\n"
+        "    sys.stdout.write(e.read().decode())\n"
+    )
+
+
+def _scrape_metrics(
+    runner: Callable[[str], subprocess.CompletedProcess[str]],
+    url: str,
+) -> dict[str, list[tuple[dict[str, str], float]]]:
+    """Scrape ``url`` in-pod and return ``{metric_name: [(labels, value), ...]}``.
+
+    Only ``nv_config_manager_spiffe_*`` samples are retained so the assertions
+    stay focused and the return value small.
+    """
+    result = runner(_fetch_script(f"{url}/metrics"))
+    if result.returncode != 0:
+        pytest.fail(f"kubectl exec failed: rc={result.returncode} stderr={result.stderr.strip()!r}")
+
+    status, _, body = result.stdout.partition("\n")
+    if status.strip() != "OK":
+        pytest.fail(f"/metrics scrape at {url} returned status {status.strip()!r}: {body[:500]!r}")
+
+    out: dict[str, list[tuple[dict[str, str], float]]] = {}
+    for family in text_string_to_metric_families(body):
+        for sample in family.samples:
+            if sample.name.startswith("nv_config_manager_spiffe_"):
+                out.setdefault(sample.name, []).append((dict(sample.labels), sample.value))
+    return out
+
+
+class TestSpiffeMetricsExposed:
+    """The SPIFFE credential collector must surface on every service /metrics."""
+
+    @pytest.mark.parametrize("service,url_fixture", _SERVICE_CASES)
+    def test_trust_bundle_metrics_present(
+        self,
+        request: pytest.FixtureRequest,
+        exec_python_in_spiffe_pod: Callable[[str], subprocess.CompletedProcess[str]],
+        service: str,
+        url_fixture: str,
+    ) -> None:
+        """Trust-bundle health must be readable with at least one signing key."""
+        url = request.getfixturevalue(url_fixture)
+        metrics = _scrape_metrics(exec_python_in_spiffe_pod, url)
+
+        readable = metrics.get(f"{_BUNDLE}_readable")
+        assert readable, f"[{service}] {_BUNDLE}_readable missing from /metrics"
+        assert readable[0][1] == 1.0, (
+            f"[{service}] trust bundle not readable: {readable!r}. Check that "
+            f"spiffe-helper wrote bundle.json and jwks_uri points at it."
+        )
+
+        keys = metrics.get(f"{_BUNDLE}_keys")
+        assert keys, f"[{service}] {_BUNDLE}_keys missing from /metrics"
+        assert keys[0][1] >= 1.0, f"[{service}] trust bundle has no signing keys: {keys!r}"
+
+    @pytest.mark.parametrize("service,url_fixture", _SERVICE_CASES)
+    def test_jwt_svid_expiry_present_and_future(
+        self,
+        request: pytest.FixtureRequest,
+        exec_python_in_spiffe_pod: Callable[[str], subprocess.CompletedProcess[str]],
+        spiffe_trust_domain: str,
+        service: str,
+        url_fixture: str,
+    ) -> None:
+        """JWT-SVID must be readable and its expiry must be in the future.
+
+        Also asserts the ``trust_domain`` label matches the SVID's trust domain
+        (derived independently from the ``aud`` claim by the fixture), proving
+        the label is the low-cardinality domain rather than the workload path.
+        """
+        url = request.getfixturevalue(url_fixture)
+        metrics = _scrape_metrics(exec_python_in_spiffe_pod, url)
+
+        readable = metrics.get(f"{_SVID}_readable")
+        assert readable, f"[{service}] {_SVID}_readable missing from /metrics"
+        assert readable[0][1] == 1.0, (
+            f"[{service}] JWT-SVID not readable/decodable: {readable!r}. "
+            f"spiffe-helper may have stopped refreshing jwt-svid."
+        )
+
+        expiry = metrics.get(f"{_SVID}_expiry_timestamp_seconds")
+        assert expiry, f"[{service}] {_SVID}_expiry_timestamp_seconds missing from /metrics"
+        labels, value = expiry[0]
+        assert value > time.time(), (
+            f"[{service}] JWT-SVID already expired (exp={value}, now={time.time()}). "
+            f"spiffe-helper is not rotating the SVID."
+        )
+        assert labels.get("trust_domain") == spiffe_trust_domain, (
+            f"[{service}] trust_domain label {labels.get('trust_domain')!r} does not match "
+            f"the SVID trust domain {spiffe_trust_domain!r}"
+        )
+        # The label must never carry the full workload path (cardinality/leak).
+        assert "/" not in labels.get("trust_domain", ""), (
+            f"[{service}] trust_domain label leaks a path: {labels.get('trust_domain')!r}"
+        )


### PR DESCRIPTION
## Summary

Adds a lazy Prometheus collector that reports the health of the SPIFFE credentials the spiffe-helper sidecar writes, so operators can alert **before** service-to-service auth silently breaks. Registered via `install_identity_probe`, so every FastAPI service exposes it on its existing `/metrics` endpoint.

### Metrics

**Trust bundle** (`bundle.json` — inbound JWT-SVID validation):
- `nv_config_manager_spiffe_trust_bundle_readable` — `1` if the bundle file reads + parses, else `0`
- `nv_config_manager_spiffe_trust_bundle_keys` — number of signing keys (`0` = broken bundle)
- `nv_config_manager_spiffe_trust_bundle_earliest_cert_expiry_timestamp_seconds` — earliest `x5c` `notAfter`, emitted only when keys carry certificate chains

**JWT-SVID** (`jwt-svid` — outbound credential liveness):
- `nv_config_manager_spiffe_jwt_svid_readable` — `1` if the token file reads + decodes, else `0`
- `nv_config_manager_spiffe_jwt_svid_expiry_timestamp_seconds` — the token's `exp`; decays toward now if spiffe-helper stops refreshing (**the real "auth about to break" alert target**)

### Design notes
- Bundle **file age is intentionally not published**: the trust bundle only changes on signing-key rotation, so its mtime would be a misleading liveness signal (false positives when idle, false negatives right after a rotation). The JWT-SVID `exp` is the correct liveness/pre-breakage signal.
- Reads both files **at scrape time only** — no background poller, no per-request overhead (the app already reads `jwt-svid` per outbound call).
- No-ops when SPIFFE is unconfigured or the bundle is served over HTTP (no local file).
- Wired in `install_identity_probe` via a local import to avoid a circular dependency (`metrics` imports `auth` for config).

## Test plan
- [x] `uv run ruff check` / `ruff format` clean
- [x] `uv run mypy src/nv_config_manager/common/metrics.py` clean
- [x] `uv run pytest src/tests/common/test_metrics.py src/tests/common/test_auth.py` — 65 passed
- [ ] Confirm metrics appear on a live service `/metrics` in a SPIFFE-enabled deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SPIFFE JWT-SVID configuration via `jwt_svid_path` (defaulting to empty when unset).
  * Introduced Prometheus SPIFFE credential health metrics for trust bundles and JWT-SVIDs, including readability, signing key counts, and certificate/JWT expiry indicators.
  * Exposed SPIFFE health metrics on each service’s `/metrics` endpoint.
* **Bug Fixes**
  * Metrics registration failures during identity probe setup are now non-blocking (logged as warnings).
* **Tests**
  * Added unit and integration coverage for metric presence, labels, and failure modes (including HTTP JWKS handling and malformed inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->