### PR TITLE
fix(ui): use mirrored Node builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ docker-build-kea-admin:
 # Build NVIDIA Config Manager UI image
 docker-build-ui:
 	@echo "🏗️  Building NVIDIA Config Manager UI image with tag $(LOCAL_TAG)..."
-	docker build --provenance=false $(APT_MIRROR_ARGS) -t nv-config-manager-ui:$(LOCAL_TAG) -f build/ui.Dockerfile ui/
+	docker build --provenance=false -t nv-config-manager-ui:$(LOCAL_TAG) -f build/ui.Dockerfile ui/
 	@echo "✅ Built nv-config-manager-ui:$(LOCAL_TAG)"
 
 # Build Nautobot image
@@ -616,7 +616,6 @@ docker-build-single-ui: ## Builds and pushes UI image for PLATFORM.
 		--platform $(PLATFORM) \
 		-t $(REGISTRY)/nv-config-manager-ui:$(VERSION) \
 		$(EXTRA_TAGS) \
-		$(APT_MIRROR_ARGS) \
 		-f build/ui.Dockerfile \
 		$(DOCKER_BUILD_OUTPUT) \
 		ui/
@@ -753,7 +752,6 @@ docker-build-ui-multiarch: docker-buildx-setup ## Builds and pushes multi-arch N
 		-t $(REGISTRY)/nv-config-manager-ui:$(VERSION) \
 		$(LATEST_TAG_ui) \
 		$(EXTRA_TAGS) \
-		$(APT_MIRROR_ARGS) \
 		-f build/ui.Dockerfile \
 		--push \
 		ui/

--- a/build/ui.Dockerfile
+++ b/build/ui.Dockerfile
@@ -1,34 +1,13 @@
 # NVIDIA Config Manager UI - Next.js Application
 #
 # Uses NVIDIA distroless Node.js image for minimal attack surface.
-# Multi-stage build: deps/builder stages use Ubuntu, runtime uses distroless.
+# Multi-stage build: deps/builder stages use the official Node.js image,
+# runtime uses NVIDIA distroless.
 
 # =============================================================================
 # Dependencies stage - install npm packages
 # =============================================================================
-FROM nvcr.io/nvidia/base/ubuntu:noble-20260217 AS deps
-
-ARG APT_MIRROR=""
-ARG APT_MIRROR_GPG_KEY_URL=""
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install Node.js 24.x
-COPY --from=scripts configure-apt-mirror.sh /tmp/configure-apt-mirror.sh
-RUN set -eux; \
-    /tmp/configure-apt-mirror.sh "$APT_MIRROR" "$APT_MIRROR_GPG_KEY_URL" ubuntu && \
-    apt-get update && apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        gnupg && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends nodejs && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM docker.io/library/node:24-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS deps
 
 WORKDIR /app
 
@@ -75,4 +54,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["server.js"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Description

Fix intermittent kind integration failures to fetch the NodeSource signing key.

This change:

- replaces the Ubuntu/NodeSource dependency stage with the official
  `node:24-bookworm-slim` image pinned to its multi-architecture digest;
- lets CI resolve that `docker.io` base through the runner's existing Docker Hub
  pull-through cache configured by `setup-proxy-cache`, avoiding per-job
  anonymous Docker Hub pulls;
- removes the now-obsolete APT mirror arguments and build context from the three
  UI Makefile targets; and
- invokes `node server.js` explicitly because the pinned NVIDIA distroless v4
  runtime uses the shell-less wrapper as its entrypoint and cannot execute
  `server.js` directly.

The final runtime remains `nvcr.io/nvidia/distroless/node:24-v4.0.10` at its
existing pinned digest. There are no UI application or dependency-lock changes.

## Validation

- [x] Standard CI passes. Pending this draft PR's CI.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test aa782b85a842ed8ce4403774c8770548c7f9ab46
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`aa782b8`](https://github.com/NVIDIA/nv-config-manager/commit/aa782b85a842ed8ce4403774c8770548c7f9ab46) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30310184708).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests
      are not needed. The image build and runtime health check directly cover
      this Dockerfile-only change.
- [x] Documentation is updated for user-facing behavior changes. Not
      applicable; this only changes build plumbing and corrects the container
      entry command.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs. Not applicable; no generated
      sources changed.
