### PR TITLE
fix(helm): use Recreate strategy for persistent Redis

### DIFF
--- a/deploy/helm/templates/redis.yaml
+++ b/deploy/helm/templates/redis.yaml
@@ -41,7 +41,13 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ $redisName }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.externalServices.redis.persistence.enabled }}
+  # A ReadWriteOnce PVC cannot be mounted by old and new pods on different nodes.
+  strategy:
+    type: Recreate
+  {{- else }}
   {{- include "nv-config-manager.deploymentStrategy" (dict "root" .) | nindent 2 }}
+  {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Description

Use the `Recreate` deployment strategy for chart-managed Redis whenever
persistence is enabled.

`Recreate` stops the old pod before creating its replacement, allowing the
volume to detach and reattach cleanly. This introduces the expected brief Redis
interruption during a rollout but preserves the PVC and its data. Ephemeral
Redis retains the existing deployment-strategy behavior.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Redis deployments with persistent storage to use a recreate strategy, preventing storage mounting conflicts during updates.
  * Redis deployments without persistent storage continue using the standard update strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->