### PR TITLE
fix(installer): address setup-local-eso shell maintainability findings

### DIFF
--- a/deploy/scripts/setup-local-eso.sh
+++ b/deploy/scripts/setup-local-eso.sh
@@ -59,7 +59,7 @@ log_warn() {
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $*"
+    echo -e "${RED}[ERROR]${NC} $*" >&2
     return 0
 }
 
@@ -327,6 +327,10 @@ main() {
         case "$argument" in
             --deploy|-d)
                 do_deploy=true
+                ;;
+            *)
+                log_error "Unknown argument: $argument"
+                return 2
                 ;;
         esac
     done


### PR DESCRIPTION
## Description

Handle the two open Sonar findings in `deploy/scripts/setup-local-eso.sh`:

- Reject unexpected command-line arguments with an error and exit status 2 instead of silently ignoring them.
- Send messages from `log_error` to standard error.

## Validation

- [z] Standard CI passes.
- [z] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run locally because this change is limited to argument parsing and error-stream handling in a local setup script.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

No documentation or generated artifacts are affected by this script-only maintenance fix.
