### PR TITLE
fix(nautobot): prevent uWSGI /metrics self-deadlock and fix scrape path

### DIFF
--- a/.cursor/rules/dco-signoff.mdc
+++ b/.cursor/rules/dco-signoff.mdc
@@ -1,0 +1,11 @@
+---
+description: Require Developer Certificate of Origin sign-off on commits
+alwaysApply: true
+---
+
+# DCO Sign-Off
+
+- Create every commit with `git commit --signoff` (or `git commit -s`).
+- The `Signed-off-by` trailer must match the commit author.
+- Before pushing, verify each new commit contains the trailer.
+- Never fabricate a sign-off for another contributor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ version when a release tag is promoted.
 
 ## Unreleased
 
-- No unreleased changes have been recorded yet.
+### Fixed
+
+- Fixed a Nautobot uWSGI self-deadlock on `/metrics/` by preloading
+  `django_prometheus.cache.metrics`, and scrape Nautobot via `/metrics/`
+  instead of `/metrics` to avoid recurring 404s.
 
 ## 1.3.0
 

--- a/deploy/helm/templates/_nautobot-configmap-data.tpl
+++ b/deploy/helm/templates/_nautobot-configmap-data.tpl
@@ -121,6 +121,16 @@ uwsgi.ini: |
   
   ; The WSGI module to load
   module = nautobot.core.wsgi:application
+
+  ; Preload django-prometheus cache metrics before any request.
+  ; Without this, the first /metrics/ scrape can self-deadlock: Nautobot's
+  ; metrics collector registers while holding Prometheus's non-reentrant
+  ; registry lock, then touches Django's cache, which lazily imports
+  ; django_prometheus.cache.metrics and tries to re-acquire the same lock.
+  ; Concurrent GraphQL init then blocks on the Python import lock, making
+  ; GraphQL appear responsible. Intermittent because each uWSGI worker
+  ; initializes independently.
+  import = django_prometheus.cache.metrics
   
   ; Listen queue size
   listen = {{ .Values.nautobot.server.uwsgi.listen }}

--- a/deploy/helm/templates/monitoring.yaml
+++ b/deploy/helm/templates/monitoring.yaml
@@ -692,7 +692,8 @@ spec:
       app.kubernetes.io/name: {{ $nautobotName }}
   podMetricsEndpoints:
     - port: http
-      path: /metrics
+      # Nautobot serves metrics at /metrics/ (trailing slash); /metrics 404s.
+      path: /metrics/
       interval: {{ $scrapeInterval }}
       scrapeTimeout: {{ $scrapeTimeout }}
       {{- if .Values.global.customLabels }}


### PR DESCRIPTION
## Summary

Fixes an intermittent Nautobot uWSGI self-deadlock triggered by the first `/metrics/` scrape on a worker, plus the recurring PodMonitor 404.

### Root cause

1. `/metrics/` registers Nautobot's metrics collector while holding Prometheus's registry lock.
2. The collector accesses Django's cache.
3. Django lazily imports `django_prometheus.cache.metrics`.
4. That module registers additional Prometheus counters and tries to acquire the **same non-reentrant registry lock** → the metrics thread deadlocks on itself.
5. Concurrent GraphQL initialization then blocks on the Python import lock, making GraphQL *appear* responsible.

Intermittent because each uWSGI worker initializes independently — one worker can deadlock while another keeps serving.

### Fix

- Preload `import = django_prometheus.cache.metrics` in `uwsgi.ini` so those counters register at worker startup, before any scrape holds the registry lock.
- Scrape the Nautobot PodMonitor via `/metrics/` (trailing slash) instead of `/metrics`, eliminating the recurring 404.

### Validation

- `helm template` renders both changes correctly.
- Manually validated the preload workaround: 12 concurrent GraphQL + 12 metrics requests all returned 200; Alloy scrapes cleanly every 30s.

## Test plan

- [ ] CI helm lint/template passes
- [ ] Confirm no `/metrics` 404s in Alloy after rollout
- [ ] Confirm no worker deadlocks under concurrent GraphQL + metrics load

---

## Post-merge root-cause proof (empirical) + follow-up

After merge we reproduced the deadlock end-to-end and pinned down *why* it only
affected `nv-config-manager`. Recording it here for posterity; the structural
fix lands in **#181**.

### The exact mechanism (single-threaded, deterministic)

The web server runs multiple uWSGI workers, and with **no `PROMETHEUS_MULTIPROC_DIR`**
`prometheus_client` uses the global registry created with `auto_describe=True`:

1. A scrape calls `REGISTRY.register(NautobotAppMetricsCollector())`.
2. `NautobotAppMetricsCollector` defines **no `describe()`**, so with
   `auto_describe=True`, `register()` calls `collect()` **while holding the
   non-reentrant `REGISTRY._lock`**.
3. `collect()` reads Django's cache → lazily imports
   `django_prometheus.cache.backends.redis` → `django_prometheus.cache.metrics`.
4. That module instantiates `Counter()`s at import time, each re-acquiring the
   **lock the same thread already holds** → self-deadlock.

The "GraphQL" symptom is a red herring: a second thread doing its first import
of the same module blocks on the Python import lock behind the deadlocked
thread, so GraphQL *appears* stuck.

### Reproduction (Kind `nv-config-manager` pod)

- **Vulnerable path:** a single cold Python process that runs
  `nautobot.setup()` then `REGISTRY.register(NautobotAppMetricsCollector())`
  (with `PROMETHEUS_MULTIPROC_DIR` unset and `cache.metrics` not yet imported)
  **hangs**; `faulthandler` dumps the stack self-deadlocked inside
  `cache/metrics.py` module import under `REGISTRY.register`.
- **Fixed path:** the same script with `import django_prometheus.cache.metrics`
  added before `register()` **returns cleanly** — confirming the preload
  shipped in this PR.

### Why only `nv-config-manager` (not `cerebro`)

`cerebro` runs the **stock Nautobot image, which bakes
`prometheus_multiproc_dir=/prom_cache`**, so it always used a fresh
`CollectorRegistry(auto_describe=False)` and could not hit the self-deadlock.
Our **custom distroless image does not set it**, forcing the vulnerable global
registry path. (`cerebro` had a *different* problem — un-reaped multiproc `.db`
files accumulating into the tens of thousands and slowing scrapes — which does
not apply here.)

### Follow-up: #181

The preload in this PR mitigates the deadlock. **#181** removes it at the root
by enabling proper `prometheus_client` multiprocess mode (`auto_describe=False`),
which also fixes per-worker metric aggregation. (No startup-clear/reaper is
needed there: an emptyDir is fresh per pod and per-PID files are reused across
in-place restarts.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mitigated intermittent self-deadlocks and recurring errors when collecting Nautobot metrics.
  * Updated Prometheus metrics scraping to use the correct `/metrics/` endpoint to align with trailing-slash routing.
  * Improved startup metrics initialization to reduce monitoring disruptions during concurrent startup activity.
* **Documentation**
  * Added an unreleased changelog entry describing the metrics monitoring mitigation and the updated scraping approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

