### PR TITLE
fix(ztp): harden storage download streaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -801,22 +801,22 @@ docker-build-temporal-multiarch: docker-buildx-setup ## Builds and pushes multi-
 # Service run targets (for local development without k8s)
 # =============================================================================
 run-ztp-api:
-	uv run uvicorn nv_config_manager.ztp.api.main:app --reload --port 8080
+	uv run uvicorn nv_config_manager.ztp.api.main:app --loop asyncio --reload --port 8080
 
 run-dhcp-api:
-	uv run uvicorn nv_config_manager.dhcp.api:app --reload --port 8081
+	uv run uvicorn nv_config_manager.dhcp.api:app --loop asyncio --reload --port 8081
 
 run-temporal-api:
-	uv run uvicorn nv_config_manager.temporal.api.main:app --reload --port 8082
+	uv run uvicorn nv_config_manager.temporal.api.main:app --loop asyncio --reload --port 8082
 
 run-temporal-worker:
 	uv run python -m nv_config_manager.temporal.worker.main
 
 run-render-api:
-	uv run uvicorn nv_config_manager.render.api.main:app --reload --port 8083
+	uv run uvicorn nv_config_manager.render.api.main:app --loop asyncio --reload --port 8083
 
 run-config-store-api:
-	uv run uvicorn nv_config_manager.config_store.api.main:app --reload --port 8084
+	uv run uvicorn nv_config_manager.config_store.api.main:app --loop asyncio --reload --port 8084
 
 # Database migrations
 db-migrate:

--- a/deploy/helm/sample-nv-config-manager.ini
+++ b/deploy/helm/sample-nv-config-manager.ini
@@ -186,6 +186,12 @@ user_domain = prod.config-manager.example.com
 use_internal_endpoint = false
 storage_type = s3
 s3_bucket = ngc-network-firmware-images
+# Download memory and concurrency bounds.
+http_stream_chunk_bytes = 67108864
+http_max_concurrent_downloads = 16
+sftp_read_ahead_bytes = 16777216
+sftp_max_concurrent_downloads = 32
+sftp_metrics_port = 9100
 # Optional S3-compatible endpoint and AWS region.
 # Leave endpoint unset for default AWS S3 resolution. For EKS IRSA, set the
 # region and rely on the ServiceAccount's IAM role instead of static credentials.

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1346,6 +1346,20 @@ s3_region = {{ $s3.region }}
 {{ end -}}
 {{- end -}}
 
+{{/*
+Network ZTP download settings rendered into the main INI.
+*/}}
+{{- define "nv-config-manager.networkZtpIniDownloadConfig" -}}
+{{- $downloads := .Values.networkZtp.downloads | default dict -}}
+{{- $http := $downloads.http | default dict -}}
+{{- $sftp := $downloads.sftp | default dict -}}
+http_stream_chunk_bytes = {{ $http.chunkSizeBytes | default 67108864 | int }}
+http_max_concurrent_downloads = {{ $http.maxConcurrentDownloads | default 16 | int }}
+sftp_read_ahead_bytes = {{ $sftp.readAheadBytes | default 16777216 | int }}
+sftp_max_concurrent_downloads = {{ $sftp.maxConcurrentDownloads | default 32 | int }}
+sftp_metrics_port = {{ $sftp.metricsPort | default 9100 | int }}
+{{- end -}}
+
 {{- define "nv-config-manager.networkZtpExistingSecretIniConfig" -}}
 {{- if eq (include "nv-config-manager.networkZtp.s3ExistingSecretIniEnabled" .) "true" -}}
 {{- $s3 := .Values.networkZtp.storage.s3 | default dict -}}

--- a/deploy/helm/templates/_vault-agent.tpl
+++ b/deploy/helm/templates/_vault-agent.tpl
@@ -504,6 +504,7 @@ nv-config-manager.ini body (consul-template): must stay in sync with vault-secre
           allowed_groups = {{ $root.Values.networkZtp.gateway.allowedGroups | join "," }}
           {{- end }}
 {{ include "nv-config-manager.networkZtpIniStorageConfig" $root | indent 10 }}
+{{ include "nv-config-manager.networkZtpIniDownloadConfig" $root | indent 10 }}
 {{ include "nv-config-manager.vaultAgent.ztpS3IniConfig" $root | indent 10 }}
 
           {{- end }}

--- a/deploy/helm/templates/kubernetes-secrets.yaml
+++ b/deploy/helm/templates/kubernetes-secrets.yaml
@@ -324,6 +324,7 @@ spec:
               allowed_groups = {{ .Values.networkZtp.gateway.allowedGroups | join "," }}
               {{- end }}
 {{ include "nv-config-manager.networkZtpIniStorageConfig" . | indent 14 }}
+{{ include "nv-config-manager.networkZtpIniDownloadConfig" . | indent 14 }}
 {{ include "nv-config-manager.networkZtpExistingSecretIniConfig" . | indent 14 }}
 
               {{- end }}

--- a/deploy/helm/templates/monitoring.yaml
+++ b/deploy/helm/templates/monitoring.yaml
@@ -383,6 +383,14 @@ spec:
       metricRelabelings:
         {{- include "nv-config-manager.podMonitorMetricRelabelings" . | nindent 8 }}
       {{- end }}
+    - port: sftp-metrics
+      path: /metrics
+      interval: {{ $scrapeInterval }}
+      scrapeTimeout: {{ $scrapeTimeout }}
+      {{- if .Values.global.customLabels }}
+      metricRelabelings:
+        {{- include "nv-config-manager.podMonitorMetricRelabelings" . | nindent 8 }}
+      {{- end }}
 {{- end }}
 
 {{- /* Network DHCP PodMonitor */}}

--- a/deploy/helm/templates/network-policy.yaml
+++ b/deploy/helm/templates/network-policy.yaml
@@ -2,6 +2,8 @@
 #
 {{- $dhcpName := include "nv-config-manager.componentName" (dict "root" . "component" "dhcp") }}
 {{- $ztpName := include "nv-config-manager.componentName" (dict "root" . "component" "ztp") }}
+{{- $ztpDownloads := (.Values.networkZtp.downloads | default dict) }}
+{{- $ztpSftpDownloads := ($ztpDownloads.sftp | default dict) }}
 # =============================================================================
 # Network Policy - Namespace Isolation
 # =============================================================================
@@ -51,7 +53,7 @@ spec:
         - protocol: TCP
           port: 9090
         - protocol: TCP
-          port: {{ (.Values.networkZtp.downloads.sftp.metricsPort | default 9100) }}
+          port: {{ ($ztpSftpDownloads.metricsPort | default 9100) }}
         - protocol: TCP
           port: {{ .Values.networkDhcp.kea.storkAgentPort }}
         - protocol: TCP

--- a/deploy/helm/templates/network-policy.yaml
+++ b/deploy/helm/templates/network-policy.yaml
@@ -51,6 +51,8 @@ spec:
         - protocol: TCP
           port: 9090
         - protocol: TCP
+          port: {{ (.Values.networkZtp.downloads.sftp.metricsPort | default 9100) }}
+        - protocol: TCP
           port: {{ .Values.networkDhcp.kea.storkAgentPort }}
         - protocol: TCP
           port: 9187  # CNPG metrics exporter

--- a/deploy/helm/templates/vault-secrets.yaml
+++ b/deploy/helm/templates/vault-secrets.yaml
@@ -949,6 +949,7 @@ spec:
           allowed_groups = {{ .Values.networkZtp.gateway.allowedGroups | join "," }}
           {{- end }}
 {{ include "nv-config-manager.networkZtpIniStorageConfig" . | indent 10 }}
+{{ include "nv-config-manager.networkZtpIniDownloadConfig" . | indent 10 }}
           {{- if eq (include "nv-config-manager.networkZtp.s3EsoIniEnabled" .) "true" }}
           {{- $s3 := .Values.networkZtp.storage.s3 | default dict }}
           {{- $endpointVaultKey := include "nv-config-manager.vault.configuredKeyName" (dict "root" . "secret" "ztpS3" "key" "endpoint") }}

--- a/deploy/helm/templates/ztp.yaml
+++ b/deploy/helm/templates/ztp.yaml
@@ -5,6 +5,9 @@
 {{- $ztpFileStorage := eq .Values.networkZtp.storage.type "file" }}
 {{- $ztpSpiffeJwt := and .Values.spiffe.enabled (eq (.Values.spiffe.authMode | default "jwt") "jwt") }}
 {{- $ztpVaultAgentJwt := and (eq .Values.secrets.method "vault-agent") (eq (.Values.secrets.vaultAgent.autoAuthMethod | default "kubernetes") "jwt") }}
+{{- $downloads := .Values.networkZtp.downloads | default dict }}
+{{- $httpDownloads := $downloads.http | default dict }}
+{{- $sftpDownloads := $downloads.sftp | default dict }}
 ---
 # Network ZTP Deployment
 apiVersion: apps/v1
@@ -69,6 +72,10 @@ spec:
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         - name: ACCEPT_REQUEST_HEADERS
           value: "true"
+        - name: ZTP_HTTP_STREAM_CHUNK_BYTES
+          value: {{ $httpDownloads.chunkSizeBytes | default 67108864 | int | quote }}
+        - name: ZTP_HTTP_MAX_CONCURRENT_DOWNLOADS
+          value: {{ $httpDownloads.maxConcurrentDownloads | default 16 | int | quote }}
         {{- include "nv-config-manager.networkZtpStorageEnv" . | nindent 8 }}
         {{- if .Values.observability.enabled }}
         {{- include "nv-config-manager.otelAppEnv" (dict "root" . "serviceName" "nv-config-manager-ztp") | nindent 8 }}
@@ -109,6 +116,10 @@ spec:
           value: {{ include "nv-config-manager.vaultAgent.configManagerIniPathApp" . | quote }}
         - name: ENVIRONMENT
           value: {{ .Values.global.environment }}
+        - name: ZTP_HTTP_STREAM_CHUNK_BYTES
+          value: {{ $httpDownloads.chunkSizeBytes | default 67108864 | int | quote }}
+        - name: ZTP_HTTP_MAX_CONCURRENT_DOWNLOADS
+          value: {{ $httpDownloads.maxConcurrentDownloads | default 16 | int | quote }}
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         {{- include "nv-config-manager.networkZtpStorageEnv" . | nindent 8 }}
         {{- if .Values.observability.enabled }}
@@ -149,11 +160,19 @@ spec:
           value: {{ include "nv-config-manager.vaultAgent.configManagerIniPathApp" . | quote }}
         - name: ENVIRONMENT
           value: {{ .Values.global.environment }}
+        - name: ZTP_SFTP_READ_AHEAD_BYTES
+          value: {{ $sftpDownloads.readAheadBytes | default 16777216 | int | quote }}
+        - name: ZTP_SFTP_MAX_CONCURRENT_DOWNLOADS
+          value: {{ $sftpDownloads.maxConcurrentDownloads | default 32 | int | quote }}
+        - name: ZTP_SFTP_METRICS_PORT
+          value: {{ $sftpDownloads.metricsPort | default 9100 | int | quote }}
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         {{- include "nv-config-manager.networkZtpStorageEnv" . | nindent 8 }}
         ports:
         - containerPort: 2222
           name: sftp
+        - containerPort: {{ $sftpDownloads.metricsPort | default 9100 | int }}
+          name: sftp-metrics
         resources:
           {{- toYaml .Values.networkZtp.resources.sftp | nindent 10 }}
         {{- if or $ztpConfigVolume $ztpFileStorage }}
@@ -233,6 +252,10 @@ spec:
     targetPort: 9000
     protocol: TCP
     name: http
+  - port: {{ $sftpDownloads.metricsPort | default 9100 | int }}
+    targetPort: sftp-metrics
+    protocol: TCP
+    name: sftp-metrics
   selector:
     app: {{ $ztpName }}
 ---

--- a/deploy/helm/templates/ztp.yaml
+++ b/deploy/helm/templates/ztp.yaml
@@ -6,7 +6,6 @@
 {{- $ztpSpiffeJwt := and .Values.spiffe.enabled (eq (.Values.spiffe.authMode | default "jwt") "jwt") }}
 {{- $ztpVaultAgentJwt := and (eq .Values.secrets.method "vault-agent") (eq (.Values.secrets.vaultAgent.autoAuthMethod | default "kubernetes") "jwt") }}
 {{- $downloads := .Values.networkZtp.downloads | default dict }}
-{{- $httpDownloads := $downloads.http | default dict }}
 {{- $sftpDownloads := $downloads.sftp | default dict }}
 ---
 # Network ZTP Deployment
@@ -72,10 +71,6 @@ spec:
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         - name: ACCEPT_REQUEST_HEADERS
           value: "true"
-        - name: ZTP_HTTP_STREAM_CHUNK_BYTES
-          value: {{ $httpDownloads.chunkSizeBytes | default 67108864 | int | quote }}
-        - name: ZTP_HTTP_MAX_CONCURRENT_DOWNLOADS
-          value: {{ $httpDownloads.maxConcurrentDownloads | default 16 | int | quote }}
         {{- include "nv-config-manager.networkZtpStorageEnv" . | nindent 8 }}
         {{- if .Values.observability.enabled }}
         {{- include "nv-config-manager.otelAppEnv" (dict "root" . "serviceName" "nv-config-manager-ztp") | nindent 8 }}
@@ -116,10 +111,6 @@ spec:
           value: {{ include "nv-config-manager.vaultAgent.configManagerIniPathApp" . | quote }}
         - name: ENVIRONMENT
           value: {{ .Values.global.environment }}
-        - name: ZTP_HTTP_STREAM_CHUNK_BYTES
-          value: {{ $httpDownloads.chunkSizeBytes | default 67108864 | int | quote }}
-        - name: ZTP_HTTP_MAX_CONCURRENT_DOWNLOADS
-          value: {{ $httpDownloads.maxConcurrentDownloads | default 16 | int | quote }}
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         {{- include "nv-config-manager.networkZtpStorageEnv" . | nindent 8 }}
         {{- if .Values.observability.enabled }}
@@ -160,12 +151,6 @@ spec:
           value: {{ include "nv-config-manager.vaultAgent.configManagerIniPathApp" . | quote }}
         - name: ENVIRONMENT
           value: {{ .Values.global.environment }}
-        - name: ZTP_SFTP_READ_AHEAD_BYTES
-          value: {{ $sftpDownloads.readAheadBytes | default 16777216 | int | quote }}
-        - name: ZTP_SFTP_MAX_CONCURRENT_DOWNLOADS
-          value: {{ $sftpDownloads.maxConcurrentDownloads | default 32 | int | quote }}
-        - name: ZTP_SFTP_METRICS_PORT
-          value: {{ $sftpDownloads.metricsPort | default 9100 | int | quote }}
         {{- include "nv-config-manager.customLabelsEnv" . | nindent 8 }}
         {{- include "nv-config-manager.networkZtpStorageEnv" . | nindent 8 }}
         ports:

--- a/deploy/helm/values-local-medium.yaml
+++ b/deploy/helm/values-local-medium.yaml
@@ -165,6 +165,14 @@ ui:
 # -----------------------------------------------------------------------------
 networkZtp:
   replicas: 1
+  downloads:
+    http:
+      chunkSizeBytes: 67108864 # 64 MiB
+      maxConcurrentDownloads: 8
+    sftp:
+      readAheadBytes: 16777216 # 16 MiB
+      maxConcurrentDownloads: 16
+      metricsPort: 9100
   nodeSelector: null
   affinity: null
 

--- a/deploy/helm/values-local-small.yaml
+++ b/deploy/helm/values-local-small.yaml
@@ -133,6 +133,14 @@ renderService:
 # -----------------------------------------------------------------------------
 networkZtp:
   replicas: 1
+  downloads:
+    http:
+      chunkSizeBytes: 16777216 # 16 MiB
+      maxConcurrentDownloads: 2
+    sftp:
+      readAheadBytes: 16777216 # 16 MiB
+      maxConcurrentDownloads: 8
+      metricsPort: 9100
   resources:
     http:
       requests:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1309,9 +1309,10 @@ networkZtp:
   # ---------------------------------------------------------------------------
   # Download configuration
   # ---------------------------------------------------------------------------
-  # These bounds are per ZTP container. They prevent enough large streams from
-  # being active at once to exhaust the container while retaining good fleet
-  # provisioning throughput. Local size profiles lower the limits below.
+  # These values render into the unified INI's [ztp] section. The bounds are
+  # per ZTP container and prevent enough large streams from being active at
+  # once to exhaust it while retaining good fleet provisioning throughput.
+  # Local size profiles lower the limits below.
   downloads:
     http:
       # Largest read issued to object storage for one HTTP response.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1306,6 +1306,25 @@ networkZtp:
     # before it is closed. Shorter than the total timeout to detect stalled
     # uploads promptly.
     idleTimeout: 300s
+  # ---------------------------------------------------------------------------
+  # Download configuration
+  # ---------------------------------------------------------------------------
+  # These bounds are per ZTP container. They prevent enough large streams from
+  # being active at once to exhaust the container while retaining good fleet
+  # provisioning throughput. Local size profiles lower the limits below.
+  downloads:
+    http:
+      # Largest read issued to object storage for one HTTP response.
+      chunkSizeBytes: 67108864 # 64 MiB
+      # Includes requests waiting on a slow device; held for response lifetime.
+      maxConcurrentDownloads: 16
+    sftp:
+      # One bounded read-ahead cache is held per active SFTP file handle.
+      readAheadBytes: 16777216 # 16 MiB
+      # Held from SFTP open until the remote client closes the handle.
+      maxConcurrentDownloads: 32
+      # Dedicated Prometheus endpoint for metrics emitted by the SFTP process.
+      metricsPort: 9100
   # Deployment configuration
   replicas: 3
   # Resources per container type

--- a/development/ufm_mock/mock_server.py
+++ b/development/ufm_mock/mock_server.py
@@ -315,4 +315,5 @@ if __name__ == "__main__":
         ssl_certfile=os.environ.get("SSL_CERTFILE"),
         ssl_keyfile=os.environ.get("SSL_KEYFILE"),
         log_level=os.environ.get("LOG_LEVEL", "info"),
+        loop="asyncio",
     )

--- a/src/nv_config_manager/config_store/api/main.py
+++ b/src/nv_config_manager/config_store/api/main.py
@@ -125,4 +125,5 @@ def main() -> None:
         host="0.0.0.0",
         port=9000,
         log_config=None,
+        loop="asyncio",
     )

--- a/src/nv_config_manager/dhcp/api.py
+++ b/src/nv_config_manager/dhcp/api.py
@@ -323,6 +323,7 @@ def main() -> None:
         port=args.port,
         proxy_headers=True,
         log_config=None,
+        loop="asyncio",
     )
 
 

--- a/src/nv_config_manager/mcp/main.py
+++ b/src/nv_config_manager/mcp/main.py
@@ -193,4 +193,5 @@ def main() -> None:
         port=args.port,
         proxy_headers=True,
         log_config=None,
+        loop="asyncio",
     )

--- a/src/nv_config_manager/render/api/main.py
+++ b/src/nv_config_manager/render/api/main.py
@@ -42,6 +42,7 @@ def main() -> None:
         port=9000,
         proxy_headers=True,
         log_config=None,
+        loop="asyncio",
     )
 
 

--- a/src/nv_config_manager/temporal/api/main.py
+++ b/src/nv_config_manager/temporal/api/main.py
@@ -152,4 +152,5 @@ def main() -> None:
         port=9000,
         proxy_headers=True,
         log_config=None,
+        loop="asyncio",
     )

--- a/src/nv_config_manager/ztp/api/device_v1.py
+++ b/src/nv_config_manager/ztp/api/device_v1.py
@@ -125,6 +125,7 @@ async def load_firmware(device_uuid: str, request: Request) -> StreamingResponse
             storage_client.get_firmware_object,
             device_data.platform,
             device_data.version,
+            request=request,
         )
     except ObjectStorageNotFoundException as exc:
         raise HTTPException(status_code=404, detail="Firmware image not found in S3.") from exc

--- a/src/nv_config_manager/ztp/api/files_v1.py
+++ b/src/nv_config_manager/ztp/api/files_v1.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """S3 File Endpoints."""
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
 from fastapi.responses import StreamingResponse
 
 from nv_config_manager.common.auth import SSOIdentity, require_authenticated_identity
@@ -31,12 +31,19 @@ router = APIRouter(prefix="/files", tags=["files"], responses={404: {"descriptio
 
 
 @router.get("/{platform}/{version}/{filename}", response_class=StreamingResponse)
-async def load_object(platform: str, version: str, filename: str) -> StreamingResponse:
+async def load_object(
+    platform: str, version: str, filename: str, request: Request
+) -> StreamingResponse:
     """Load the firmware by platform and version."""
     storage_client = get_storage_client()
     try:
         return await create_object_storage_streaming_response(
-            storage_client, storage_client.get_object, platform, version, filename
+            storage_client,
+            storage_client.get_object,
+            platform,
+            version,
+            filename,
+            request=request,
         )
     except ObjectStorageNotFoundException as exc:
         raise HTTPException(status_code=404, detail="File not found in S3.") from exc

--- a/src/nv_config_manager/ztp/api/firmware_v1.py
+++ b/src/nv_config_manager/ztp/api/firmware_v1.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """V1 Device API Endpoints."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from nv_config_manager.common.config import get_storage_client
@@ -31,7 +31,7 @@ router = APIRouter(
 
 
 @router.get("/{platform}/{version}", response_class=StreamingResponse)
-async def load_firmware(platform: str, version: str) -> StreamingResponse:
+async def load_firmware(platform: str, version: str, request: Request) -> StreamingResponse:
     """Load the firmware by platform and version.
 
     Note: For large firmware files, use curl or direct browser download instead of
@@ -40,7 +40,11 @@ async def load_firmware(platform: str, version: str) -> StreamingResponse:
     storage_client = get_storage_client()
     try:
         return await create_object_storage_streaming_response(
-            storage_client, storage_client.get_firmware_object, platform, version
+            storage_client,
+            storage_client.get_firmware_object,
+            platform,
+            version,
+            request=request,
         )
     except ObjectStorageNotFoundException as exc:
         raise HTTPException(status_code=404, detail="Firmware image not found in S3.") from exc

--- a/src/nv_config_manager/ztp/api/main.py
+++ b/src/nv_config_manager/ztp/api/main.py
@@ -51,6 +51,7 @@ def main() -> None:
         timeout_keep_alive=75,
         limit_concurrency=1000,
         backlog=2048,
+        loop="asyncio",
     )
 
 

--- a/src/nv_config_manager/ztp/api/streaming.py
+++ b/src/nv_config_manager/ztp/api/streaming.py
@@ -15,21 +15,43 @@
 """Streaming response utilities for large file downloads."""
 
 import asyncio
+import inspect
 import re
 from collections.abc import AsyncIterator, Callable
+from time import monotonic
 from typing import Any
 from urllib.parse import quote
+from uuid import uuid4
 
+from fastapi import HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from nv_config_manager.common.log import LogCategory, get_logger
-from nv_config_manager.ztp.storage import ObjectStorageClient
+from nv_config_manager.common.log import LogCategory, escape_log_newlines, get_logger
+from nv_config_manager.ztp.download_control import AsyncDownloadLimiter, get_positive_int_env
+from nv_config_manager.ztp.storage import (
+    ObjectStorageClient,
+    ObjectStorageDownload,
+    ObjectStorageException,
+    ObjectStorageRangeNotSatisfiableException,
+    record_storage_download,
+)
 
 logger = get_logger(__name__, category=LogCategory.ZTP)
 
+HTTP_STREAM_CHUNK_BYTES = get_positive_int_env("ZTP_HTTP_STREAM_CHUNK_BYTES", 64 * 1024 * 1024)
+HTTP_DOWNLOAD_LIMITER = AsyncDownloadLimiter(
+    get_positive_int_env("ZTP_HTTP_MAX_CONCURRENT_DOWNLOADS", 2),
+    protocol="http",
+)
+
 
 async def create_object_storage_streaming_response(
-    storage_client: ObjectStorageClient, get_method: Callable[..., Any], *args: Any, **kwargs: Any
+    storage_client: ObjectStorageClient,
+    get_method: Callable[..., Any],
+    *args: Any,
+    request: Request,
+    download_limiter: AsyncDownloadLimiter | None = None,
+    **kwargs: Any,
 ) -> StreamingResponse:
     """Create a streaming response that properly manages the storage client lifecycle.
 
@@ -41,68 +63,227 @@ async def create_object_storage_streaming_response(
         storage_client: The ObjectStorageClient instance to use (S3Client or FileStoreClient)
         get_method: The async method to call (e.g., storage_client.get_firmware_object)
         *args: Positional arguments for the get_method
+        request: The HTTP request, used to propagate a single Range header to storage
         **kwargs: Keyword arguments for the get_method
 
     Returns:
         StreamingResponse configured for optimal large file streaming
     """
-    chunk_size = 256 * 1024 * 1024  # 256MB chunks
+    chunk_size = HTTP_STREAM_CHUNK_BYTES
+    limiter = download_limiter or HTTP_DOWNLOAD_LIMITER
 
-    # Open storage connection but don't close it until streaming is done
-    await storage_client.connect()
+    range_header = request.headers.get("range")
 
+    admission_wait_seconds = await limiter.acquire()
+
+    # Open storage connection but don't close it until streaming is done.
     try:
-        filename, file_handle = await get_method(*args, **kwargs)
-        logger.info("Streaming file: %s", filename)
+        await storage_client.connect()
+
+        download: ObjectStorageDownload = await get_method(
+            *args,
+            range_header=range_header,
+            **kwargs,
+        )
+    except asyncio.CancelledError:
+        # CancelledError is a BaseException, so it must be handled separately or
+        # the admission permit remains held forever. Shield backend cleanup long
+        # enough to give aiohttp/aiobotocore a chance to close its session.
+        try:
+            await asyncio.shield(storage_client.close())
+        except Exception:
+            logger.exception("Storage client cleanup failed after request cancellation")
+        finally:
+            limiter.release()
+        raise
+    except ObjectStorageRangeNotSatisfiableException as exc:
+        try:
+            await storage_client.close()
+        finally:
+            limiter.release()
+        raise HTTPException(
+            status_code=416,
+            detail="Requested range is not satisfiable.",
+            headers={
+                "Accept-Ranges": "bytes",
+                "Content-Range": f"bytes */{exc.total_length}",
+            },
+        ) from exc
     except Exception:
         # Close client and let the exception bubble up to the endpoint
         # The endpoint will handle specific exceptions (like ObjectStorageNotFoundException)
-        await storage_client.close()
+        try:
+            await storage_client.close()
+        finally:
+            limiter.release()
         raise
+
+    transfer_id = uuid4().hex
+
+    def log_fields(**extra: Any) -> dict[str, Any]:
+        """Return safe structured fields shared by each transfer log entry."""
+        return {
+            "transfer_id": transfer_id,
+            "storage_backend": escape_log_newlines(download.backend),
+            "storage_key": escape_log_newlines(download.object_key),
+            "storage_endpoint": (
+                escape_log_newlines(download.endpoint) if download.endpoint else None
+            ),
+            "s3_request_id": (
+                escape_log_newlines(download.request_id) if download.request_id else None
+            ),
+            "storage_filename": escape_log_newlines(download.filename),
+            "content_length": download.content_length,
+            "total_length": download.total_length,
+            "range_start": download.byte_range.start if download.byte_range else None,
+            "range_end": download.byte_range.end if download.byte_range else None,
+            "range_header": escape_log_newlines(range_header) if range_header else None,
+            **extra,
+        }
+
+    logger.info(
+        "Storage stream opened",
+        extra=log_fields(
+            protocol="http",
+            admission_wait_seconds=admission_wait_seconds,
+            active_downloads=limiter.active,
+        ),
+    )
 
     # Create a proper async generator that reads from the file handle
     async def stream_from_storage() -> AsyncIterator[bytes]:
+        bytes_streamed = 0
+        started_at = monotonic()
         try:
-            logger.debug("Starting to stream file, chunk_size=%d", chunk_size)
+            logger.info(
+                "Storage stream started",
+                extra=log_fields(protocol="http", chunk_size=chunk_size),
+            )
 
             # Read and yield chunks - works for both S3 StreamingBody and regular file handles
-            if hasattr(file_handle, "iter_chunks"):
+            if hasattr(download.file_handle, "iter_chunks"):
                 # S3 StreamingBody - use async iteration
-                async for chunk in file_handle.iter_chunks(chunk_size):
+                async for chunk in download.file_handle.iter_chunks(chunk_size):
+                    if not chunk:
+                        continue
+                    if bytes_streamed + len(chunk) > download.content_length:
+                        raise ObjectStorageException(
+                            "Storage response exceeded its declared content length "
+                            f"({download.content_length} bytes)"
+                        )
+                    bytes_streamed += len(chunk)
                     yield chunk
             else:
                 # Regular file handle (from FileStoreClient) - use async read to avoid blocking
-                while True:
+                while bytes_streamed < download.content_length:
                     # Use asyncio.to_thread to prevent blocking the event loop
-                    chunk = await asyncio.to_thread(file_handle.read, chunk_size)
+                    chunk = await asyncio.to_thread(
+                        download.file_handle.read,
+                        min(chunk_size, download.content_length - bytes_streamed),
+                    )
                     if not chunk:
                         break
+                    bytes_streamed += len(chunk)
                     yield chunk
 
-            logger.debug("All chunks yielded successfully")
-        except Exception as e:
-            logger.error("Error during streaming: %s", e, exc_info=True)
+            if bytes_streamed != download.content_length:
+                raise ObjectStorageException(
+                    "Storage response ended before its declared content length: "
+                    f"received {bytes_streamed} of {download.content_length} bytes"
+                )
+
+            duration_seconds = monotonic() - started_at
+            record_storage_download(
+                backend=download.backend,
+                protocol="http",
+                outcome="completed",
+                bytes_received=bytes_streamed,
+                duration_seconds=duration_seconds,
+            )
+            logger.info(
+                "Storage stream completed",
+                extra=log_fields(
+                    protocol="http",
+                    outcome="completed",
+                    bytes_streamed=bytes_streamed,
+                    duration_seconds=duration_seconds,
+                    bytes_per_second=(bytes_streamed / duration_seconds if duration_seconds else 0),
+                ),
+            )
+        except asyncio.CancelledError:
+            duration_seconds = monotonic() - started_at
+            record_storage_download(
+                backend=download.backend,
+                protocol="http",
+                outcome="cancelled",
+                bytes_received=bytes_streamed,
+                duration_seconds=duration_seconds,
+            )
+            logger.warning(
+                "Storage stream cancelled",
+                extra=log_fields(
+                    protocol="http",
+                    outcome="cancelled",
+                    bytes_streamed=bytes_streamed,
+                    duration_seconds=duration_seconds,
+                ),
+            )
+            raise
+        except Exception as exc:
+            duration_seconds = monotonic() - started_at
+            record_storage_download(
+                backend=download.backend,
+                protocol="http",
+                outcome="failed",
+                bytes_received=bytes_streamed,
+                duration_seconds=duration_seconds,
+            )
+            logger.exception(
+                "Storage stream failed",
+                extra=log_fields(
+                    protocol="http",
+                    outcome="failed",
+                    bytes_streamed=bytes_streamed,
+                    duration_seconds=duration_seconds,
+                    error_type=type(exc).__name__,
+                    error=escape_log_newlines(exc),
+                ),
+            )
             raise
         finally:
             logger.debug("Stream generator cleanup: closing file handle and storage client")
-            # Close the file handle
-            if callable(getattr(file_handle, "close", None)):
-                # Use asyncio.to_thread for sync close to avoid blocking
-                await asyncio.to_thread(file_handle.close)
-            # Close the storage client
-            if callable(getattr(storage_client, "close", None)):
-                await storage_client.close()
-            logger.debug("Storage client closed")
+            try:
+                # Close the file handle.
+                if callable(getattr(download.file_handle, "close", None)):
+                    close_result = download.file_handle.close()
+                    if inspect.isawaitable(close_result):
+                        await close_result
+            finally:
+                try:
+                    # Close the storage client.
+                    if callable(getattr(storage_client, "close", None)):
+                        await storage_client.close()
+                    logger.debug("Storage client closed")
+                finally:
+                    limiter.release()
 
-    ascii_filename = re.sub(r'[\x00-\x1f\x7f"\\]', "", filename)
-    encoded_filename = quote(filename, safe="")
+    ascii_filename = re.sub(r'[\x00-\x1f\x7f"\\]', "", download.filename)
+    encoded_filename = quote(download.filename, safe="")
+    headers = {
+        "Content-Disposition": (
+            f"attachment; filename=\"{ascii_filename}\"; filename*=UTF-8''{encoded_filename}"
+        ),
+        "Cache-Control": "no-cache",
+        "Accept-Ranges": "bytes",
+        "Content-Length": str(download.content_length),
+    }
+    if download.byte_range is not None:
+        headers["Content-Range"] = (
+            f"bytes {download.byte_range.start}-{download.byte_range.end}/{download.total_length}"
+        )
     return StreamingResponse(
         content=stream_from_storage(),
         media_type="application/octet-stream",
-        headers={
-            "Content-Disposition": (
-                f"attachment; filename=\"{ascii_filename}\"; filename*=UTF-8''{encoded_filename}"
-            ),
-            "Cache-Control": "no-cache",
-        },
+        headers=headers,
+        status_code=206 if download.byte_range is not None else 200,
     )

--- a/src/nv_config_manager/ztp/api/streaming.py
+++ b/src/nv_config_manager/ztp/api/streaming.py
@@ -27,7 +27,7 @@ from fastapi import HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from nv_config_manager.common.log import LogCategory, escape_log_newlines, get_logger
-from nv_config_manager.ztp.download_control import AsyncDownloadLimiter, get_positive_int_env
+from nv_config_manager.ztp.download_control import AsyncDownloadLimiter, get_positive_int_config
 from nv_config_manager.ztp.storage import (
     ObjectStorageClient,
     ObjectStorageDownload,
@@ -38,9 +38,9 @@ from nv_config_manager.ztp.storage import (
 
 logger = get_logger(__name__, category=LogCategory.ZTP)
 
-HTTP_STREAM_CHUNK_BYTES = get_positive_int_env("ZTP_HTTP_STREAM_CHUNK_BYTES", 64 * 1024 * 1024)
+HTTP_STREAM_CHUNK_BYTES = get_positive_int_config("http_stream_chunk_bytes", 64 * 1024 * 1024)
 HTTP_DOWNLOAD_LIMITER = AsyncDownloadLimiter(
-    get_positive_int_env("ZTP_HTTP_MAX_CONCURRENT_DOWNLOADS", 2),
+    get_positive_int_config("http_max_concurrent_downloads", 2),
     protocol="http",
 )
 

--- a/src/nv_config_manager/ztp/download_control.py
+++ b/src/nv_config_manager/ztp/download_control.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bounded admission control for ZTP object-storage downloads."""
+
+import asyncio
+import logging
+import os
+import threading
+from time import monotonic
+
+from prometheus_client import Gauge, Histogram
+
+logger = logging.getLogger(__name__)
+
+DOWNLOAD_ADMISSION_ACTIVE = Gauge(
+    "storage_download_admission_active",
+    "Object-storage downloads currently admitted by protocol.",
+    labelnames=("protocol",),
+    namespace="nv_config_manager",
+    subsystem="ztp",
+)
+DOWNLOAD_ADMISSION_WAIT_SECONDS = Histogram(
+    "storage_download_admission_wait_seconds",
+    "Time downloads wait for object-storage admission by protocol.",
+    labelnames=("protocol",),
+    namespace="nv_config_manager",
+)
+
+
+def get_positive_int_env(name: str, default: int) -> int:
+    """Read a positive integer environment variable, falling back safely."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %d", name, value, default)
+        return default
+    if parsed <= 0:
+        logger.warning("Invalid %s=%r; using default %d", name, value, default)
+        return default
+    return parsed
+
+
+class AsyncDownloadLimiter:
+    """Limit concurrent HTTP streams while retaining a permit for their lifetime."""
+
+    def __init__(self, capacity: int, protocol: str) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._semaphore = asyncio.Semaphore(capacity)
+        self._protocol = protocol
+        self._active = 0
+
+    @property
+    def active(self) -> int:
+        """Return the number of downloads currently holding a permit."""
+        return self._active
+
+    async def acquire(self) -> float:
+        """Wait for and acquire a permit, returning the wait duration."""
+        started_at = monotonic()
+        await self._semaphore.acquire()
+        wait_seconds = monotonic() - started_at
+        self._active += 1
+        DOWNLOAD_ADMISSION_ACTIVE.labels(protocol=self._protocol).set(self._active)
+        DOWNLOAD_ADMISSION_WAIT_SECONDS.labels(protocol=self._protocol).observe(wait_seconds)
+        return wait_seconds
+
+    def release(self) -> None:
+        """Release one permit after the response stream has finished."""
+        if self._active <= 0:
+            raise RuntimeError("cannot release a download permit that is not held")
+        self._active -= 1
+        DOWNLOAD_ADMISSION_ACTIVE.labels(protocol=self._protocol).set(self._active)
+        self._semaphore.release()
+
+
+class ThreadDownloadLimiter:
+    """Thread-safe counterpart for Paramiko's synchronous SFTP callbacks."""
+
+    def __init__(self, capacity: int, protocol: str) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._semaphore = threading.BoundedSemaphore(capacity)
+        self._protocol = protocol
+        self._active = 0
+        self._lock = threading.Lock()
+
+    @property
+    def active(self) -> int:
+        """Return the number of downloads currently holding a permit."""
+        with self._lock:
+            return self._active
+
+    def acquire(self) -> float:
+        """Wait for and acquire a permit, returning the wait duration."""
+        started_at = monotonic()
+        self._semaphore.acquire()
+        wait_seconds = monotonic() - started_at
+        with self._lock:
+            self._active += 1
+            DOWNLOAD_ADMISSION_ACTIVE.labels(protocol=self._protocol).set(self._active)
+        DOWNLOAD_ADMISSION_WAIT_SECONDS.labels(protocol=self._protocol).observe(wait_seconds)
+        return wait_seconds
+
+    def release(self) -> None:
+        """Release one permit after the SFTP handle has closed."""
+        with self._lock:
+            if self._active <= 0:
+                raise RuntimeError("cannot release a download permit that is not held")
+            self._active -= 1
+            DOWNLOAD_ADMISSION_ACTIVE.labels(protocol=self._protocol).set(self._active)
+        self._semaphore.release()

--- a/src/nv_config_manager/ztp/download_control.py
+++ b/src/nv_config_manager/ztp/download_control.py
@@ -36,6 +36,7 @@ DOWNLOAD_ADMISSION_WAIT_SECONDS = Histogram(
     "Time downloads wait for object-storage admission by protocol.",
     labelnames=("protocol",),
     namespace="nv_config_manager",
+    subsystem="ztp",
 )
 
 

--- a/src/nv_config_manager/ztp/download_control.py
+++ b/src/nv_config_manager/ztp/download_control.py
@@ -16,11 +16,13 @@
 
 import asyncio
 import logging
-import os
 import threading
+from configparser import ConfigParser
 from time import monotonic
 
 from prometheus_client import Gauge, Histogram
+
+from nv_config_manager.common.config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -40,18 +42,21 @@ DOWNLOAD_ADMISSION_WAIT_SECONDS = Histogram(
 )
 
 
-def get_positive_int_env(name: str, default: int) -> int:
-    """Read a positive integer environment variable, falling back safely."""
-    value = os.getenv(name)
-    if value is None:
-        return default
+def get_positive_int_config(
+    name: str,
+    default: int,
+    config: ConfigParser | None = None,
+) -> int:
+    """Read a positive integer from the ZTP INI section, falling back safely."""
+    app_config = config if config is not None else load_config()
     try:
-        parsed = int(value)
+        parsed = app_config.getint("ztp", name, fallback=default)
     except ValueError:
-        logger.warning("Invalid %s=%r; using default %d", name, value, default)
+        value = app_config.get("ztp", name, fallback=None)
+        logger.warning("Invalid [ztp] %s=%r; using default %d", name, value, default)
         return default
     if parsed <= 0:
-        logger.warning("Invalid %s=%r; using default %d", name, value, default)
+        logger.warning("Invalid [ztp] %s=%r; using default %d", name, parsed, default)
         return default
     return parsed
 

--- a/src/nv_config_manager/ztp/filestore.py
+++ b/src/nv_config_manager/ztp/filestore.py
@@ -22,11 +22,14 @@ from types import TracebackType
 from typing import Any, BinaryIO, Self
 
 from nv_config_manager.ztp.storage import (
+    ObjectStorageChangedException,
     ObjectStorageClient,
+    ObjectStorageDownload,
     ObjectStorageException,
     ObjectStorageExistsException,
     ObjectStorageNotAuthorizedException,
     ObjectStorageNotFoundException,
+    parse_http_range,
 )
 
 
@@ -47,6 +50,11 @@ class FileStoreNotAuthorizedException(ObjectStorageNotAuthorizedException):
 
 
 _PATH_TRAVERSAL_MSG = "Path traversal detected: resolved path escapes base directory"
+
+
+def _file_revision(stat: os.stat_result) -> str:
+    """Build a revision token that detects replacement or modification of a file."""
+    return f"{stat.st_dev}:{stat.st_ino}:{stat.st_mtime_ns}:{stat.st_size}"
 
 
 class FileStoreClient(ObjectStorageClient):
@@ -149,7 +157,57 @@ class FileStoreClient(ObjectStorageClient):
             raise FileStoreException(_PATH_TRAVERSAL_MSG)
         return file_path
 
-    async def get_firmware_object(self, platform: str, image: str) -> tuple[str, Any]:
+    async def _open_download(
+        self,
+        file_path: Path,
+        filename: str,
+        object_key: str,
+        *,
+        range_header: str | None,
+        known_total_length: int | None = None,
+        if_match: str | None = None,
+    ) -> ObjectStorageDownload:
+        """Open a file-backed object, seeking to the requested byte range if present."""
+
+        def _open_file() -> tuple[BinaryIO, int, Any, str]:
+            if not file_path.exists():
+                raise FileStoreNotFoundException(f"File not found: {file_path}")
+            file_handle = open(file_path, mode="rb")
+            try:
+                stat = os.fstat(file_handle.fileno())
+                total_length = stat.st_size
+                revision = _file_revision(stat)
+                if known_total_length is not None and total_length != known_total_length:
+                    raise ObjectStorageChangedException(
+                        f"{object_key} changed while it was being downloaded"
+                    )
+                if if_match is not None and revision != if_match:
+                    raise ObjectStorageChangedException(
+                        f"{object_key} changed while it was being downloaded"
+                    )
+                byte_range = parse_http_range(range_header, total_length)
+                if byte_range is not None:
+                    file_handle.seek(byte_range.start)
+                return file_handle, total_length, byte_range, revision
+            except BaseException:
+                file_handle.close()
+                raise
+
+        file_handle, total_length, byte_range, revision = await asyncio.to_thread(_open_file)
+        return ObjectStorageDownload(
+            filename=filename,
+            file_handle=file_handle,
+            content_length=byte_range.length if byte_range is not None else total_length,
+            total_length=total_length,
+            backend="filestore",
+            object_key=object_key,
+            byte_range=byte_range,
+            etag=revision,
+        )
+
+    async def get_firmware_object(
+        self, platform: str, image: str, *, range_header: str | None = None
+    ) -> ObjectStorageDownload:
         """Return the filename and file handle for the given device firmware.
 
         Args:
@@ -162,30 +220,41 @@ class FileStoreClient(ObjectStorageClient):
         # Build full path
         file_path = self.base_path / image_info["path"]
 
-        def _open_file() -> BinaryIO:
-            if not file_path.exists():
-                raise FileStoreNotFoundException(f"Firmware image file not found: {file_path}")
-            return open(file_path, mode="rb")
-
-        file_handle = await asyncio.to_thread(_open_file)
-        return str(image_info["filename"]), file_handle
+        try:
+            return await self._open_download(
+                file_path,
+                str(image_info["filename"]),
+                str(image_info["path"]),
+                range_header=range_header,
+            )
+        except FileStoreNotFoundException as exc:
+            raise FileStoreNotFoundException(f"Firmware image file not found: {file_path}") from exc
 
     async def get_firmware_checksum(self, platform: str, image: str) -> str:
         """Get the checksum for the firmware image from manifest."""
         image_info = self._get_image_from_manifest(platform, image)
         return str(image_info["sha256"])
 
-    async def get_object(self, platform: str, version: str, filename: str) -> tuple[str, Any]:
+    async def get_object(
+        self,
+        platform: str,
+        version: str,
+        filename: str,
+        *,
+        range_header: str | None = None,
+        known_total_length: int | None = None,
+        if_match: str | None = None,
+    ) -> ObjectStorageDownload:
         """Get an arbitrary file stored under a given platform/version."""
         file_path = self._get_file_path(platform, version, filename)
-
-        def _open_file() -> BinaryIO:
-            if not file_path.exists():
-                raise FileStoreNotFoundException(f"File not found: {file_path}")
-            return open(file_path, mode="rb")
-
-        file_handle = await asyncio.to_thread(_open_file)
-        return filename, file_handle
+        return await self._open_download(
+            file_path,
+            filename,
+            f"{platform}/{version}/{filename}",
+            range_header=range_header,
+            known_total_length=known_total_length,
+            if_match=if_match,
+        )
 
     async def get_checksum(self, platform: str, version: str, filename: str) -> str:
         """Get checksum for a file from manifest."""
@@ -222,7 +291,7 @@ class FileStoreClient(ObjectStorageClient):
             "size": stat.st_size,
             "last_modified": stat.st_mtime,
             "metadata": {"sha256-checksum": checksum} if checksum else {},
-            "etag": None,  # File storage doesn't have ETags
+            "etag": _file_revision(stat),
         }
 
     async def list_object_keys(self, platform: str, version: str) -> list[dict[str, Any]]:

--- a/src/nv_config_manager/ztp/filestore.py
+++ b/src/nv_config_manager/ztp/filestore.py
@@ -170,9 +170,10 @@ class FileStoreClient(ObjectStorageClient):
         """Open a file-backed object, seeking to the requested byte range if present."""
 
         def _open_file() -> tuple[BinaryIO, int, Any, str]:
-            if not file_path.exists():
-                raise FileStoreNotFoundException(f"File not found: {file_path}")
-            file_handle = open(file_path, mode="rb")
+            try:
+                file_handle = open(file_path, mode="rb")
+            except FileNotFoundError as exc:
+                raise FileStoreNotFoundException(f"File not found: {file_path}") from exc
             try:
                 stat = os.fstat(file_handle.fileno())
                 total_length = stat.st_size

--- a/src/nv_config_manager/ztp/s3.py
+++ b/src/nv_config_manager/ztp/s3.py
@@ -15,6 +15,7 @@
 """S3 Proxy Client."""
 
 import os
+from time import monotonic
 from types import TracebackType
 from typing import Any, BinaryIO, Self
 
@@ -23,13 +24,21 @@ from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+from nv_config_manager.common.log import LogCategory, escape_log_newlines, get_logger
 from nv_config_manager.ztp.storage import (
+    ObjectStorageByteRange,
+    ObjectStorageChangedException,
     ObjectStorageClient,
+    ObjectStorageDownload,
     ObjectStorageException,
     ObjectStorageExistsException,
     ObjectStorageNotAuthorizedException,
     ObjectStorageNotFoundException,
+    ObjectStorageRangeNotSatisfiableException,
+    parse_http_range,
 )
+
+logger = get_logger(__name__, category=LogCategory.ZTP)
 
 
 class S3Exception(ObjectStorageException):
@@ -125,6 +134,53 @@ class S3Client(ObjectStorageClient):
             raise RuntimeError("S3Client not connected. Use 'async with' or call connect() first.")
         return self._client_instance
 
+    @property
+    def _endpoint(self) -> str:
+        """Return the configured endpoint in a form suitable for diagnostics."""
+        if self.custom_endpoint:
+            return self.custom_endpoint
+        if self.region:
+            return f"s3.{self.region}.amazonaws.com"
+        return "s3.amazonaws.com"
+
+    @staticmethod
+    def _content_length(response: dict[str, Any], operation: str, key: str) -> int:
+        """Extract and validate an S3 response content length."""
+        content_length = response.get("ContentLength")
+        if not isinstance(content_length, int) or content_length < 0:
+            raise S3Exception(
+                f"{operation} for {key} returned an invalid ContentLength: {content_length!r}"
+            )
+        return content_length
+
+    @staticmethod
+    def _request_id(response: dict[str, Any]) -> str | None:
+        """Return the S3 request ID when S3 included one in its response metadata."""
+        metadata = response.get("ResponseMetadata", {})
+        request_id = metadata.get("RequestId") if isinstance(metadata, dict) else None
+        return str(request_id) if request_id is not None else None
+
+    def _s3_log_extra(
+        self,
+        *,
+        operation: str,
+        key: str,
+        duration_seconds: float,
+        request_id: str | None = None,
+        range_header: str | None = None,
+    ) -> dict[str, Any]:
+        """Build safe, consistent fields for S3 diagnostic logs."""
+        return {
+            "storage_backend": "s3",
+            "storage_operation": operation,
+            "storage_key": escape_log_newlines(key),
+            "storage_bucket": escape_log_newlines(self.bucket),
+            "storage_endpoint": escape_log_newlines(self._endpoint),
+            "s3_request_id": escape_log_newlines(request_id) if request_id else None,
+            "range_header": escape_log_newlines(range_header) if range_header else None,
+            "duration_seconds": duration_seconds,
+        }
+
     async def connect(self) -> Self:
         """Connect to S3 and initialize the client session."""
         client_kwargs: dict[str, Any] = {}
@@ -204,11 +260,139 @@ class S3Client(ObjectStorageClient):
             raise S3Exception(f"Found multiple files in path {prefix} tagged as firmware.")
         return keys[0]
 
-    async def get_firmware_object(self, platform: str, image: str) -> tuple[str, Any]:
+    async def _get_object_download(
+        self,
+        key: str,
+        filename: str,
+        *,
+        range_header: str | None,
+        known_total_length: int | None = None,
+        if_match: str | None = None,
+    ) -> ObjectStorageDownload:
+        """Open an S3 object and capture the metadata needed to stream it safely."""
+        byte_range: ObjectStorageByteRange | None = None
+        total_length = known_total_length
+
+        if range_header is not None and total_length is None:
+            metadata_started_at = monotonic()
+            try:
+                metadata = await self._client.head_object(Bucket=self.bucket, Key=key)
+                total_length = self._content_length(metadata, "HeadObject", key)
+            except ClientError as exc:
+                logger.exception(
+                    "S3 HeadObject for range request failed",
+                    extra=self._s3_log_extra(
+                        operation="HeadObject",
+                        key=key,
+                        duration_seconds=monotonic() - metadata_started_at,
+                        range_header=range_header,
+                    ),
+                )
+                code = str(exc.response.get("Error", {}).get("Code", ""))
+                if code in {"404", "NoSuchKey"}:
+                    raise S3NotFoundException(f"Did not find {key} in S3.") from exc
+                raise S3Exception(exc) from exc
+            else:
+                logger.info(
+                    "S3 HeadObject for range request completed",
+                    extra=self._s3_log_extra(
+                        operation="HeadObject",
+                        key=key,
+                        duration_seconds=monotonic() - metadata_started_at,
+                        request_id=self._request_id(metadata),
+                        range_header=range_header,
+                    ),
+                )
+        if range_header is not None:
+            if total_length is None:
+                raise S3Exception(f"Could not determine the size of {key}")
+            byte_range = parse_http_range(range_header, total_length)
+
+        get_kwargs: dict[str, str] = {"Bucket": self.bucket, "Key": key}
+        if byte_range is not None:
+            get_kwargs["Range"] = f"bytes={byte_range.start}-{byte_range.end}"
+        if if_match is not None:
+            get_kwargs["IfMatch"] = if_match
+
+        started_at = monotonic()
+        try:
+            response = await self._client.get_object(**get_kwargs)
+            content_length = self._content_length(response, "GetObject", key)
+            if total_length is None:
+                total_length = content_length
+            if byte_range is not None and content_length != byte_range.length:
+                raise S3Exception(
+                    f"GetObject for {key} returned {content_length} bytes for "
+                    f"requested range {byte_range.start}-{byte_range.end}"
+                )
+        except ClientError as exc:
+            logger.exception(
+                "S3 GetObject failed before the response body could be streamed",
+                extra=self._s3_log_extra(
+                    operation="GetObject",
+                    key=key,
+                    duration_seconds=monotonic() - started_at,
+                    range_header=range_header,
+                ),
+            )
+            code = str(exc.response.get("Error", {}).get("Code", ""))
+            if code in {"404", "NoSuchKey"}:
+                raise S3NotFoundException(f"Did not find {key} in S3.") from exc
+            if code in {"416", "InvalidRange"} and total_length is not None:
+                raise ObjectStorageRangeNotSatisfiableException(total_length) from exc
+            if code in {"412", "PreconditionFailed"}:
+                raise ObjectStorageChangedException(
+                    f"{key} changed while it was being downloaded"
+                ) from exc
+            raise S3Exception(exc) from exc
+        except Exception:
+            logger.exception(
+                "S3 GetObject failed before the response body could be streamed",
+                extra=self._s3_log_extra(
+                    operation="GetObject",
+                    key=key,
+                    duration_seconds=monotonic() - started_at,
+                    range_header=range_header,
+                ),
+            )
+            raise
+
+        request_id = self._request_id(response)
+        logger.info(
+            "S3 GetObject opened response body",
+            extra={
+                **self._s3_log_extra(
+                    operation="GetObject",
+                    key=key,
+                    duration_seconds=monotonic() - started_at,
+                    request_id=request_id,
+                    range_header=range_header,
+                ),
+                "content_length": content_length,
+                "total_length": total_length,
+                "range_start": byte_range.start if byte_range else None,
+                "range_end": byte_range.end if byte_range else None,
+            },
+        )
+        return ObjectStorageDownload(
+            filename=filename,
+            file_handle=response["Body"],
+            content_length=content_length,
+            total_length=total_length,
+            backend="s3",
+            object_key=key,
+            byte_range=byte_range,
+            request_id=request_id,
+            endpoint=self._endpoint,
+            etag=response.get("ETag"),
+        )
+
+    async def get_firmware_object(
+        self, platform: str, image: str, *, range_header: str | None = None
+    ) -> ObjectStorageDownload:
         """Return the object and checksum for the given device."""
         key, fname = await self._get_firmware_key(platform, image)
-        obj = await self._client.get_object(Bucket=self.bucket, Key=key)
-        return fname, obj["Body"]
+        return await self._get_object_download(key, fname, range_header=range_header)
 
     async def get_firmware_checksum(self, platform: str, image: str) -> str:
         """Get the checksum for the image."""
@@ -216,16 +400,25 @@ class S3Client(ObjectStorageClient):
         rsp = await self._client.head_object(Bucket=self.bucket, Key=key)
         return str(rsp.get("Metadata", {}).get("sha256-checksum", ""))
 
-    async def get_object(self, platform: str, version: str, filename: str) -> tuple[str, Any]:
+    async def get_object(
+        self,
+        platform: str,
+        version: str,
+        filename: str,
+        *,
+        range_header: str | None = None,
+        known_total_length: int | None = None,
+        if_match: str | None = None,
+    ) -> ObjectStorageDownload:
         """Get an arbitrary file stored under a given platform/version."""
         key = f"{platform}/{version}/{filename}"
-        try:
-            obj = await self._client.get_object(Bucket=self.bucket, Key=key)
-            return filename, obj["Body"]
-        except ClientError as exc:
-            if exc.response["Error"]["Code"] == "NoSuchKey":
-                raise S3NotFoundException(f"Did not find {key} in S3.") from exc
-            raise S3Exception(exc) from exc
+        return await self._get_object_download(
+            key,
+            filename,
+            range_header=range_header,
+            known_total_length=known_total_length,
+            if_match=if_match,
+        )
 
     async def get_checksum(self, platform: str, version: str, filename: str) -> str:
         """Get an arbitrary file checksum stored under a given platform/version."""
@@ -243,18 +436,38 @@ class S3Client(ObjectStorageClient):
     ) -> dict[str, Any]:
         """Get object metadata without downloading the file content."""
         key = f"{platform}/{version}/{filename}"
+        started_at = monotonic()
         try:
             rsp = await self._client.head_object(Bucket=self.bucket, Key=key)
-            return {
+            result = {
                 "size": rsp.get("ContentLength"),
                 "last_modified": rsp.get("LastModified"),
                 "metadata": rsp.get("Metadata", {}),
                 "etag": rsp.get("ETag"),
             }
         except ClientError as exc:
+            logger.exception(
+                "S3 HeadObject failed",
+                extra=self._s3_log_extra(
+                    operation="HeadObject",
+                    key=key,
+                    duration_seconds=monotonic() - started_at,
+                ),
+            )
             if exc.response["Error"]["Code"] in ["404", "NoSuchKey"]:
                 raise S3NotFoundException(f"Did not find {key} in S3.") from exc
             raise S3Exception(exc) from exc
+        else:
+            logger.info(
+                "S3 HeadObject completed",
+                extra=self._s3_log_extra(
+                    operation="HeadObject",
+                    key=key,
+                    duration_seconds=monotonic() - started_at,
+                    request_id=self._request_id(rsp),
+                ),
+            )
+        return result
 
     async def list_object_keys(self, platform: str, version: str) -> list[dict[str, Any]]:
         """List objects within the given platform and version directory."""

--- a/src/nv_config_manager/ztp/s3.py
+++ b/src/nv_config_manager/ztp/s3.py
@@ -272,12 +272,16 @@ class S3Client(ObjectStorageClient):
         """Open an S3 object and capture the metadata needed to stream it safely."""
         byte_range: ObjectStorageByteRange | None = None
         total_length = known_total_length
+        revision = if_match
 
         if range_header is not None and total_length is None:
             metadata_started_at = monotonic()
             try:
                 metadata = await self._client.head_object(Bucket=self.bucket, Key=key)
                 total_length = self._content_length(metadata, "HeadObject", key)
+                if revision is None:
+                    metadata_etag = metadata.get("ETag")
+                    revision = str(metadata_etag) if metadata_etag is not None else None
             except ClientError as exc:
                 logger.exception(
                     "S3 HeadObject for range request failed",
@@ -311,8 +315,8 @@ class S3Client(ObjectStorageClient):
         get_kwargs: dict[str, str] = {"Bucket": self.bucket, "Key": key}
         if byte_range is not None:
             get_kwargs["Range"] = f"bytes={byte_range.start}-{byte_range.end}"
-        if if_match is not None:
-            get_kwargs["IfMatch"] = if_match
+        if revision is not None:
+            get_kwargs["IfMatch"] = revision
 
         started_at = monotonic()
         try:
@@ -384,7 +388,7 @@ class S3Client(ObjectStorageClient):
             byte_range=byte_range,
             request_id=request_id,
             endpoint=self._endpoint,
-            etag=response.get("ETag"),
+            etag=response.get("ETag", revision),
         )
 
     async def get_firmware_object(

--- a/src/nv_config_manager/ztp/s3.py
+++ b/src/nv_config_manager/ztp/s3.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """S3 Proxy Client."""
 
+import inspect
 import os
 from time import monotonic
 from types import TracebackType
@@ -319,8 +320,10 @@ class S3Client(ObjectStorageClient):
             get_kwargs["IfMatch"] = revision
 
         started_at = monotonic()
+        response_body: Any = None
         try:
             response = await self._client.get_object(**get_kwargs)
+            response_body = response.get("Body")
             content_length = self._content_length(response, "GetObject", key)
             if total_length is None:
                 total_length = content_length
@@ -350,6 +353,25 @@ class S3Client(ObjectStorageClient):
                 ) from exc
             raise S3Exception(exc) from exc
         except Exception:
+            if response_body is not None:
+                close_method = getattr(response_body, "aclose", None)
+                if not callable(close_method):
+                    close_method = getattr(response_body, "close", None)
+                if callable(close_method):
+                    try:
+                        close_result = close_method()
+                        if inspect.isawaitable(close_result):
+                            await close_result
+                    except Exception:
+                        logger.exception(
+                            "Failed to close S3 response body after validation failure",
+                            extra=self._s3_log_extra(
+                                operation="GetObject",
+                                key=key,
+                                duration_seconds=monotonic() - started_at,
+                                range_header=range_header,
+                            ),
+                        )
             logger.exception(
                 "S3 GetObject failed before the response body could be streamed",
                 extra=self._s3_log_extra(

--- a/src/nv_config_manager/ztp/sftp/main.py
+++ b/src/nv_config_manager/ztp/sftp/main.py
@@ -58,7 +58,7 @@ from nv_config_manager.common.log import (
     escape_log_newlines,
     get_logger,
 )
-from nv_config_manager.ztp.download_control import ThreadDownloadLimiter, get_positive_int_env
+from nv_config_manager.ztp.download_control import ThreadDownloadLimiter, get_positive_int_config
 from nv_config_manager.ztp.nautobot import NautobotClient
 from nv_config_manager.ztp.storage import (
     ObjectStorageClient,
@@ -75,11 +75,11 @@ shutdown_event = threading.Event()
 
 # SFTP clients normally issue small, sequential reads. Keeping one bounded range
 # in memory avoids a full-object buffer while limiting S3 requests for large files.
-SFTP_OBJECT_STORAGE_READ_AHEAD_BYTES = get_positive_int_env(
-    "ZTP_SFTP_READ_AHEAD_BYTES", 16 * 1024 * 1024
+SFTP_OBJECT_STORAGE_READ_AHEAD_BYTES = get_positive_int_config(
+    "sftp_read_ahead_bytes", 16 * 1024 * 1024
 )
 SFTP_DOWNLOAD_LIMITER = ThreadDownloadLimiter(
-    get_positive_int_env("ZTP_SFTP_MAX_CONCURRENT_DOWNLOADS", 8),
+    get_positive_int_config("sftp_max_concurrent_downloads", 8),
     protocol="sftp",
 )
 
@@ -778,7 +778,7 @@ def start_server(host: str = "0.0.0.0", port: int = 8222, level: str = "INFO") -
     # Set paramiko's log level to WARN to reduce noise
     logging.getLogger("paramiko").setLevel(logging.WARNING)
 
-    metrics_port = get_positive_int_env("ZTP_SFTP_METRICS_PORT", 9100)
+    metrics_port = get_positive_int_config("sftp_metrics_port", 9100)
     start_http_server(metrics_port, addr="0.0.0.0")  # nosec: B104
     logger.info("SFTP metrics server listening on 0.0.0.0:%d", metrics_port)
 

--- a/src/nv_config_manager/ztp/sftp/main.py
+++ b/src/nv_config_manager/ztp/sftp/main.py
@@ -172,7 +172,8 @@ class ObjectStorageRangeReader:
         if offset < 0:
             raise OSError(errno.EINVAL, "SFTP offset must not be negative")
 
-        requested_end = min(offset + length, self._content_length)
+        requested_length = min(length, self._read_ahead_bytes)
+        requested_end = min(offset + requested_length, self._content_length)
         cache_end = self._cache_start + len(self._cache)
         if not (self._cache_start <= offset and requested_end <= cache_end):
             self._load_cache(offset, requested_end)
@@ -531,16 +532,13 @@ class ZTPSFTPServer(SFTPServerInterface):
                 SFTP_DOWNLOAD_LIMITER.release()
             raise
 
-    def finish_subsystem(self) -> None:  # type: ignore[override]
-        """Clean up resources when the SFTP subsystem is finished."""
+    def close_session(self) -> None:
+        """Clear session resources after Paramiko has closed outstanding handles."""
         self.logger.debug("Clearing path cache and closing event loop")
         self._path_cache.clear()
 
-        # Close the event loop to free resources
         if self._event_loop and not self._event_loop.is_closed():
             self._event_loop.close()
-
-        super().finish_subsystem()  # type: ignore[misc, ty:unresolved-attribute]
 
     def _mock_stat(self, path: str) -> SFTPAttributes | int:
         """Return mock file attributes for the given path."""
@@ -697,6 +695,18 @@ class ZTPSFTPServer(SFTPServerInterface):
             return SFTP_FAILURE
 
 
+class ZTPSFTPSubsystemHandler(SFTPServer):
+    """Close per-session resources after Paramiko closes all SFTP handles."""
+
+    def finish_subsystem(self) -> None:
+        """Preserve the event loop until outstanding range-backed handles are closed."""
+        try:
+            super().finish_subsystem()
+        finally:
+            server = cast(ZTPSFTPServer, self.server)
+            server.close_session()
+
+
 def handle_connection(
     conn: socket.socket, addr: tuple[str, int], host_key: paramiko.RSAKey
 ) -> None:
@@ -715,7 +725,7 @@ def handle_connection(
 
         # Set up the SFTP subsystem handler
         transport.set_subsystem_handler(
-            "sftp", paramiko.SFTPServer, ZTPSFTPServer, client_addr=addr[0]
+            "sftp", ZTPSFTPSubsystemHandler, ZTPSFTPServer, client_addr=addr[0]
         )
 
         # Create server and start it

--- a/src/nv_config_manager/ztp/sftp/main.py
+++ b/src/nv_config_manager/ztp/sftp/main.py
@@ -15,6 +15,7 @@
 import argparse
 import asyncio
 import errno
+import inspect
 import io
 import logging
 import os
@@ -22,7 +23,9 @@ import signal
 import socket
 import threading
 import time
+from collections.abc import Callable
 from typing import Any, cast
+from uuid import uuid4
 
 import paramiko
 from paramiko import (
@@ -45,21 +48,40 @@ from paramiko.sftp import (
     SFTP_PERMISSION_DENIED,
 )
 from paramiko.transport import Transport
+from prometheus_client import start_http_server
 
 from nv_config_manager.common.config import get_storage_client
 from nv_config_manager.common.log import (
     EscapingLoggerAdapter,
     LogCategory,
     configure_logging,
+    escape_log_newlines,
     get_logger,
 )
+from nv_config_manager.ztp.download_control import ThreadDownloadLimiter, get_positive_int_env
 from nv_config_manager.ztp.nautobot import NautobotClient
-from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
+from nv_config_manager.ztp.storage import (
+    ObjectStorageClient,
+    ObjectStorageDownload,
+    ObjectStorageException,
+    ObjectStorageNotFoundException,
+    record_storage_download,
+)
 
 logger = get_logger(__name__, category=LogCategory.ZTP)
 
 # Global flag to control server shutdown
 shutdown_event = threading.Event()
+
+# SFTP clients normally issue small, sequential reads. Keeping one bounded range
+# in memory avoids a full-object buffer while limiting S3 requests for large files.
+SFTP_OBJECT_STORAGE_READ_AHEAD_BYTES = get_positive_int_env(
+    "ZTP_SFTP_READ_AHEAD_BYTES", 16 * 1024 * 1024
+)
+SFTP_DOWNLOAD_LIMITER = ThreadDownloadLimiter(
+    get_positive_int_env("ZTP_SFTP_MAX_CONCURRENT_DOWNLOADS", 8),
+    protocol="sftp",
+)
 
 
 def is_localhost(addr: tuple[str, int]) -> bool:
@@ -99,11 +121,218 @@ class ZTPServer(ServerInterface):
         return cast(int, OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED)
 
 
+class ObjectStorageRangeReader:
+    """Serve offset reads from object storage using one bounded range cache."""
+
+    def __init__(
+        self,
+        *,
+        storage_client: ObjectStorageClient,
+        event_loop: asyncio.AbstractEventLoop,
+        platform: str,
+        version: str,
+        filename: str,
+        content_length: int,
+        logger: logging.Logger | logging.LoggerAdapter,
+        etag: str | None = None,
+        read_ahead_bytes: int = SFTP_OBJECT_STORAGE_READ_AHEAD_BYTES,
+        release_download_permit: Callable[[], None] | None = None,
+    ) -> None:
+        if content_length < 0:
+            raise ValueError("content_length must not be negative")
+        if read_ahead_bytes <= 0:
+            raise ValueError("read_ahead_bytes must be positive")
+
+        self._storage_client = storage_client
+        self._event_loop = event_loop
+        self._platform = platform
+        self._version = version
+        self._filename = filename
+        self._content_length = content_length
+        self._etag = etag
+        self._logger = logger
+        self._read_ahead_bytes = read_ahead_bytes
+        self._cache_start = 0
+        self._cache = b""
+        self._closed = False
+        self._failed = False
+        self._started_at = time.monotonic()
+        self._transfer_id = uuid4().hex
+        self._bytes_fetched = 0
+        self._bytes_served = 0
+        self._download: ObjectStorageDownload | None = None
+        self._release_download_permit = release_download_permit
+
+    def read(self, offset: int, length: int) -> bytes:
+        """Return the requested bytes, fetching a bounded S3 range when needed."""
+        if self._closed:
+            raise OSError(errno.EBADF, "Object storage reader is closed")
+        if length <= 0 or offset >= self._content_length:
+            return b""
+        if offset < 0:
+            raise OSError(errno.EINVAL, "SFTP offset must not be negative")
+
+        requested_end = min(offset + length, self._content_length)
+        cache_end = self._cache_start + len(self._cache)
+        if not (self._cache_start <= offset and requested_end <= cache_end):
+            self._load_cache(offset, requested_end)
+
+        start = offset - self._cache_start
+        result = self._cache[start : start + (requested_end - offset)]
+        self._bytes_served += len(result)
+        return result
+
+    def close(self) -> None:
+        """Close the storage session and record the final transfer outcome."""
+        if self._closed:
+            return
+        self._closed = True
+        duration_seconds = time.monotonic() - self._started_at
+
+        if self._bytes_fetched and not self._failed:
+            outcome = "completed" if self._bytes_served >= self._content_length else "partial"
+            record_storage_download(
+                backend=self._backend,
+                protocol="sftp",
+                outcome=outcome,
+                bytes_received=self._bytes_fetched,
+                duration_seconds=duration_seconds,
+            )
+            self._logger.info(
+                "SFTP storage download completed",
+                extra={
+                    **self._log_fields(),
+                    "outcome": outcome,
+                    "content_length": self._content_length,
+                    "bytes_fetched": self._bytes_fetched,
+                    "bytes_served": self._bytes_served,
+                    "duration_seconds": duration_seconds,
+                    "bytes_per_second": (
+                        self._bytes_served / duration_seconds if duration_seconds else 0
+                    ),
+                },
+            )
+
+        try:
+            self._event_loop.run_until_complete(self._storage_client.close())
+        except Exception:
+            self._logger.exception("Failed to close SFTP object storage client")
+        finally:
+            if self._release_download_permit is not None:
+                self._release_download_permit()
+                self._release_download_permit = None
+
+    @property
+    def _backend(self) -> str:
+        return self._download.backend if self._download is not None else "unknown"
+
+    def _log_fields(self) -> dict[str, Any]:
+        download = self._download
+        return {
+            "transfer_id": self._transfer_id,
+            "storage_backend": self._backend,
+            "storage_key": escape_log_newlines(
+                download.object_key if download is not None else self._object_key
+            ),
+            "storage_endpoint": (
+                escape_log_newlines(download.endpoint)
+                if download is not None and download.endpoint
+                else None
+            ),
+            "s3_request_id": (
+                escape_log_newlines(download.request_id)
+                if download is not None and download.request_id
+                else None
+            ),
+        }
+
+    @property
+    def _object_key(self) -> str:
+        return f"{self._platform}/{self._version}/{self._filename}"
+
+    def _load_cache(self, offset: int, requested_end: int) -> None:
+        cache_end = min(max(requested_end, offset + self._read_ahead_bytes), self._content_length)
+        expected_length = cache_end - offset
+        try:
+            content = self._event_loop.run_until_complete(
+                self._read_range(offset, cache_end - 1, expected_length)
+            )
+        except Exception as exc:
+            self._record_failure(exc)
+            raise
+        self._cache_start = offset
+        self._cache = content
+
+    async def _read_range(self, start: int, end: int, expected_length: int) -> bytes:
+        download = await self._storage_client.get_object(
+            self._platform,
+            self._version,
+            self._filename,
+            range_header=f"bytes={start}-{end}",
+            known_total_length=self._content_length,
+            if_match=self._etag,
+        )
+        try:
+            chunks: list[bytes] = []
+            bytes_read = 0
+            while bytes_read < expected_length:
+                read_result = download.file_handle.read(expected_length - bytes_read)
+                chunk = cast(
+                    bytes,
+                    await read_result if inspect.isawaitable(read_result) else read_result,
+                )
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                bytes_read += len(chunk)
+            content = b"".join(chunks)
+            if len(content) != expected_length or download.content_length != expected_length:
+                raise ObjectStorageException(
+                    "Storage response did not satisfy requested range "
+                    f"{start}-{end}: received {len(content)} bytes, expected {expected_length}"
+                )
+            self._download = download
+            self._bytes_fetched += len(content)
+            return content
+        finally:
+            close = getattr(download.file_handle, "close", None)
+            if callable(close):
+                close_result = close()
+                if inspect.isawaitable(close_result):
+                    await close_result
+
+    def _record_failure(self, exc: Exception) -> None:
+        if self._failed:
+            return
+        self._failed = True
+        duration_seconds = time.monotonic() - self._started_at
+        record_storage_download(
+            backend=self._backend,
+            protocol="sftp",
+            outcome="failed",
+            bytes_received=self._bytes_fetched,
+            duration_seconds=duration_seconds,
+        )
+        self._logger.exception(
+            "SFTP storage download failed",
+            extra={
+                **self._log_fields(),
+                "content_length": self._content_length,
+                "bytes_fetched": self._bytes_fetched,
+                "bytes_served": self._bytes_served,
+                "duration_seconds": duration_seconds,
+                "error_type": type(exc).__name__,
+                "error": escape_log_newlines(exc),
+            },
+        )
+
+
 class ZTPSFTPHandle(SFTPHandle):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize a new SFTP file handle."""
         super().__init__(*args)
         self.readfile: io.StringIO | io.BytesIO | None = None
+        self.range_reader: ObjectStorageRangeReader | None = None
         self.logger: logging.Logger | logging.LoggerAdapter = logger
         self.filename: str = ""
 
@@ -117,6 +346,8 @@ class ZTPSFTPHandle(SFTPHandle):
         try:
             if self.readfile:
                 self.readfile.close()
+            if self.range_reader:
+                self.range_reader.close()
 
         except Exception as e:
             self.logger.error("Error closing file handle: %s", e)
@@ -131,17 +362,24 @@ class ZTPSFTPHandle(SFTPHandle):
             self.filename or "unknown",
         )
         try:
+            if self.range_reader is not None:
+                data = self.range_reader.read(offset, length)
+                self.logger.debug("Read %d bytes successfully", len(data))
+                return data
             if self.readfile is None:
                 return SFTPServer.convert_errno(errno.ENOENT)
             self.readfile.seek(offset)
-            data = self.readfile.read(length)
-            if isinstance(data, str):
-                data = data.encode("utf-8")
-            self.logger.debug("Read %d bytes successfully", len(data))
-            return data
+            file_data = self.readfile.read(length)
+            if isinstance(file_data, str):
+                file_data = file_data.encode("utf-8")
+            self.logger.debug("Read %d bytes successfully", len(file_data))
+            return file_data
         except OSError as e:
             self.logger.error("Error reading from file: %s", e)
             return SFTPServer.convert_errno(e.errno or errno.EIO)
+        except Exception as exc:
+            self.logger.exception("Error reading from object storage: %s", exc)
+            return SFTP_FAILURE
 
 
 class ZTPSFTPServer(SFTPServerInterface):
@@ -172,10 +410,6 @@ class ZTPSFTPServer(SFTPServerInterface):
         path_parts = path.split("/")
         if path_parts[1] == "device":
             content = self._load_ztp_file(path_parts[2], path_parts[3])
-            self._path_cache[path] = content
-            return content
-        if path_parts[1] == "file":
-            content = self._load_s3_file(path_parts[2], path_parts[3], path_parts[4])
             self._path_cache[path] = content
             return content
         if path_parts[1] == "healthcheck":
@@ -220,33 +454,82 @@ class ZTPSFTPServer(SFTPServerInterface):
         # Convert string content to bytes
         return io.BytesIO(file_content.encode("utf-8"))
 
-    def _load_s3_file(self, platform: str, version: str, filename: str) -> io.BytesIO:
-        """Load a ZTP configuration file from S3."""
+    def _open_s3_file(
+        self, platform: str, version: str, filename: str, flags: int
+    ) -> ZTPSFTPHandle:
+        """Open a range-backed object-storage handle without buffering the object."""
         self.logger.info(
-            "Loading file from S3: %s/%s/%s for %s",
+            "Opening range-backed object storage file: %s/%s/%s for %s",
             platform,
             version,
             filename,
             self._client_addr,
         )
         storage_client = get_storage_client()
+        admission_wait_seconds = SFTP_DOWNLOAD_LIMITER.acquire()
         try:
-            # Define async function to fetch from S3
-            async def get_s3_object() -> bytes:
-                async with storage_client:
-                    _, body = await storage_client.get_object(platform, version, filename)
-                    # Read the entire content (aioboto3 StreamingBody.read() is async)
-                    content = await body.read()
-                    return cast(bytes, content)
-
-            # Use the session's event loop
-            content = self._event_loop.run_until_complete(get_s3_object())
-            # Return the bytes
-            return io.BytesIO(content)
+            self._event_loop.run_until_complete(storage_client.connect())
+            metadata = self._event_loop.run_until_complete(
+                storage_client.get_object_metadata(platform, version, filename)
+            )
+            content_length = metadata.get("size")
+            if not isinstance(content_length, int) or content_length < 0:
+                raise ObjectStorageException(
+                    f"Object metadata returned invalid size for {platform}/{version}/{filename}"
+                )
+            etag = metadata.get("etag")
+            if etag is not None and not isinstance(etag, str):
+                raise ObjectStorageException(
+                    f"Object metadata returned invalid ETag for {platform}/{version}/{filename}"
+                )
         except ObjectStorageNotFoundException as exc:
+            try:
+                self._event_loop.run_until_complete(storage_client.close())
+            finally:
+                SFTP_DOWNLOAD_LIMITER.release()
             raise FileNotFoundError(
-                f"File not found in S3: {platform}/{version}/{filename}"
+                f"File not found in object storage: {platform}/{version}/{filename}"
             ) from exc
+        except Exception:
+            try:
+                self._event_loop.run_until_complete(storage_client.close())
+            finally:
+                SFTP_DOWNLOAD_LIMITER.release()
+            raise
+
+        try:
+            reader = ObjectStorageRangeReader(
+                storage_client=storage_client,
+                event_loop=self._event_loop,
+                platform=platform,
+                version=version,
+                filename=filename,
+                content_length=content_length,
+                etag=etag,
+                logger=self.logger,
+                release_download_permit=SFTP_DOWNLOAD_LIMITER.release,
+            )
+            fobj = ZTPSFTPHandle(flags)
+            fobj.set_logger(self.logger)
+            fobj.filename = filename
+            fobj.range_reader = reader
+            self.logger.info(
+                "SFTP storage download admitted",
+                extra={
+                    "storage_key": escape_log_newlines(f"{platform}/{version}/{filename}"),
+                    "admission_wait_seconds": admission_wait_seconds,
+                    "active_downloads": SFTP_DOWNLOAD_LIMITER.active,
+                    "read_ahead_bytes": SFTP_OBJECT_STORAGE_READ_AHEAD_BYTES,
+                },
+            )
+            self.logger.debug("Created range-backed SFTP handle for file: %s", fobj.filename)
+            return fobj
+        except Exception:
+            try:
+                self._event_loop.run_until_complete(storage_client.close())
+            finally:
+                SFTP_DOWNLOAD_LIMITER.release()
+            raise
 
     def finish_subsystem(self) -> None:  # type: ignore[override]
         """Clean up resources when the SFTP subsystem is finished."""
@@ -380,6 +663,14 @@ class ZTPSFTPServer(SFTPServerInterface):
         """Open a file handle for the given path with the specified flags."""
         self.logger.debug("open request: %s, flags: %s", path, flags)
         try:
+            path_parts = path.split("/")
+            if len(path_parts) >= 5 and path_parts[1] == "file":
+                return self._open_s3_file(
+                    path_parts[2],
+                    path_parts[3],
+                    path_parts[4],
+                    flags,
+                )
             file = self._load_path(path)
             self.logger.debug("Successfully loaded file for path: %s", path)
         except Exception as exc:
@@ -476,6 +767,10 @@ def start_server(host: str = "0.0.0.0", port: int = 8222, level: str = "INFO") -
 
     # Set paramiko's log level to WARN to reduce noise
     logging.getLogger("paramiko").setLevel(logging.WARNING)
+
+    metrics_port = get_positive_int_env("ZTP_SFTP_METRICS_PORT", 9100)
+    start_http_server(metrics_port, addr="0.0.0.0")  # nosec: B104
+    logger.info("SFTP metrics server listening on 0.0.0.0:%d", metrics_port)
 
     # Generate host key once at startup (RSA key generation is CPU-intensive)
     logger.info("Generating RSA host key...")

--- a/src/nv_config_manager/ztp/storage.py
+++ b/src/nv_config_manager/ztp/storage.py
@@ -14,9 +14,38 @@
 # limitations under the License.
 """Object storage client abstract base class."""
 
+import re
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass
 from types import TracebackType
 from typing import Any, BinaryIO, Self
+
+from prometheus_client import Counter, Histogram
+
+_RANGE_HEADER_RE = re.compile(r"^bytes=(?P<start>\d*)-(?P<end>\d*)$")
+
+STORAGE_DOWNLOADS = Counter(
+    "storage_downloads",
+    "Storage downloads by backend, protocol, and outcome.",
+    labelnames=("backend", "protocol", "outcome"),
+    namespace="nv_config_manager",
+    subsystem="ztp",
+)
+STORAGE_DOWNLOAD_BYTES = Counter(
+    "storage_download_bytes",
+    "Bytes received from object storage by backend and protocol.",
+    labelnames=("backend", "protocol"),
+    namespace="nv_config_manager",
+    subsystem="ztp",
+)
+STORAGE_DOWNLOAD_DURATION_SECONDS = Histogram(
+    "storage_download_duration_seconds",
+    "Object storage download duration by backend, protocol, and outcome.",
+    labelnames=("backend", "protocol", "outcome"),
+    namespace="nv_config_manager",
+    subsystem="ztp",
+)
 
 
 class ObjectStorageException(Exception):
@@ -33,6 +62,110 @@ class ObjectStorageNotFoundException(ObjectStorageException):
 
 class ObjectStorageNotAuthorizedException(ObjectStorageException):
     """Not authorized to modify this file."""
+
+
+class ObjectStorageChangedException(ObjectStorageException):
+    """The object changed after a multi-request download was opened."""
+
+
+class ObjectStorageRangeNotSatisfiableException(ObjectStorageException):
+    """The requested byte range cannot be served for an object."""
+
+    def __init__(self, total_length: int) -> None:
+        super().__init__(
+            f"Requested range is not satisfiable for an object of {total_length} bytes"
+        )
+        self.total_length = total_length
+
+
+@dataclass(frozen=True)
+class ObjectStorageByteRange:
+    """An inclusive byte range within an object."""
+
+    start: int
+    end: int
+
+    @property
+    def length(self) -> int:
+        """Return the number of bytes in the range."""
+        return self.end - self.start + 1
+
+
+@dataclass(frozen=True)
+class ObjectStorageDownload:
+    """An opened object-storage download with its transfer metadata."""
+
+    filename: str
+    file_handle: Any
+    content_length: int
+    total_length: int
+    backend: str
+    object_key: str
+    byte_range: ObjectStorageByteRange | None = None
+    request_id: str | None = None
+    endpoint: str | None = None
+    etag: str | None = None
+
+    def __iter__(self) -> Iterator[Any]:
+        """Support existing callers that unpack a download into filename and handle."""
+        yield self.filename
+        yield self.file_handle
+
+
+def parse_http_range(range_header: str | None, total_length: int) -> ObjectStorageByteRange | None:
+    """Parse one HTTP ``Range`` header against an object's known length.
+
+    Only a single ``bytes`` range is supported.  A valid range produces an
+    inclusive start/end pair; absent headers return ``None``.  Invalid,
+    multi-range, and unsatisfiable headers raise a single exception that API
+    callers can map to HTTP 416.
+    """
+    if range_header is None:
+        return None
+
+    match = _RANGE_HEADER_RE.fullmatch(range_header)
+    if match is None or "," in range_header or total_length <= 0:
+        raise ObjectStorageRangeNotSatisfiableException(total_length)
+
+    start_text = match.group("start")
+    end_text = match.group("end")
+    if not start_text and not end_text:
+        raise ObjectStorageRangeNotSatisfiableException(total_length)
+
+    if start_text:
+        start = int(start_text)
+        if start >= total_length:
+            raise ObjectStorageRangeNotSatisfiableException(total_length)
+        end = int(end_text) if end_text else total_length - 1
+        if end < start:
+            raise ObjectStorageRangeNotSatisfiableException(total_length)
+        return ObjectStorageByteRange(start=start, end=min(end, total_length - 1))
+
+    suffix_length = int(end_text)
+    if suffix_length <= 0:
+        raise ObjectStorageRangeNotSatisfiableException(total_length)
+    return ObjectStorageByteRange(
+        start=max(total_length - suffix_length, 0),
+        end=total_length - 1,
+    )
+
+
+def record_storage_download(
+    *,
+    backend: str,
+    protocol: str,
+    outcome: str,
+    bytes_received: int,
+    duration_seconds: float,
+) -> None:
+    """Record bounded, backend-level telemetry for an object download."""
+    STORAGE_DOWNLOADS.labels(backend=backend, protocol=protocol, outcome=outcome).inc()
+    STORAGE_DOWNLOAD_BYTES.labels(backend=backend, protocol=protocol).inc(bytes_received)
+    STORAGE_DOWNLOAD_DURATION_SECONDS.labels(
+        backend=backend,
+        protocol=protocol,
+        outcome=outcome,
+    ).observe(duration_seconds)
 
 
 class ObjectStorageClient(ABC):
@@ -68,7 +201,9 @@ class ObjectStorageClient(ABC):
         pass
 
     @abstractmethod
-    async def get_firmware_object(self, platform: str, image: str) -> tuple[str, Any]:
+    async def get_firmware_object(
+        self, platform: str, image: str, *, range_header: str | None = None
+    ) -> ObjectStorageDownload:
         """Return the filename and file handle for the given device firmware.
 
         Args:
@@ -76,7 +211,7 @@ class ObjectStorageClient(ABC):
             image: Version string (e.g., "5.14.0")
 
         Returns:
-            Tuple of (filename, file_handle)
+            Opened object download and its transfer metadata
         """
         pass
 
@@ -94,16 +229,28 @@ class ObjectStorageClient(ABC):
         pass
 
     @abstractmethod
-    async def get_object(self, platform: str, version: str, filename: str) -> tuple[str, Any]:
+    async def get_object(
+        self,
+        platform: str,
+        version: str,
+        filename: str,
+        *,
+        range_header: str | None = None,
+        known_total_length: int | None = None,
+        if_match: str | None = None,
+    ) -> ObjectStorageDownload:
         """Get an arbitrary file stored under a given platform/version.
 
         Args:
             platform: Platform name
             version: Version string
             filename: Name of the file to retrieve
+            range_header: Optional single HTTP byte range
+            known_total_length: Previously observed object size, avoiding another metadata request
+            if_match: Previously observed revision token that the object must still match
 
         Returns:
-            Tuple of (filename, file_handle)
+            Opened object download and its transfer metadata
         """
         pass
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -106,6 +106,11 @@ use_internal_endpoint = true
 api_service = http://ztp-api.example.local:9000
 use_internal_endpoint = true
 user_domain = ztp.example.com
+http_stream_chunk_bytes = 67108864
+http_max_concurrent_downloads = 16
+sftp_read_ahead_bytes = 16777216
+sftp_max_concurrent_downloads = 32
+sftp_metrics_port = 9100
 
 [temporal]
 grpc_service = temporal-frontend.example.local:7233

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -623,6 +623,63 @@ def _find_ztp_pod(namespace: str) -> str | None:
 
 
 @pytest.fixture(scope="session")
+def kind_filestore_deployment(config_manager_namespace: str) -> None:
+    """Require an ephemeral Kind ZTP deployment backed by writable file storage."""
+    try:
+        context_result = subprocess.run(
+            ["kubectl", "config", "current-context"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        pytest.skip("Could not determine the Kubernetes context")
+
+    context = context_result.stdout.strip()
+    if not context.startswith("kind-"):
+        pytest.skip(f"FileStore mutation test requires a Kind context, got {context!r}")
+
+    pod_name = _find_ztp_pod(config_manager_namespace)
+    if pod_name is None:
+        pytest.skip("Could not find the ZTP pod")
+
+    try:
+        pod_result = subprocess.run(
+            [
+                "kubectl",
+                "get",
+                "pod",
+                pod_name,
+                "-n",
+                config_manager_namespace,
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        pod = json.loads(pod_result.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        pytest.skip("Could not inspect the ZTP pod storage configuration")
+
+    http_api = next(
+        (
+            container
+            for container in pod.get("spec", {}).get("containers", [])
+            if container.get("name") == "http-api"
+        ),
+        None,
+    )
+    writable_file_store = http_api is not None and any(
+        mount.get("name") == "os-images" and not mount.get("readOnly", False)
+        for mount in http_api.get("volumeMounts", [])
+    )
+    if not writable_file_store:
+        pytest.skip("ZTP is not configured with a writable FileStore")
+
+
+@pytest.fixture(scope="session")
 def sftp_port_forward(config_manager_namespace: str) -> Generator[tuple[str, int] | None]:
     """Set up a dedicated port-forward for the SFTP server.
 

--- a/src/tests/integration/test_ztp.py
+++ b/src/tests/integration/test_ztp.py
@@ -18,7 +18,9 @@ These tests verify that the ZTP API correctly serves configuration files
 for ZTP-enabled devices and properly updates device status to Provisioned.
 """
 
+from hashlib import sha256
 from typing import Any
+from uuid import uuid4
 
 import paramiko
 import pytest
@@ -320,6 +322,63 @@ class TestZTPAPI:
             )
 
         print(f"✅ Found {total_count} ZTP-enabled devices")
+
+
+class TestZTPFileStore:
+    """CI-only tests that mutate the ephemeral Kind FileStore."""
+
+    @pytest.mark.ci_only
+    @pytest.mark.timeout(60)
+    def test_upload_and_download_round_trip(
+        self,
+        kind_filestore_deployment: None,
+        ztp_api_url: str,
+        ztp_client: requests.Session,
+    ) -> None:
+        """Upload a dummy file, then verify full and ranged downloads."""
+        transfer_id = uuid4().hex
+        platform = "ci-filestore"
+        version = "round-trip"
+        filename = f"payload-{transfer_id}.bin"
+        seed = f"nv-config-manager FileStore round-trip {transfer_id}\n".encode()
+        payload = (seed * ((256 * 1024 // len(seed)) + 1))[: 256 * 1024]
+        checksum = sha256(payload).hexdigest()
+        object_url = f"{ztp_api_url}/v1/files/{platform}/{version}/{filename}"
+
+        upload_response = ztp_client.post(
+            object_url,
+            params={"checksum": checksum},
+            files={"file": (filename, payload, "application/octet-stream")},
+            headers={"Content-Type": None},
+            timeout=60,
+        )
+        upload_response.raise_for_status()
+        assert upload_response.json() == "OK"
+
+        download_response = ztp_client.get(object_url, timeout=60)
+        download_response.raise_for_status()
+        assert download_response.headers["Accept-Ranges"] == "bytes"
+        assert int(download_response.headers["Content-Length"]) == len(payload)
+        assert download_response.content == payload
+        assert sha256(download_response.content).hexdigest() == checksum
+
+        range_start = 17
+        range_end = len(payload) - 23
+        range_response = ztp_client.get(
+            object_url,
+            headers={"Range": f"bytes={range_start}-{range_end}"},
+            timeout=60,
+        )
+        assert range_response.status_code == 206
+        assert range_response.headers["Content-Range"] == (
+            f"bytes {range_start}-{range_end}/{len(payload)}"
+        )
+        assert int(range_response.headers["Content-Length"]) == range_end - range_start + 1
+        assert range_response.content == payload[range_start : range_end + 1]
+
+        checksum_response = ztp_client.get(f"{object_url}/checksum", timeout=30)
+        checksum_response.raise_for_status()
+        assert checksum_response.json() == {"checksum": checksum}
 
 
 class TestZTPSFTP:

--- a/src/tests/ztp/api/test_main.py
+++ b/src/tests/ztp/api/test_main.py
@@ -30,6 +30,11 @@ from nv_config_manager.ztp.s3 import (
     S3ExistsException,
     S3NotFoundException,
 )
+from nv_config_manager.ztp.storage import (
+    ObjectStorageByteRange,
+    ObjectStorageDownload,
+    ObjectStorageRangeNotSatisfiableException,
+)
 
 SSO_HEADERS = {"X-Auth-Request-Email": "test@nvidia.com"}
 
@@ -196,7 +201,14 @@ def test_device_v1_firmware(mock_device_data, mock_not_found_data, client):
         mock_s3_instance.connect = AsyncMock(return_value=mock_s3_instance)
         mock_s3_instance.close = AsyncMock(return_value=None)
         mock_s3_instance.get_firmware_object = AsyncMock(
-            return_value=("testfname", mock_streaming_body)
+            return_value=ObjectStorageDownload(
+                filename="testfname",
+                file_handle=mock_streaming_body,
+                content_length=len(mock_content),
+                total_length=len(mock_content),
+                backend="s3",
+                object_key="cumulus-linux/testfname",
+            )
         )
         mock_s3_class.return_value = mock_s3_instance
 
@@ -220,7 +232,14 @@ def test_device_v1_firmware(mock_device_data, mock_not_found_data, client):
         mock_streaming_body2.iter_chunks = async_iter_chunks2
         mock_streaming_body = mock_streaming_body2
         mock_s3_instance.get_firmware_object = AsyncMock(
-            return_value=("testfname", mock_streaming_body)
+            return_value=ObjectStorageDownload(
+                filename="testfname",
+                file_handle=mock_streaming_body,
+                content_length=len(mock_content),
+                total_length=len(mock_content),
+                backend="s3",
+                object_key="cumulus-linux/testfname",
+            )
         )
 
         with patch(
@@ -449,7 +468,14 @@ def test_v1_firmware(client):
     mock_s3_instance.connect = AsyncMock(return_value=mock_s3_instance)
     mock_s3_instance.close = AsyncMock(return_value=None)
     mock_s3_instance.get_firmware_object = AsyncMock(
-        return_value=("testfname", mock_streaming_body)
+        return_value=ObjectStorageDownload(
+            filename="testfname",
+            file_handle=mock_streaming_body,
+            content_length=len(mock_content),
+            total_length=len(mock_content),
+            backend="s3",
+            object_key="arista_eos/testfname",
+        )
     )
     mock_s3_class.return_value = mock_s3_instance
 
@@ -522,7 +548,14 @@ def test_v1_files_get(client):
     mock_s3_instance.connect = AsyncMock(return_value=mock_s3_instance)
     mock_s3_instance.close = AsyncMock(return_value=None)
     mock_s3_instance.get_object = AsyncMock(
-        return_value=("testfname\r\nFORGED", mock_streaming_body)
+        return_value=ObjectStorageDownload(
+            filename="testfname\r\nFORGED",
+            file_handle=mock_streaming_body,
+            content_length=len(mock_content),
+            total_length=len(mock_content),
+            backend="s3",
+            object_key="arista_eos/testfname",
+        )
     )
     mock_s3_class.return_value = mock_s3_instance
 
@@ -539,7 +572,9 @@ def test_v1_files_get(client):
     assert rsp.headers["content-disposition"] == (
         "attachment; filename=\"testfnameFORGED\"; filename*=UTF-8''testfname%0D%0AFORGED"
     )
-    mock_logger.info.assert_called_once_with("Streaming file: %s", "testfname\r\nFORGED")
+    assert rsp.headers["content-length"] == str(len(mock_content))
+    assert rsp.headers["accept-ranges"] == "bytes"
+    assert any(call.args[0] == "Storage stream opened" for call in mock_logger.info.call_args_list)
 
     # Object not found
     mock_s3_instance.get_object = AsyncMock(side_effect=S3NotFoundException())
@@ -549,6 +584,73 @@ def test_v1_files_get(client):
     ):
         rsp = client.get("/v1/files/arista_eos/4.29.3M/image.bin", headers=SSO_HEADERS)
         assert rsp.status_code == 404
+
+
+def test_v1_files_get_range(client):
+    """A single range is forwarded to storage and returned as a 206 response."""
+    mock_content = b"3456"
+    mock_streaming_body = MagicMock()
+
+    async def async_iter_chunks(chunk_size):
+        yield mock_content
+
+    mock_streaming_body.iter_chunks = async_iter_chunks
+    mock_s3_instance = MagicMock()
+    mock_s3_instance.connect = AsyncMock(return_value=mock_s3_instance)
+    mock_s3_instance.close = AsyncMock(return_value=None)
+    mock_s3_instance.get_object = AsyncMock(
+        return_value=ObjectStorageDownload(
+            filename="image.bin",
+            file_handle=mock_streaming_body,
+            content_length=len(mock_content),
+            total_length=10,
+            backend="s3",
+            object_key="arista_eos/4.29.3M/image.bin",
+            byte_range=ObjectStorageByteRange(start=3, end=6),
+        )
+    )
+
+    with patch(
+        "nv_config_manager.ztp.api.files_v1.get_storage_client", return_value=mock_s3_instance
+    ):
+        rsp = client.get(
+            "/v1/files/arista_eos/4.29.3M/image.bin",
+            headers={**SSO_HEADERS, "Range": "bytes=3-6"},
+        )
+
+    assert rsp.status_code == 206
+    assert rsp.content == mock_content
+    assert rsp.headers["content-length"] == "4"
+    assert rsp.headers["content-range"] == "bytes 3-6/10"
+    assert rsp.headers["accept-ranges"] == "bytes"
+    mock_s3_instance.get_object.assert_awaited_once_with(
+        "arista_eos",
+        "4.29.3M",
+        "image.bin",
+        range_header="bytes=3-6",
+    )
+
+
+def test_v1_files_get_unsatisfiable_range(client):
+    """An unsatisfiable storage range becomes a standards-compliant HTTP 416."""
+    mock_s3_instance = MagicMock()
+    mock_s3_instance.connect = AsyncMock(return_value=mock_s3_instance)
+    mock_s3_instance.close = AsyncMock(return_value=None)
+    mock_s3_instance.get_object = AsyncMock(
+        side_effect=ObjectStorageRangeNotSatisfiableException(total_length=10)
+    )
+
+    with patch(
+        "nv_config_manager.ztp.api.files_v1.get_storage_client", return_value=mock_s3_instance
+    ):
+        rsp = client.get(
+            "/v1/files/arista_eos/4.29.3M/image.bin",
+            headers={**SSO_HEADERS, "Range": "bytes=10-"},
+        )
+
+    assert rsp.status_code == 416
+    assert rsp.headers["accept-ranges"] == "bytes"
+    assert rsp.headers["content-range"] == "bytes */10"
 
 
 def test_v1_files_checksum(client):

--- a/src/tests/ztp/api/test_streaming.py
+++ b/src/tests/ztp/api/test_streaming.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for object-storage HTTP streaming responses."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.requests import Request
+
+from nv_config_manager.ztp.api.streaming import create_object_storage_streaming_response
+from nv_config_manager.ztp.download_control import AsyncDownloadLimiter
+from nv_config_manager.ztp.storage import (
+    ObjectStorageDownload,
+    ObjectStorageException,
+)
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_rejects_a_short_storage_body() -> None:
+    """An early upstream EOF is logged and raised instead of silently succeeding."""
+    body = MagicMock()
+
+    async def iter_chunks(chunk_size: int):
+        assert chunk_size > 0
+        yield b"short"
+
+    body.iter_chunks = iter_chunks
+    storage_client = MagicMock()
+    storage_client.connect = AsyncMock(return_value=storage_client)
+    storage_client.close = AsyncMock(return_value=None)
+    get_object = AsyncMock(
+        return_value=ObjectStorageDownload(
+            filename="image.bin",
+            file_handle=body,
+            content_length=10,
+            total_length=10,
+            backend="s3",
+            object_key="platform/version/image.bin",
+        )
+    )
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "headers": [],
+            "path": "/v1/files/platform/version/image.bin",
+            "query_string": b"",
+        }
+    )
+
+    response = await create_object_storage_streaming_response(
+        storage_client,
+        get_object,
+        request=request,
+    )
+
+    assert response.headers["content-length"] == "10"
+    with pytest.raises(ObjectStorageException, match="ended before its declared content length"):
+        async for _ in response.body_iterator:
+            pass
+
+    storage_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_holds_admission_until_the_stream_finishes() -> None:
+    """A queued download cannot open until the prior response has closed."""
+    limiter = AsyncDownloadLimiter(1, protocol="test-http")
+
+    def make_response_dependencies() -> tuple[MagicMock, AsyncMock, Request]:
+        body = MagicMock()
+
+        async def iter_chunks(chunk_size: int):
+            assert chunk_size > 0
+            yield b"data"
+
+        body.iter_chunks = iter_chunks
+        storage_client = MagicMock()
+        storage_client.connect = AsyncMock(return_value=storage_client)
+        storage_client.close = AsyncMock(return_value=None)
+        get_object = AsyncMock(
+            return_value=ObjectStorageDownload(
+                filename="image.bin",
+                file_handle=body,
+                content_length=4,
+                total_length=4,
+                backend="s3",
+                object_key="platform/version/image.bin",
+            )
+        )
+        request = Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "headers": [],
+                "path": "/v1/files/platform/version/image.bin",
+                "query_string": b"",
+            }
+        )
+        return storage_client, get_object, request
+
+    first_client, first_get_object, first_request = make_response_dependencies()
+    first_response = await create_object_storage_streaming_response(
+        first_client,
+        first_get_object,
+        request=first_request,
+        download_limiter=limiter,
+    )
+    assert limiter.active == 1
+
+    second_client, second_get_object, second_request = make_response_dependencies()
+    second_response_task = asyncio.create_task(
+        create_object_storage_streaming_response(
+            second_client,
+            second_get_object,
+            request=second_request,
+            download_limiter=limiter,
+        )
+    )
+    await asyncio.sleep(0)
+    assert not second_response_task.done()
+
+    assert [chunk async for chunk in first_response.body_iterator] == [b"data"]
+    second_response = await second_response_task
+    assert limiter.active == 1
+
+    assert [chunk async for chunk in second_response.body_iterator] == [b"data"]
+    assert limiter.active == 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_releases_admission_when_setup_is_cancelled() -> None:
+    """Cancellation during backend setup closes storage and returns the permit."""
+    limiter = AsyncDownloadLimiter(1, protocol="test-http-cancel")
+    storage_client = MagicMock()
+    storage_client.connect = AsyncMock(side_effect=asyncio.CancelledError())
+    storage_client.close = AsyncMock(return_value=None)
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "headers": [],
+            "path": "/v1/files/platform/version/image.bin",
+            "query_string": b"",
+        }
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await create_object_storage_streaming_response(
+            storage_client,
+            AsyncMock(),
+            request=request,
+            download_limiter=limiter,
+        )
+
+    storage_client.close.assert_awaited_once()
+    assert limiter.active == 0
+
+    await limiter.acquire()
+    assert limiter.active == 1
+    limiter.release()

--- a/src/tests/ztp/sftp/test_main.py
+++ b/src/tests/ztp/sftp/test_main.py
@@ -16,15 +16,12 @@ import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from paramiko import (
-    AUTH_SUCCESSFUL,
-    OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED,
-    OPEN_SUCCEEDED,
-    SFTP_OK,
-    SFTPAttributes,
-)
+from paramiko import SFTPAttributes
+from paramiko.common import AUTH_SUCCESSFUL, OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED, OPEN_SUCCEEDED
+from paramiko.sftp import SFTP_OK
 
 from nv_config_manager.ztp.sftp.main import (
+    ObjectStorageRangeReader,
     ZTPServer,
     ZTPSFTPHandle,
     ZTPSFTPServer,
@@ -32,6 +29,7 @@ from nv_config_manager.ztp.sftp.main import (
     shutdown_event,
     start_server,
 )
+from nv_config_manager.ztp.storage import ObjectStorageDownload
 
 
 @pytest.fixture
@@ -115,42 +113,146 @@ def test_load_ztp_file(mock_nb_client, sftp_server, mock_device_data):
     assert result.getvalue() == b"test config"
 
 
+def test_object_storage_range_reader_fetches_bounded_ranges(sftp_server):
+    """SFTP reads only fetch the configured range cache, not the full object."""
+    storage_client = MagicMock()
+    storage_client.close = AsyncMock()
+    body_one = MagicMock()
+    body_one.read = AsyncMock(side_effect=[b"ab", b"cd"])
+    body_two = MagicMock()
+    body_two.read = AsyncMock(side_effect=[b"ef", b"gh"])
+    storage_client.get_object = AsyncMock(
+        side_effect=[
+            ObjectStorageDownload(
+                filename="firmware.bin",
+                file_handle=body_one,
+                content_length=4,
+                total_length=10,
+                backend="s3",
+                object_key="cisco/1.0/firmware.bin",
+            ),
+            ObjectStorageDownload(
+                filename="firmware.bin",
+                file_handle=body_two,
+                content_length=4,
+                total_length=10,
+                backend="s3",
+                object_key="cisco/1.0/firmware.bin",
+            ),
+        ]
+    )
+    reader = ObjectStorageRangeReader(
+        storage_client=storage_client,
+        event_loop=sftp_server._event_loop,
+        platform="cisco",
+        version="1.0",
+        filename="firmware.bin",
+        content_length=10,
+        etag='"revision-1"',
+        logger=MagicMock(),
+        read_ahead_bytes=4,
+    )
+
+    assert reader.read(0, 2) == b"ab"
+    assert reader.read(2, 2) == b"cd"
+    assert reader.read(4, 2) == b"ef"
+    assert reader.read(10, 2) == b""
+    assert storage_client.get_object.await_count == 2
+    assert storage_client.get_object.await_args_list[0].kwargs == {
+        "range_header": "bytes=0-3",
+        "known_total_length": 10,
+        "if_match": '"revision-1"',
+    }
+    assert storage_client.get_object.await_args_list[1].kwargs == {
+        "range_header": "bytes=4-7",
+        "known_total_length": 10,
+        "if_match": '"revision-1"',
+    }
+    body_one.close.assert_called_once()
+    body_two.close.assert_called_once()
+    assert body_one.read.await_args_list[0].args == (4,)
+    assert body_one.read.await_args_list[1].args == (2,)
+
+    reader.close()
+    storage_client.close.assert_awaited_once()
+
+
+def test_object_storage_range_reader_releases_its_download_permit_once(sftp_server):
+    """A download permit is held for the SFTP handle's full lifetime."""
+    storage_client = MagicMock()
+    storage_client.close = AsyncMock()
+    release_download_permit = MagicMock()
+    reader = ObjectStorageRangeReader(
+        storage_client=storage_client,
+        event_loop=sftp_server._event_loop,
+        platform="cisco",
+        version="1.0",
+        filename="firmware.bin",
+        content_length=10,
+        logger=MagicMock(),
+        release_download_permit=release_download_permit,
+    )
+
+    reader.close()
+    reader.close()
+
+    storage_client.close.assert_awaited_once()
+    release_download_permit.assert_called_once()
+
+
+def test_object_storage_range_reader_supports_synchronous_file_handles(sftp_server):
+    """PVC-backed synchronous range handles are bounded and closed after each read."""
+    storage_client = MagicMock()
+    storage_client.close = AsyncMock()
+    body = io.BytesIO(b"abcd-and-unrequested-data")
+    storage_client.get_object = AsyncMock(
+        return_value=ObjectStorageDownload(
+            filename="firmware.bin",
+            file_handle=body,
+            content_length=4,
+            total_length=10,
+            backend="filestore",
+            object_key="cisco/1.0/firmware.bin",
+            etag="file-revision",
+        )
+    )
+    reader = ObjectStorageRangeReader(
+        storage_client=storage_client,
+        event_loop=sftp_server._event_loop,
+        platform="cisco",
+        version="1.0",
+        filename="firmware.bin",
+        content_length=10,
+        etag="file-revision",
+        logger=MagicMock(),
+        read_ahead_bytes=4,
+    )
+
+    assert reader.read(0, 2) == b"ab"
+    assert body.closed
+    reader.close()
+
+
 @patch("nv_config_manager.ztp.sftp.main.get_storage_client")
-def test_load_s3_file(mock_s3_client, sftp_server):
-    """Test loading file from S3."""
-    # Create a mock StreamingBody with async read
-    mock_streaming_body = MagicMock()
-    mock_streaming_body.read = AsyncMock(return_value=b"s3 content")
+def test_open_s3_file_creates_range_backed_handle(mock_s3_client, sftp_server):
+    """Opening an S3 file must fetch metadata only until the first SFTP read."""
+    storage_client = MagicMock()
+    storage_client.connect = AsyncMock()
+    storage_client.close = AsyncMock()
+    storage_client.get_object_metadata = AsyncMock(
+        return_value={"size": 1024, "etag": '"revision-1"'}
+    )
+    storage_client.get_object = AsyncMock()
+    mock_s3_client.return_value = storage_client
 
-    # Mock the async context manager and get_object method
-    mock_s3_instance = MagicMock()
-    mock_s3_instance.__aenter__ = AsyncMock(return_value=mock_s3_instance)
-    mock_s3_instance.__aexit__ = AsyncMock(return_value=None)
-    mock_s3_instance.get_object = AsyncMock(return_value=("config.txt", mock_streaming_body))
-    mock_s3_client.return_value = mock_s3_instance
+    result = sftp_server.open("/file/cisco/1.0/firmware.bin", 0, None)
 
-    result = sftp_server._load_s3_file("cisco", "1.0", "config.txt")
-    assert isinstance(result, io.BytesIO)
-    assert result.getvalue() == b"s3 content"
-
-
-@patch("nv_config_manager.ztp.sftp.main.get_storage_client")
-def test_load_s3_file_binary(mock_s3_client, sftp_server):
-    """Test loading binary file from S3."""
-    # Create a mock StreamingBody with binary content and async read
-    mock_streaming_body = MagicMock()
-    mock_streaming_body.read = AsyncMock(return_value=b"\x00\x01\x02\x03\x04\x05")
-
-    # Mock the async context manager and get_object method
-    mock_s3_instance = MagicMock()
-    mock_s3_instance.__aenter__ = AsyncMock(return_value=mock_s3_instance)
-    mock_s3_instance.__aexit__ = AsyncMock(return_value=None)
-    mock_s3_instance.get_object = AsyncMock(return_value=("firmware.bin", mock_streaming_body))
-    mock_s3_client.return_value = mock_s3_instance
-
-    result = sftp_server._load_s3_file("cisco", "1.0", "firmware.bin")
-    assert isinstance(result, io.BytesIO)
-    assert result.getvalue() == b"\x00\x01\x02\x03\x04\x05"
+    assert isinstance(result, ZTPSFTPHandle)
+    assert result.range_reader is not None
+    assert result.range_reader._etag == '"revision-1"'
+    storage_client.get_object.assert_not_awaited()
+    result.close()
+    storage_client.close.assert_awaited_once()
 
 
 def test_load_path(sftp_server):
@@ -227,8 +329,9 @@ def test_handle_connection(mock_transport):
 
 
 @pytest.mark.timeout(0)  # override default timeout, sftp startup takes a bit
+@patch("nv_config_manager.ztp.sftp.main.start_http_server")
 @patch("nv_config_manager.ztp.sftp.main.socket.socket")
-def test_start_server(mock_socket):
+def test_start_server(mock_socket, mock_start_http_server):
     """Test server startup."""
     # Mock socket instance
     mock_socket_instance = MagicMock()
@@ -242,3 +345,4 @@ def test_start_server(mock_socket):
     mock_socket_instance.bind.assert_called_once_with(("127.0.0.1", 2222))
     mock_socket_instance.listen.assert_called_once_with(10)
     mock_socket_instance.close.assert_called_once()
+    mock_start_http_server.assert_called_once_with(9100, addr="0.0.0.0")

--- a/src/tests/ztp/sftp/test_main.py
+++ b/src/tests/ztp/sftp/test_main.py
@@ -25,6 +25,7 @@ from nv_config_manager.ztp.sftp.main import (
     ZTPServer,
     ZTPSFTPHandle,
     ZTPSFTPServer,
+    ZTPSFTPSubsystemHandler,
     handle_connection,
     shutdown_event,
     start_server,
@@ -177,6 +178,47 @@ def test_object_storage_range_reader_fetches_bounded_ranges(sftp_server):
     storage_client.close.assert_awaited_once()
 
 
+def test_object_storage_range_reader_bounds_oversized_requests(sftp_server):
+    """A client cannot make one SFTP read exceed the configured cache bound."""
+    storage_client = MagicMock()
+    storage_client.close = AsyncMock()
+    body = MagicMock()
+    body.read = AsyncMock(return_value=b"abcd")
+    storage_client.get_object = AsyncMock(
+        return_value=ObjectStorageDownload(
+            filename="firmware.bin",
+            file_handle=body,
+            content_length=4,
+            total_length=100,
+            backend="s3",
+            object_key="cisco/1.0/firmware.bin",
+        )
+    )
+    reader = ObjectStorageRangeReader(
+        storage_client=storage_client,
+        event_loop=sftp_server._event_loop,
+        platform="cisco",
+        version="1.0",
+        filename="firmware.bin",
+        content_length=100,
+        logger=MagicMock(),
+        read_ahead_bytes=4,
+    )
+
+    assert reader.read(0, 100) == b"abcd"
+    storage_client.get_object.assert_awaited_once_with(
+        "cisco",
+        "1.0",
+        "firmware.bin",
+        range_header="bytes=0-3",
+        known_total_length=100,
+        if_match=None,
+    )
+    body.read.assert_awaited_once_with(4)
+
+    reader.close()
+
+
 def test_object_storage_range_reader_releases_its_download_permit_once(sftp_server):
     """A download permit is held for the SFTP handle's full lifetime."""
     storage_client = MagicMock()
@@ -196,6 +238,54 @@ def test_object_storage_range_reader_releases_its_download_permit_once(sftp_serv
     reader.close()
     reader.close()
 
+    storage_client.close.assert_awaited_once()
+    release_download_permit.assert_called_once()
+
+
+def test_subsystem_closes_handles_before_session_event_loop(sftp_server):
+    """Paramiko must close range readers while their session loop is still usable."""
+    events: list[str] = []
+    storage_client = MagicMock()
+    storage_client.close = AsyncMock()
+    release_download_permit = MagicMock()
+    reader = ObjectStorageRangeReader(
+        storage_client=storage_client,
+        event_loop=sftp_server._event_loop,
+        platform="cisco",
+        version="1.0",
+        filename="firmware.bin",
+        content_length=10,
+        logger=MagicMock(),
+        release_download_permit=release_download_permit,
+    )
+    handle = ZTPSFTPHandle(0)
+    handle.range_reader = reader
+    handler = object.__new__(ZTPSFTPSubsystemHandler)
+    handler.server = sftp_server
+
+    def close_outstanding_handles(_handler: ZTPSFTPSubsystemHandler) -> None:
+        events.append("handles")
+        assert not sftp_server._event_loop.is_closed()
+        handle.close()
+
+    original_close_session = sftp_server.close_session
+
+    def close_session() -> None:
+        events.append("session")
+        original_close_session()
+
+    with (
+        patch(
+            "nv_config_manager.ztp.sftp.main.SFTPServer.finish_subsystem",
+            autospec=True,
+            side_effect=close_outstanding_handles,
+        ),
+        patch.object(sftp_server, "close_session", side_effect=close_session),
+    ):
+        handler.finish_subsystem()
+
+    assert events == ["handles", "session"]
+    assert sftp_server._event_loop.is_closed()
     storage_client.close.assert_awaited_once()
     release_download_permit.assert_called_once()
 
@@ -324,6 +414,12 @@ def test_handle_connection(mock_transport):
 
     # Verify transport was set up and started
     mock_transport_instance.add_server_key.assert_called_once_with(mock_host_key)
+    mock_transport_instance.set_subsystem_handler.assert_called_once_with(
+        "sftp",
+        ZTPSFTPSubsystemHandler,
+        ZTPSFTPServer,
+        client_addr=mock_addr[0],
+    )
     mock_transport_instance.start_server.assert_called_once()
     mock_transport_instance.close.assert_called_once()
 

--- a/src/tests/ztp/test_filestore.py
+++ b/src/tests/ztp/test_filestore.py
@@ -18,6 +18,7 @@ import io
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -240,6 +241,20 @@ async def test_get_object_not_found(temp_storage_dir, monkeypatch):
 
     with pytest.raises(FileStoreNotFoundException, match="File not found"):
         await client.get_object("cumulus-linux", "5.9.0", "nonexistent.txt")
+
+
+@pytest.mark.asyncio
+async def test_get_object_deleted_while_opening(temp_storage_dir, monkeypatch):
+    """A file removed immediately before open is still reported as not found."""
+    monkeypatch.setenv("FILE_STORE_PATH", temp_storage_dir)
+    client = FileStoreClient()
+    await client.connect()
+
+    with (
+        patch("builtins.open", side_effect=FileNotFoundError),
+        pytest.raises(FileStoreNotFoundException, match="File not found"),
+    ):
+        await client.get_object("cumulus-linux", "5.9.0", "config.txt")
 
 
 @pytest.mark.asyncio

--- a/src/tests/ztp/test_filestore.py
+++ b/src/tests/ztp/test_filestore.py
@@ -27,6 +27,7 @@ from nv_config_manager.ztp.filestore import (
     FileStoreExistsException,
     FileStoreNotFoundException,
 )
+from nv_config_manager.ztp.storage import ObjectStorageChangedException
 
 MOCK_CONTENT = b"testcontent"
 MOCK_MANIFEST = {
@@ -242,6 +243,32 @@ async def test_get_object_not_found(temp_storage_dir, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_object_range(temp_storage_dir, monkeypatch):
+    """File storage seeks to the requested byte range and reports its exact length."""
+    monkeypatch.setenv("FILE_STORE_PATH", temp_storage_dir)
+    client = FileStoreClient()
+    await client.connect()
+
+    test_file_path = Path(temp_storage_dir) / "cumulus-linux/5.9.0/config.txt"
+    test_file_path.write_bytes(b"0123456789")
+
+    download = await client.get_object(
+        "cumulus-linux",
+        "5.9.0",
+        "config.txt",
+        range_header="bytes=3-6",
+    )
+
+    assert download.content_length == 4
+    assert download.total_length == 10
+    assert download.byte_range is not None
+    assert download.byte_range.start == 3
+    assert download.byte_range.end == 6
+    assert download.file_handle.read(download.content_length) == b"3456"
+    download.file_handle.close()
+
+
+@pytest.mark.asyncio
 async def test_get_checksum_success(temp_storage_dir, monkeypatch):
     """Test successful checksum retrieval for firmware image."""
     monkeypatch.setenv("FILE_STORE_PATH", temp_storage_dir)
@@ -280,7 +307,29 @@ async def test_get_object_metadata_success(temp_storage_dir, monkeypatch):
     assert metadata["size"] == len(MOCK_CONTENT)
     assert "last_modified" in metadata
     assert metadata["metadata"]["sha256-checksum"] == "abc123def456"
-    assert metadata["etag"] is None
+    assert isinstance(metadata["etag"], str)
+
+
+@pytest.mark.asyncio
+async def test_get_object_range_rejects_changed_revision(temp_storage_dir, monkeypatch):
+    """Multi-range FileStore downloads fail if the backing file changes."""
+    monkeypatch.setenv("FILE_STORE_PATH", temp_storage_dir)
+    client = FileStoreClient()
+    await client.connect()
+
+    metadata = await client.get_object_metadata("cumulus-linux", "5.9.0", "cumulus.bin")
+    file_path = Path(temp_storage_dir) / "cumulus-linux/5.9.0/cumulus.bin"
+    file_path.write_bytes(b"replacement")
+
+    with pytest.raises(ObjectStorageChangedException, match="changed while"):
+        await client.get_object(
+            "cumulus-linux",
+            "5.9.0",
+            "cumulus.bin",
+            range_header="bytes=0-3",
+            known_total_length=metadata["size"],
+            if_match=metadata["etag"],
+        )
 
 
 @pytest.mark.asyncio

--- a/src/tests/ztp/test_s3.py
+++ b/src/tests/ztp/test_s3.py
@@ -26,6 +26,7 @@ from nv_config_manager.ztp.s3 import (
     S3ExistsException,
     S3NotFoundException,
 )
+from nv_config_manager.ztp.storage import ObjectStorageChangedException
 
 MOCK_CONTENT = b"testcontent"
 
@@ -131,7 +132,10 @@ async def test_get_firmware_object():
     client._client_instance = MockBoto3S3Client()
 
     client._client.get_object = AsyncMock(
-        return_value={"Body": StreamingBody(io.BytesIO(MOCK_CONTENT), len(MOCK_CONTENT))}
+        return_value={
+            "Body": StreamingBody(io.BytesIO(MOCK_CONTENT), len(MOCK_CONTENT)),
+            "ContentLength": len(MOCK_CONTENT),
+        }
     )
     client._client.list_objects = AsyncMock(
         return_value={
@@ -252,7 +256,10 @@ async def test_get_object():
     client._client_instance = MockBoto3S3Client()
 
     client._client.get_object = AsyncMock(
-        return_value={"Body": StreamingBody(io.BytesIO(MOCK_CONTENT), len(MOCK_CONTENT))}
+        return_value={
+            "Body": StreamingBody(io.BytesIO(MOCK_CONTENT), len(MOCK_CONTENT)),
+            "ContentLength": len(MOCK_CONTENT),
+        }
     )
 
     fname, obj = await client.get_object("Cumulus Linux", "5.7.0", "image.bin")
@@ -266,6 +273,94 @@ async def test_get_object():
         S3NotFoundException, match="Did not find Cumulus Linux/5.7.0/image.bin in S3."
     ):
         await client.get_object("Cumulus Linux", "5.7.0", "image.bin")
+
+
+@pytest.mark.asyncio
+async def test_get_object_range():
+    """A requested HTTP range is validated and passed through to S3."""
+    client = S3Client()
+    client._client_instance = MockBoto3S3Client()
+    client._client.head_object = AsyncMock(return_value={"ContentLength": len(MOCK_CONTENT)})
+    client._client.get_object = AsyncMock(
+        return_value={
+            "Body": StreamingBody(io.BytesIO(MOCK_CONTENT[2:6]), len(MOCK_CONTENT[2:6])),
+            "ContentLength": len(MOCK_CONTENT[2:6]),
+        }
+    )
+
+    download = await client.get_object(
+        "Cumulus Linux",
+        "5.7.0",
+        "image.bin",
+        range_header="bytes=2-5",
+    )
+
+    assert download.content_length == 4
+    assert download.total_length == len(MOCK_CONTENT)
+    assert download.byte_range is not None
+    assert download.byte_range.start == 2
+    assert download.byte_range.end == 5
+    client._client.get_object.assert_awaited_once_with(
+        Bucket="ngc-network-firmware-images",
+        Key="Cumulus Linux/5.7.0/image.bin",
+        Range="bytes=2-5",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_object_range_uses_known_revision_without_another_head():
+    """SFTP range reads reuse open metadata and pin every GET to its ETag."""
+    client = S3Client()
+    client._client_instance = MockBoto3S3Client()
+    client._client.head_object = AsyncMock()
+    client._client.get_object = AsyncMock(
+        return_value={
+            "Body": StreamingBody(io.BytesIO(MOCK_CONTENT[2:6]), 4),
+            "ContentLength": 4,
+            "ETag": '"revision-1"',
+        }
+    )
+
+    download = await client.get_object(
+        "Cumulus Linux",
+        "5.7.0",
+        "image.bin",
+        range_header="bytes=2-5",
+        known_total_length=len(MOCK_CONTENT),
+        if_match='"revision-1"',
+    )
+
+    client._client.head_object.assert_not_awaited()
+    client._client.get_object.assert_awaited_once_with(
+        Bucket="ngc-network-firmware-images",
+        Key="Cumulus Linux/5.7.0/image.bin",
+        Range="bytes=2-5",
+        IfMatch='"revision-1"',
+    )
+    assert download.etag == '"revision-1"'
+
+
+@pytest.mark.asyncio
+async def test_get_object_range_rejects_changed_revision():
+    """An S3 precondition failure cannot splice two object revisions together."""
+    client = S3Client()
+    client._client_instance = MockBoto3S3Client()
+    client._client.get_object = AsyncMock(
+        side_effect=ClientError(
+            {"Error": {"Code": "PreconditionFailed"}},
+            "GetObject",
+        )
+    )
+
+    with pytest.raises(ObjectStorageChangedException, match="changed while"):
+        await client.get_object(
+            "Cumulus Linux",
+            "5.7.0",
+            "image.bin",
+            range_header="bytes=2-5",
+            known_total_length=len(MOCK_CONTENT),
+            if_match='"revision-1"',
+        )
 
 
 @pytest.mark.asyncio

--- a/src/tests/ztp/test_s3.py
+++ b/src/tests/ztp/test_s3.py
@@ -406,6 +406,53 @@ async def test_get_object_range_rejects_changed_revision():
 
 
 @pytest.mark.asyncio
+async def test_get_object_closes_body_when_content_length_is_invalid():
+    """A response body is closed when GetObject metadata cannot be validated."""
+    client = S3Client()
+    client._client_instance = MockBoto3S3Client()
+    body = MagicMock(spec=["close"])
+    client._client.get_object = AsyncMock(
+        return_value={
+            "Body": body,
+            "ContentLength": "invalid",
+        }
+    )
+
+    with pytest.raises(S3Exception, match="invalid ContentLength"):
+        await client.get_object("Cumulus Linux", "5.7.0", "image.bin")
+
+    body.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_get_object_closes_body_when_range_length_is_invalid():
+    """A response body is asynchronously closed when its range length is wrong."""
+    client = S3Client()
+    client._client_instance = MockBoto3S3Client()
+    body = MagicMock(spec=["aclose", "close"])
+    body.aclose = AsyncMock()
+    client._client.get_object = AsyncMock(
+        return_value={
+            "Body": body,
+            "ContentLength": 3,
+        }
+    )
+
+    with pytest.raises(S3Exception, match="returned 3 bytes"):
+        await client.get_object(
+            "Cumulus Linux",
+            "5.7.0",
+            "image.bin",
+            range_header="bytes=2-5",
+            known_total_length=len(MOCK_CONTENT),
+            if_match='"revision-1"',
+        )
+
+    body.aclose.assert_awaited_once_with()
+    body.close.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_checksum():
     client = S3Client()
     client._client_instance = MockBoto3S3Client()

--- a/src/tests/ztp/test_s3.py
+++ b/src/tests/ztp/test_s3.py
@@ -280,11 +280,17 @@ async def test_get_object_range():
     """A requested HTTP range is validated and passed through to S3."""
     client = S3Client()
     client._client_instance = MockBoto3S3Client()
-    client._client.head_object = AsyncMock(return_value={"ContentLength": len(MOCK_CONTENT)})
+    client._client.head_object = AsyncMock(
+        return_value={
+            "ContentLength": len(MOCK_CONTENT),
+            "ETag": '"revision-1"',
+        }
+    )
     client._client.get_object = AsyncMock(
         return_value={
             "Body": StreamingBody(io.BytesIO(MOCK_CONTENT[2:6]), len(MOCK_CONTENT[2:6])),
             "ContentLength": len(MOCK_CONTENT[2:6]),
+            "ETag": '"revision-1"',
         }
     )
 
@@ -304,6 +310,42 @@ async def test_get_object_range():
         Bucket="ngc-network-firmware-images",
         Key="Cumulus Linux/5.7.0/image.bin",
         Range="bytes=2-5",
+        IfMatch='"revision-1"',
+    )
+    assert download.etag == '"revision-1"'
+
+
+@pytest.mark.asyncio
+async def test_get_object_range_rejects_revision_changed_after_head():
+    """The ranged GET must remain pinned to the object revision inspected by HEAD."""
+    client = S3Client()
+    client._client_instance = MockBoto3S3Client()
+    client._client.head_object = AsyncMock(
+        return_value={
+            "ContentLength": len(MOCK_CONTENT),
+            "ETag": '"revision-1"',
+        }
+    )
+    client._client.get_object = AsyncMock(
+        side_effect=ClientError(
+            {"Error": {"Code": "PreconditionFailed"}},
+            "GetObject",
+        )
+    )
+
+    with pytest.raises(ObjectStorageChangedException, match="changed while"):
+        await client.get_object(
+            "Cumulus Linux",
+            "5.7.0",
+            "image.bin",
+            range_header="bytes=2-5",
+        )
+
+    client._client.get_object.assert_awaited_once_with(
+        Bucket="ngc-network-firmware-images",
+        Key="Cumulus Linux/5.7.0/image.bin",
+        Range="bytes=2-5",
+        IfMatch='"revision-1"',
     )
 
 

--- a/src/tests/ztp/test_storage.py
+++ b/src/tests/ztp/test_storage.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for storage factory."""
+"""Unit tests for storage factory and byte-range parsing."""
 
 import pytest
 
@@ -22,6 +22,11 @@ from nv_config_manager.common.config import (
 )
 from nv_config_manager.ztp.filestore import FileStoreClient
 from nv_config_manager.ztp.s3 import S3Client
+from nv_config_manager.ztp.storage import (
+    ObjectStorageByteRange,
+    ObjectStorageRangeNotSatisfiableException,
+    parse_http_range,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -175,3 +180,34 @@ def test_get_storage_client_file_storage_from_ini(monkeypatch, tmp_path):
 
     assert isinstance(client, FileStoreClient)
     assert client.base_path == storage_path
+
+
+@pytest.mark.parametrize(
+    ("range_header", "total_length", "expected"),
+    [
+        (None, 10, None),
+        ("bytes=2-5", 10, ObjectStorageByteRange(start=2, end=5)),
+        ("bytes=2-", 10, ObjectStorageByteRange(start=2, end=9)),
+        ("bytes=-4", 10, ObjectStorageByteRange(start=6, end=9)),
+        ("bytes=8-99", 10, ObjectStorageByteRange(start=8, end=9)),
+    ],
+)
+def test_parse_http_range(
+    range_header: str | None,
+    total_length: int,
+    expected: ObjectStorageByteRange | None,
+) -> None:
+    """Single HTTP byte ranges resolve to their inclusive bounds."""
+    assert parse_http_range(range_header, total_length) == expected
+
+
+@pytest.mark.parametrize(
+    "range_header",
+    ["bytes=", "bytes=10-", "bytes=5-2", "bytes=-0", "items=0-1", "bytes=0-1,2-3"],
+)
+def test_parse_http_range_rejects_unsatisfiable_or_multi_ranges(range_header: str) -> None:
+    """Invalid and multi-range requests are consistently mapped to HTTP 416 upstream."""
+    with pytest.raises(ObjectStorageRangeNotSatisfiableException) as exc_info:
+        parse_http_range(range_header, 10)
+
+    assert exc_info.value.total_length == 10


### PR DESCRIPTION
## Description

### Summary

Hardens ZTP firmware and file downloads against truncated transfers and memory pressure, while adding storage-level instrumentation to diagnose S3/FileStore and SFTP failures.

### Changes

- Added exact `Content-Length` and `Accept-Ranges` headers to HTTP downloads.
- Added HTTP byte-range support with correct `206`/`416` responses.
- Detects storage responses that end before their declared length instead of silently completing a truncated download.
- Streams SFTP downloads in bounded chunks instead of buffering entire objects in memory.
- Added configurable HTTP and SFTP download concurrency limits and chunk sizes to mitigate `OOMKilled` pods during concurrent provisioning.
- Pins multi-request SFTP downloads to the same object revision, detecting objects modified during transfer.
- Added structured transfer instrumentation and Prometheus metrics for:
  - Backend connection and transfer duration
  - Bytes transferred
  - Active and queued downloads
  - Admission-control wait time
  - Storage keys, request IDs, ranges, and failure details
- Added Helm defaults and environment-specific sizing for download limits.
- Added monitoring and network-policy support for ZTP metrics.
- Added a CI-only Kind FileStore integration test that:
  - Uploads a uniquely named dummy file
  - Downloads and verifies the complete object
  - Verifies its SHA-256 checksum
  - Exercises and validates a ranged download
  - Skips unless running against a writable FileStore in a Kind cluster

The behavior applies to all HTTP object download routes:

- `/v1/files/{platform}/{version}/{filename}`
- `/v1/firmware/{platform}/{version}`
- `/v1/device/{uuid}/firmware`

These routes share the same streaming response implementation and backend download methods.

### Motivation

Users observed intermittent checksum failures where large downloads returned different truncated sizes while still appearing successful to clients. Concurrent SFTP provisioning also caused excessive memory usage because complete S3 objects were buffered before being served.

These changes make incomplete transfers detectable and resumable while bounding per-pod memory usage during concurrent downloads.

## Validation

- Exercised HTTP and SFTP downloads against a local Kind deployment backed by S3.
- Verified full downloads, range requests, response headers, checksums, and transfer logs.
- Ran concurrent SFTP and HTTP download testing.
- Confirmed bounded-memory SFTP streaming under concurrency.
- ZTP unit tests passed.
- Ruff, SPDX, DCO, TruffleHog, and Helm rendering checks passed.
- Added CI coverage for FileStore upload/download round trips.

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. When the PR is ready for
review, approve the current commit and start the suite with these PR comments:

```text
/ok to test <sha>
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`64bd11b`](https://github.com/NVIDIA/nv-config-manager/commit/64bd11b176acabb02bfb0c75f48f170b8d78502e) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30120378916).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP byte-range support for firmware, files, and SFTP reads with correct 206/416 responses and range headers.
  * Introduced configurable HTTP/SFTP download tuning and a dedicated SFTP metrics port.
  * Enabled bounded, on-demand SFTP object-range reading with concurrency admission control.
* **Monitoring**
  * Added download telemetry and extended Prometheus scraping/network policies to include SFTP metrics.
* **Bug Fixes**
  * Improved handling of unsatisfiable, incomplete, and changed-in-flight range requests with standards-compliant headers.
* **Tests**
  * Expanded unit/integration coverage for range handling, streaming, limiter behavior, and SFTP range-reader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->