### PR TITLE
fix(nautobot): enable prometheus multiprocess mode in the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ version when a release tag is promoted.
   `prometheus_client` in multiprocess mode, and scrape Nautobot via `/metrics/`
   instead of `/metrics` to avoid recurring 404s. Nautobot metrics now aggregate
   across all uWSGI workers instead of reporting only the worker that answered
-  the scrape.
+  the scrape. The multiprocess metrics directory is an `emptyDir` with a size
+  limit so it starts empty on every pod start and cannot grow without bound,
+  and the Celery probes no longer leave metric files behind on each check.
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ version when a release tag is promoted.
 
 ### Fixed
 
-- Fixed a Nautobot uWSGI self-deadlock on `/metrics/` by preloading
-  `django_prometheus.cache.metrics`, and scrape Nautobot via `/metrics/`
-  instead of `/metrics` to avoid recurring 404s.
+- Fixed a Nautobot uWSGI self-deadlock on `/metrics/` by running
+  `prometheus_client` in multiprocess mode, and scrape Nautobot via `/metrics/`
+  instead of `/metrics` to avoid recurring 404s. Nautobot metrics now aggregate
+  across all uWSGI workers instead of reporting only the worker that answered
+  the scrape.
 
 ## 1.3.0
 

--- a/build/nautobot.Dockerfile
+++ b/build/nautobot.Dockerfile
@@ -68,7 +68,8 @@ RUN mkdir -p /opt/nautobot/static \
     /opt/nautobot/media/devicetype-images \
     /opt/nautobot/media/image-attachments \
     /opt/nautobot/git \
-    /opt/nautobot/.cache && \
+    /opt/nautobot/.cache \
+    /prom_cache && \
     chmod -R a+rX /opt/nautobot/.venv /opt/nautobot/nautobot_config.py /opt/nautobot/nv_config_manager_auth
 
 # =============================================================================
@@ -80,6 +81,18 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV NAUTOBOT_ROOT=/opt/nautobot
 ENV NAUTOBOT_CONFIG=/opt/nautobot/nautobot_config.py
+# Prometheus multiprocess mode. These variables only enable multiprocess mode and
+# name the shared metrics directory -- they do not themselves create a registry.
+# The /metrics handler must still build an isolated CollectorRegistry and register
+# a MultiProcessCollector on it; Nautobot core already does this when either
+# spelling is set (NautobotMetricsView, nautobot/core/views/__init__.py), so no
+# application-side change is needed. That per-request registry uses
+# auto_describe=False, so register() never calls collect() while holding the
+# non-reentrant registry lock that deadlocks the first /metrics scrape against the
+# global REGISTRY, and metrics aggregate across all uWSGI workers. Nautobot accepts
+# either spelling; the stock Nautobot image bakes the lower-case one, so both are set.
+ENV prometheus_multiproc_dir=/prom_cache
+ENV PROMETHEUS_MULTIPROC_DIR=/prom_cache
 
 WORKDIR /opt/nautobot
 
@@ -90,6 +103,8 @@ COPY --from=builder /opt/nautobot/nv_config_manager_auth /opt/nautobot/nv_config
 COPY --from=builder --chown=root:root --chmod=0755 /opt/nautobot/static /opt/nautobot/static
 COPY --from=builder --chown=1000:1000 /opt/nautobot/media /opt/nautobot/media
 COPY --from=builder --chown=1000:1000 /opt/nautobot/git /opt/nautobot/git
+# Writable dir for prometheus_client multiprocess metric files (see ENV above).
+COPY --from=builder --chown=1000:1000 /prom_cache /prom_cache
 COPY --from=builder --chown=root:root --chmod=0755 /opt/nautobot/jobs /opt/nautobot/jobs
 COPY --from=builder --chown=1000:1000 /opt/nautobot/.cache /opt/nautobot/.cache
 

--- a/deploy/helm/templates/_nautobot-configmap-data.tpl
+++ b/deploy/helm/templates/_nautobot-configmap-data.tpl
@@ -121,16 +121,6 @@ uwsgi.ini: |
   
   ; The WSGI module to load
   module = nautobot.core.wsgi:application
-
-  ; Preload django-prometheus cache metrics before any request.
-  ; Without this, the first /metrics/ scrape can self-deadlock: Nautobot's
-  ; metrics collector registers while holding Prometheus's non-reentrant
-  ; registry lock, then touches Django's cache, which lazily imports
-  ; django_prometheus.cache.metrics and tries to re-acquire the same lock.
-  ; Concurrent GraphQL init then blocks on the Python import lock, making
-  ; GraphQL appear responsible. Intermittent because each uWSGI worker
-  ; initializes independently.
-  import = django_prometheus.cache.metrics
   
   ; Listen queue size
   listen = {{ .Values.nautobot.server.uwsgi.listen }}

--- a/deploy/helm/templates/nautobot.yaml
+++ b/deploy/helm/templates/nautobot.yaml
@@ -696,6 +696,8 @@ spec:
               mountPath: /opt/nautobot/static
             - name: nautobot-media
               mountPath: /opt/nautobot/media
+            - name: prom-cache
+              mountPath: /prom_cache
             {{- if hasKey .Values.nautobot.rbac "groupMapping" }}
             # Mount as a directory (not subPath) so kubelet syncs file
             # updates in-place: ConfigMap edits propagate to the running
@@ -794,6 +796,15 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        # prometheus_client keys its multiprocess metric files by PID and never reaps
+        # them, so /prom_cache only grows over a pod's lifetime.  An emptyDir starts
+        # empty on every pod start and caps the growth -- the image already creates
+        # the directory, so this adds lifecycle management, not the directory itself.
+        # Steady state is a few files per uWSGI worker; the limit is sized to be a
+        # regression signal rather than something normal operation approaches.
+        - name: prom-cache
+          emptyDir:
+            sizeLimit: 256Mi
         {{- if .Values.nautobot.customJobs.enabled }}
         - name: custom-jobs
           persistentVolumeClaim:
@@ -960,18 +971,26 @@ spec:
                 name: {{ $nautobotName }}-env
           resources:
             {{- toYaml .Values.nautobot.celery.resources | nindent 12 }}
-          {{- if .Values.nautobot.customJobs.enabled }}
           volumeMounts:
+            - name: prom-cache
+              mountPath: /prom_cache
+            {{- if .Values.nautobot.customJobs.enabled }}
             - name: custom-jobs
               mountPath: /opt/nautobot/jobs/custom
               readOnly: true
-          {{- end }}
+            {{- end }}
+          # Celery has no HTTP listener, so unlike the web pod these probes must fork.
+          # The forked process gets a fresh PID, and any nautobot-server invocation
+          # with $prometheus_multiproc_dir set writes a set of *.db files under it that
+          # nothing reaps.  Dropping the variable from the child's environment keeps
+          # prometheus_client in single-process mode for the probe, so it writes none;
+          # `celery inspect ping` never touches /metrics, so nothing is lost.
           livenessProbe:
             exec:
               command:
                 - python
                 - -c
-                - "import os, subprocess, sys; sys.exit(subprocess.call(['nautobot-server', 'celery', 'inspect', 'ping', '--destination', 'celery@' + os.environ.get('HOSTNAME', '')]))"
+                - "import os, subprocess, sys; os.environ.pop('prometheus_multiproc_dir', None); os.environ.pop('PROMETHEUS_MULTIPROC_DIR', None); sys.exit(subprocess.call(['nautobot-server', 'celery', 'inspect', 'ping', '--destination', 'celery@' + os.environ.get('HOSTNAME', '')]))"
             initialDelaySeconds: 60
             periodSeconds: 120
             timeoutSeconds: 60
@@ -981,17 +1000,21 @@ spec:
               command:
                 - python
                 - -c
-                - "import os, subprocess, sys; sys.exit(subprocess.call(['nautobot-server', 'celery', 'inspect', 'ping', '--destination', 'celery@' + os.environ.get('HOSTNAME', '')]))"
+                - "import os, subprocess, sys; os.environ.pop('prometheus_multiproc_dir', None); os.environ.pop('PROMETHEUS_MULTIPROC_DIR', None); sys.exit(subprocess.call(['nautobot-server', 'celery', 'inspect', 'ping', '--destination', 'celery@' + os.environ.get('HOSTNAME', '')]))"
             initialDelaySeconds: 60
             periodSeconds: 120
             timeoutSeconds: 60
             failureThreshold: 10
-      {{- if .Values.nautobot.customJobs.enabled }}
       volumes:
+        # See the nautobot web pod for why /prom_cache is an emptyDir.
+        - name: prom-cache
+          emptyDir:
+            sizeLimit: 256Mi
+        {{- if .Values.nautobot.customJobs.enabled }}
         - name: custom-jobs
           persistentVolumeClaim:
             claimName: {{ .Values.nautobot.customJobs.pvcName }}
-      {{- end }}
+        {{- end }}
       terminationGracePeriodSeconds: 120
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Enable **prometheus_client multiprocess mode** for Nautobot by baking
`prometheus_multiproc_dir=/prom_cache` into the image — exactly how the stock
Nautobot image does it. This makes the `/metrics` self-deadlock *structurally
impossible* (not just mitigated) and produces metrics aggregated across all
uWSGI workers instead of whichever single worker answers the scrape.

Multiprocess mode brings one liability with it: `prometheus_client` keys its
metric files by PID and never reaps them, so `/prom_cache` grows for as long as
a pod lives. This PR also bounds that directory and stops the celery probes
from feeding it, so the mode is enabled and contained in a single change.

Supersedes the mitigation in #174, whose `uwsgi.ini` preload is removed here as
part of the same change.

No new Helm values or knobs.

## Root cause (condensed)

The web server runs multiple uWSGI workers. With no `PROMETHEUS_MULTIPROC_DIR`,
`prometheus_client` uses the **global in-process registry** created with
`auto_describe=True`:

1. A scrape calls `REGISTRY.register(NautobotAppMetricsCollector())`.
2. The collector has no `describe()`, so with `auto_describe=True`, `register()`
   calls `collect()` **while holding the non-reentrant `REGISTRY._lock`**.
3. `collect()` touches Django's cache → lazily imports
   `django_prometheus.cache.backends.redis` → `django_prometheus.cache.metrics`,
   which instantiates `Counter()`s at import time, each **re-acquiring the lock
   the same thread already holds** → self-deadlock.

Setting `prometheus_multiproc_dir` switches every worker to a fresh
`CollectorRegistry(auto_describe=False)`, so `register()` never calls `collect()`
under the lock. Full reproduction/proof is in #174.

> Environments that already use the stock Nautobot image never hit this because
> that image bakes `prometheus_multiproc_dir=/prom_cache`; our custom distroless
> image did not. This change brings our image in line.

### The liability that comes with multiprocess mode

`prometheus_client` writes one set of `*.db` files per PID and only reaps
*live-gauge* files — counters and histograms are cumulative, so deleting them
would make metrics go backwards. Anything that spawns short-lived
`nautobot-server` processes therefore leaves orphans behind permanently, and
every `/metrics` scrape has to read the whole directory.

This is not theoretical. A sibling deployment that has run in multiprocess mode
all along accumulated **49,636 files (778 MB)** in `/prom_cache` after 22 days,
at which point concurrent scrapes became GIL-bound on file I/O and timed out. A
`uwsgi --connect-and-read` tracebacker dump on that live pod showed every worker
thread parked in `prometheus_client/mmap_dict.py:read_all_values_from_file`. It
presents like a deadlock but is a throughput collapse — no lock involved. Its
cause was an `exec: nautobot-server health_check` liveness probe forking a new
PID every 120s.

## Change

**`build/nautobot.Dockerfile`**

* `ENV prometheus_multiproc_dir=/prom_cache` (+ upper-case `PROMETHEUS_MULTIPROC_DIR`
  alias for cross-version compatibility).
* Create `/prom_cache` in the builder stage and `COPY --chown=1000:1000` it into
  the runtime image (the distroless runtime has no shell, so it can't `mkdir` at
  build time; this mirrors the existing `media`/`.cache` dirs and makes it
  writable by the runtime uid). `prometheus_client` requires the dir to exist.

**`deploy/helm/templates/_nautobot-configmap-data.tpl`**

* Remove `import = django_prometheus.cache.metrics`. With multiprocess mode on,
  the `/metrics` handler builds a per-request `CollectorRegistry()`;
  `CollectorRegistry` defaults to `auto_describe=False`, and `register()` only
  substitutes `collector.collect()` for a missing `describe()` when
  `auto_describe` is set. `collect()` is therefore never invoked while the
  registry lock is held, the lazy `django_prometheus.cache.metrics` import can no
  longer re-enter it, and the preload is dead weight. The template is now
  byte-identical to its pre-#174 content.

**`deploy/helm/templates/nautobot.yaml`**

* `/prom_cache` becomes an **`emptyDir` with a 256Mi `sizeLimit`** on the web and
  celery pods. The image still creates the directory; the volume only adds
  lifecycle management — it starts empty on every pod start and cannot grow
  without bound. Steady state is a handful of files per uWSGI worker (tens of
  KB each), so the limit is a regression signal, not something normal operation
  approaches. `fsGroup: 1000` is already set on these pods and the image chowns
  the directory to 1000:1000, so the mount is writable.
* The **celery liveness/readiness probes drop `$prometheus_multiproc_dir` and
  `$PROMETHEUS_MULTIPROC_DIR` from the environment** of the `nautobot-server`
  process they fork. A celery worker has no HTTP listener, so these probes can't
  become `httpGet` the way the web pod's already are. Without the variable the
  forked process keeps `prometheus_client` in single-process mode and writes no
  files at all. `celery inspect ping` never touches `/metrics`, so nothing is
  lost.

The env is image-wide (matching the stock Nautobot image), so it applies to the
web server as well as celery/beat — consistent with the stock image's behavior.

## Validation

* Confirmed against the pinned Nautobot **2.4.36** that `NautobotMetricsView.get()`
  selects `CollectorRegistry()` + `MultiProcessCollector` when either env spelling
  is present (`nautobot/core/views/__init__.py:489-501`), and against
  `prometheus_client/registry.py` that `CollectorRegistry.__init__` defaults to
  `auto_describe=False` and `_get_names()` only falls back to `collector.collect`
  when `_auto_describe` is truthy. That is what makes the preload removal safe.
* `helm template ... --values values-ci.yaml` renders; the emitted `uwsgi.ini`
  contains no `import` directive and is otherwise unchanged. Also renders clean
  with `values-observability.yaml` layered, and `helm lint` passes (only the
  pre-existing temporal name-length warnings).
* Audited every rendered Nautobot pod for probe handler and mount:

  ```
  test-nv-config-manager-nautobot / nautobot
      startup/liveness/readiness = httpGet /health/:http
      /prom_cache -> emptyDir sizeLimit 256Mi
  test-nv-config-manager-nautobot-celery / celery
      liveness/readiness = exec, strips prom env before forking
      /prom_cache -> emptyDir sizeLimit 256Mi
  test-nv-config-manager-nautobot-celery-beat / celery-beat
      liveness = exec, file-mtime check (never forks nautobot-server)
  ```

  Re-rendered with `nautobot.customJobs.enabled=true` to cover the restructured
  celery `volumes`/`volumeMounts` blocks, which were previously wrapped entirely
  in that conditional; both `prom-cache` and `custom-jobs` appear.
* Executed the new probe one-liner with both env spellings set and confirmed the
  forked child sees neither, still sees `HOSTNAME`, and that the exit code
  propagates (so probe semantics are unchanged).
* Checked the runtime image is actually able to use the directory: the distroless
  base runs as `nvs` = **uid/gid 1000** (matching the `--chown`), and the chart's
  container security context does **not** set `readOnlyRootFilesystem`, so
  `/prom_cache` is writable.
* Diffed our image against the upstream `nautobot:2.4.36` `final` stage: its
  complete production `ENV` set is `PYTHONUNBUFFERED`, `NAUTOBOT_ROOT` and
  `prometheus_multiproc_dir`, so this was the **only** missing environment
  variable. Everything else stock provides is either already covered
  (`docker-entrypoint.sh`'s `post_upgrade`/superuser work is done by
  `migration_runner.py`; `uwsgi.ini` comes from the chart ConfigMap;
  `/etc/mime.types` is already in the distroless base;
  `INSTALLATION_METRICS_ENABLED=False` is set in `nautobot_config.py`) or
  deliberately unused (self-signed certs + `https`/8443, `libmariadb3`,
  `libxmlsec1`).

## Notes

* No `metrics.multiproc.*` values / toggle (removed from an earlier revision of
  this PR at review request — matches the stock image exactly).
* Takes effect on image rebuild + rollout.
* The web pod needed no probe change: its startup/liveness/readiness probes are
  already `httpGet /health/` (#173), served by the existing uWSGI workers, so it
  creates no new PIDs. Before that fix it would have been the worst offender —
  readiness every 10s plus liveness every 120s.
* Celery **beat** is deliberately left alone. Its probe is a `/tmp` file-mtime
  check that never forks `nautobot-server`, and the beat process itself is a
  single long-lived PID, so nothing accumulates.
* Not fully eliminated, and not worth further machinery: a uWSGI worker that is
  respawned (harakiri, OOM, crash) gets a new PID and orphans its predecessor's
  files for the life of the pod. `harakiri` is 1210s and none of
  `max-requests` / `max-worker-lifetime` / `reload-on-rss` / `cheaper` are set,
  so worker churn is rare, and the `emptyDir` caps the worst case regardless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nautobot Prometheus metrics reliability by aggregating metrics across all web workers.
  * Fixed recurring `/metrics/` 404 errors for NVIDIA Config Manager monitoring.
  * Prevented Celery health checks from generating unnecessary metrics artifacts.

* **Operations**
  * Added dedicated, ephemeral metrics storage with a 256 MiB limit.
  * Metrics storage resets when a pod restarts, preventing unbounded growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Kind Integration

<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`d79a997`](https://github.com/NVIDIA/nv-config-manager/commit/d79a99702e28ee161036fd06d806a2c999db3d2d) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30476383889).
<!-- kind-integration-result:end -->
