### PR TITLE
Document Spectrum-X switch management

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -146,17 +146,17 @@ navigation:
     - page: Spectrum-X Switch Management
       path: ../user-guides/spectrum-x-switch-management/index.mdx
 
-    - section: SpX Overlay Lifecycle
+    - section: Spectrum-X Overlay Lifecycle
       collapsible: true
       collapsed-by-default: true
       contents:
-      - page: SpX Overlay Creation
+      - page: Spectrum-X Overlay Creation
         path: ../user-guides/vpc-creation/index.mdx
-      - page: SpX Overlay Deletion
+      - page: Spectrum-X Overlay Deletion
         path: ../user-guides/vpc-deletion/index.mdx
-      - page: SpX Overlay Assignment
+      - page: Spectrum-X Overlay Assignment
         path: ../user-guides/vpc-assignment/index.mdx
-      - page: SpX Overlay Tenant Change
+      - page: Spectrum-X Overlay Tenant Change
         path: ../user-guides/vpc-tenant-change/index.mdx
 
   - section: Deployment

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -80,8 +80,6 @@ navigation:
     collapsible: true
     collapsed-by-default: true
     contents:
-    - page: Spectrum-X Switch Management
-      path: ../user-guides/spectrum-x-switch-management/index.mdx
     - page: New Site Bringup
       path: ../user-guides/new-site-deployment/index.mdx
     - page: Controlling Running Workflows
@@ -144,6 +142,9 @@ navigation:
         path: ../user-guides/ib-pkey-member-delete/index.mdx
       - page: IB Port GUID Discovery
         path: ../user-guides/ib-port-guid-discovery/index.mdx
+
+    - page: Spectrum-X Switch Management
+      path: ../user-guides/spectrum-x-switch-management/index.mdx
 
     - section: SpX Overlay Lifecycle
       collapsible: true

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -80,6 +80,8 @@ navigation:
     collapsible: true
     collapsed-by-default: true
     contents:
+    - page: Spectrum-X Switch Management
+      path: ../user-guides/spectrum-x-switch-management/index.mdx
     - page: New Site Bringup
       path: ../user-guides/new-site-deployment/index.mdx
     - page: Controlling Running Workflows

--- a/docs/i-want-to.mdx
+++ b/docs/i-want-to.mdx
@@ -11,6 +11,7 @@ A scenario-first index into the docs. Pick the row that describes what you are t
 | I want to... | Go to |
 | :----------- | :---- |
 | Understand what Config Manager is and which path to start with. | [Start Here](getting-started/index.mdx) |
+| Understand how Config Manager supports Spectrum-X switch bootstrap and operations. | [Spectrum-X Switch Management](user-guides/spectrum-x-switch-management/index.mdx) |
 | Know whether to use the Config Manager UI, Nautobot UI, Temporal Web, or an API. | [Which Interface Should I Use?](getting-started/interfaces.mdx) |
 | Preview Config Manager locally without touching real devices. | [Local Development Quick Start](getting-started/local-development-quick-start.mdx) |
 | Validate Config Manager workflows against simulated Cumulus switches in NVIDIA DSX Air. | [DSX Air Simulation User Guide](user-guides/air-simulation/index.mdx) |

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,6 +15,7 @@ The project's GitHub repository is [https://github.com/nvidia/nv-config-manager]
 - [Start Here](getting-started/index.mdx) explains the product, personas, and recommended first path.
 - [Getting Started with Config Manager](install/index.mdx) covers the standard connected install path.
 - [Which Interface Should I Use?](getting-started/interfaces.mdx) explains the Config Manager UI, Nautobot UI, Temporal Web, and APIs.
+- [Spectrum-X Switch Management](user-guides/spectrum-x-switch-management/index.mdx) summarizes day-0 and day-2 Spectrum-X support and links to the relevant workflows.
 - [Airgapped Deployment](install/install-airgapped.mdx) covers disconnected environments.
 - [DSX Air Simulation User Guide](user-guides/air-simulation/index.mdx) covers workflow validation in NVIDIA DSX Air.
 - [I want to...](i-want-to.mdx) routes common tasks to the right guide.

--- a/docs/temporal/workflows/vpc-creation.mdx
+++ b/docs/temporal/workflows/vpc-creation.mdx
@@ -12,10 +12,6 @@ A VPC is an _overlay network_, using virtual routing and forwarding (VRF) with r
 
 Typically, Spectrum-X tenant isolation is handled by the DPU with [Astra](https://developer.nvidia.com/blog/redefining-secure-ai-infrastructure-with-nvidia-bluefield-astra-for-nvidia-vera-rubin-nvl72/#what_is_nvidia_bluefield_astra%C2%A0), but where a DPU-based isolation solution (such as [NiCo](https://docs.nvidia.com/infra-controller/documentation/home) + Astra) is not available, Config Manager supports isolation at the Switch port level on the underlay instead.
 
-<Warning title="Experimental">
-This workflow is experimental and not intended for general use. Use it only in test or pilot environments.
-</Warning>
-
 ## User Interface
 
 ### Form Inputs

--- a/docs/temporal/workflows/vpc-deletion.mdx
+++ b/docs/temporal/workflows/vpc-deletion.mdx
@@ -6,10 +6,6 @@ position: 10
 
 Removes a virtual private cloud (VPC) and cleans up associated network resources and configurations.
 
-<Warning title="Experimental">
-This workflow is experimental and not intended for general use. Use it only in test or pilot environments.
-</Warning>
-
 ## User Interface
 
 ### Form Inputs

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -43,9 +43,7 @@ flowchart LR
   changes, collect state, validate the fabric, rotate credentials, and manage
   the switch lifecycle.
 
-See [System Architecture](../../overview/architecture.mdx) for the component
-model and [Which Interface Should I Use?](../../getting-started/interfaces.mdx)
-for the Config Manager UI, Nautobot UI, Temporal Web, and API boundaries.
+The [System Architecture](../../overview/architecture.mdx) describes the component model. [Which Interface Should I Use?](../../getting-started/interfaces.mdx) explains the Config Manager UI, Nautobot UI, Temporal Web, and API boundaries.
 
 ## Spectrum-X switch workflows
 

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -86,8 +86,7 @@ For a routine configuration change:
 1. Run [Configuration Deploy](../configuration-deploy/index.mdx) for one switch
    or [Multi-Device Deploy](../multi-deploy/index.mdx) for a coordinated
    fabric-wide change.
-1. Review the generated diff at the approval stage. After an approved apply,
-   Config Manager captures a new running-configuration backup.
+1. Review the generated diff at the approval stage. After Config Manager applies the approved change, it captures a new running-configuration backup.
 
 ## Spectrum-X overlay lifecycle
 

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -9,17 +9,8 @@ Ethernet switches. A Spectrum-X switch running Cumulus Linux follows the same
 provisioning, configuration, validation, and lifecycle workflows as any other
 Cumulus Linux switch in Config Manager.
 
-Spectrum-X is therefore not a separate device platform in Config Manager.
-Model the switch with the appropriate Cumulus Linux platform and fabric role in
-Nautobot. Config Manager then selects the role- and version-specific templates
-and workflows that apply to the device.
-
 This page is the starting point for Spectrum-X switch support. It summarizes the
 management path and links to the detailed operator guides.
-
-Within a CIN deployment, this page covers the Spectrum-X Ethernet portion of the
-network. Config Manager's InfiniBand operations use separate InfiniBand
-workflows.
 
 ## Where Config Manager fits
 

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -1,0 +1,153 @@
+---
+title: Spectrum-X Switch Management
+sidebar-title: Spectrum-X Switch Management
+position: 5
+---
+
+NVIDIA Config Manager, also known internally as Kiwi, supports the day-0 and
+day-2 management of Spectrum-X Ethernet switches. A Spectrum-X switch running
+Cumulus Linux follows the same provisioning, configuration, validation, and
+lifecycle workflows as any other Cumulus Linux switch in Config Manager.
+
+Spectrum-X is therefore not a separate device platform in Config Manager.
+Model the switch with the appropriate Cumulus Linux platform and fabric role in
+Nautobot. Config Manager then selects the role- and version-specific templates
+and workflows that apply to the device.
+
+This page is the starting point for Spectrum-X switch support. It summarizes the
+management path and links to the detailed operator guides.
+
+Within a CIN deployment, this page covers the Spectrum-X Ethernet portion of the
+network. Config Manager's InfiniBand operations use separate InfiniBand
+workflows.
+
+## Where Config Manager fits
+
+```mermaid
+flowchart LR
+    N["Nautobot<br/>source of truth"] --> R["Render Service"]
+    T["Cumulus Linux<br/>configuration templates"] --> R
+    R --> C["Config Store<br/>versioned intent"]
+    C --> Z["DHCP and ZTP<br/>day-0 bootstrap"]
+    C --> W["Temporal workflows<br/>day-2 operations"]
+    Z --> S["Spectrum-X switches<br/>Cumulus Linux"]
+    W <--> S
+    W -->|running-config backups| C
+```
+
+- **Nautobot is the source of truth.** Device identity, platform, role,
+  interfaces, cabling, addressing, tenant data, and config contexts define the
+  intended state.
+- **The Render Service converts intent into device configuration.** It combines
+  Nautobot data with the Cumulus Linux templates selected for the switch role
+  and software version.
+- **The Config Store versions intended and running configurations.** ZTP and
+  deployment workflows consume the rendered intent; backup workflows write
+  running-state snapshots for audit and drift detection.
+- **DHCP and ZTP handle initial provisioning.** A factory-default switch obtains
+  its boot information, installs the intended Cumulus Linux image when needed,
+  downloads its rendered configuration, and reports its provisioning state.
+- **Temporal workflows handle ongoing operations.** Config Manager reaches the
+  switch over the management network to calculate and apply configuration
+  changes, collect state, validate the fabric, rotate credentials, and manage
+  the switch lifecycle.
+
+See [System Architecture](../../overview/architecture.mdx) for the component
+model and [Which Interface Should I Use?](../../getting-started/interfaces.mdx)
+for the Config Manager UI, Nautobot UI, Temporal Web, and API boundaries.
+
+## Spectrum-X switch workflows
+
+The following workflows are the normal operational path for Spectrum-X
+switches. The linked guides contain prerequisites, UI inputs, execution stages,
+verification steps, and failure recovery.
+
+| Phase | Task | Config Manager path |
+| :---- | :--- | :------------------ |
+| Model | Register switches, interfaces, cabling, addressing, roles, software targets, and config contexts. | [Nautobot Bootstrap](../../nautobot/index.mdx) and [DHCP Modeling in Nautobot](../../dhcp/nautobot-modeling.mdx) |
+| Bootstrap | Provision factory-default switches with the intended Cumulus Linux image and configuration. | [New Site Bringup](../new-site-deployment/index.mdx) and [Network ZTP](../../network-ztp/index.mdx) |
+| Validate | Compare observed LLDP, FDB, and ARP data with the modeled cabling. | [Cable Validation](../cable-validation/index.mdx) |
+| Validate | Collect Cumulus platform, environmental, and inventory health across the site. | [Cumulus Hardware Validation](../hardware-validation/index.mdx) |
+| Observe | Identify hosts connected to each switch interface. | [Connected Host Metadata](../connected-host-metadata/index.mdx) |
+| Configure | Review and apply a rendered change to one switch, with human approval of the diff. | [Configuration Deploy](../configuration-deploy/index.mdx) |
+| Configure | Apply a reviewed change across multiple switches with grouped, per-batch approval. | [Multi-Device Deploy](../multi-deploy/index.mdx) |
+| Audit | Capture running configurations and compare them with intended state. | [Configuration Backup](../configuration-backup/index.mdx) and [Site Configuration Backup](../site-configuration-backup/index.mdx) |
+| Recover | Factory-reset a reachable switch, re-run ZTP, and capture a fresh backup. | [Device Reprovision](../reprovision/index.mdx) |
+| Maintain | Upgrade Cumulus Linux through the image install, reboot, ZTP, and post-upgrade validation cycle. | [Switch OS Upgrade](../switch-os-upgrade/index.mdx) |
+| Secure | Rotate device credentials on one switch or across a site. | [Device Password Rotation](../device-password-rotation/index.mdx) and [Site Password Rotation](../site-password-rotation/index.mdx) |
+
+### Typical operating sequences
+
+For a new Spectrum-X fabric:
+
+1. Load the approved topology and device intent into Nautobot.
+1. Upload the required Cumulus Linux images to the ZTP service.
+1. Follow [New Site Bringup](../new-site-deployment/index.mdx) to power on and
+   provision the switches.
+1. Run [Cable Validation](../cable-validation/index.mdx) and
+   [Cumulus Hardware Validation](../hardware-validation/index.mdx) before
+   handing the fabric to normal operations.
+
+For a routine configuration change:
+
+1. Change the source data in Nautobot or the applicable configuration template.
+1. Confirm that the Render Service produced the expected intended configuration.
+1. Run [Configuration Deploy](../configuration-deploy/index.mdx) for one switch
+   or [Multi-Device Deploy](../multi-deploy/index.mdx) for a coordinated
+   fabric-wide change.
+1. Review the generated diff at the approval stage. After an approved apply,
+   Config Manager captures a new running-configuration backup.
+
+## Spectrum-X overlay lifecycle
+
+Config Manager also includes workflows for switch-port tenant isolation on the
+Spectrum-X underlay. These workflows manage the overlay, VRF, VXLAN, device, and
+interface intent in Nautobot and can render and deploy the resulting
+configuration.
+
+<Warning title="Experimental">
+The SpX overlay workflows are experimental and are not intended for general
+production use. Use them only in test or pilot environments. The general
+Cumulus Linux workflows in the previous section are not part of this
+experimental designation.
+</Warning>
+
+| Workflow | Purpose | Device impact |
+| :------- | :------ | :------------ |
+| [SpX Overlay Creation](../vpc-creation/index.mdx) | Allocate the route distinguisher and create the Overlay, VRF, and L3 VXLAN objects in Nautobot. | No switch configuration is changed. |
+| [SpX Overlay Assignment](../vpc-assignment/index.mdx) | Bind an existing overlay VRF to a device and selected interfaces in Nautobot. This is normally called by SpX Overlay Tenant Change; the standalone workflow is API-only. | No switch configuration is changed until a deploy runs. |
+| [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx) | Orchestrate assignment, tenant-scoped rendering, and deployment to a switch. | Applies the validated tenant configuration to the target switch. |
+| [SpX Overlay Deletion](../vpc-deletion/index.mdx) | Remove unused VRF, VXLAN, and Overlay metadata after assignments have been removed. | Deletes Nautobot intent; in-use VRFs are protected from deletion. |
+
+The common operator path is:
+
+1. Run **SpX Overlay Creation** once for the tenant overlay at the site.
+1. Run **SpX Overlay Tenant Change** to assign the overlay to a switch and its
+   ports, render the changed intent, and deploy it end to end.
+1. Before deletion, remove the overlay from all interfaces and deploy that
+   removal. Then run **SpX Overlay Deletion** to clean up the unused Nautobot
+   objects.
+
+These overlay workflows are additional to the normal Spectrum-X switch
+management path. They are not required for ZTP, general configuration
+deployment, backup, validation, reprovisioning, software upgrades, or password
+rotation.
+
+## Management prerequisites
+
+Before operating a Spectrum-X switch through Config Manager, confirm:
+
+- The device is modeled in Nautobot with its Cumulus Linux platform, fabric
+  role, serial number, management identity, interfaces, cabling, intended
+  software, and required config contexts.
+- Config Manager can reach the device management network and the required
+  [firewall ports](../../firewall-ports/index.mdx) are open.
+- Device credentials are available through the configured secrets backend.
+- The correct Cumulus Linux image is available to the
+  [ZTP service](../../network-ztp/upload-images.mdx).
+- The Render Service has produced a current intended configuration in the
+  Config Store before a deploy, backup, reprovision, or upgrade workflow runs.
+
+For device-facing validation without physical hardware, use the
+[DSX Air Simulation User Guide](../air-simulation/index.mdx), which provisions
+simulated Cumulus Linux switches and supports the main Ethernet workflows.

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -105,13 +105,6 @@ Spectrum-X underlay. These workflows manage the overlay, VRF, VXLAN, device, and
 interface intent in Nautobot and can render and deploy the resulting
 configuration.
 
-<Warning title="Experimental">
-The SpX overlay workflows are experimental and are not intended for general
-production use. Use them only in test or pilot environments. The general
-Cumulus Linux workflows in the previous section are not part of this
-experimental designation.
-</Warning>
-
 | Workflow | Purpose | Device impact |
 | :------- | :------ | :------------ |
 | [SpX Overlay Creation](../vpc-creation/index.mdx) | Allocate the route distinguisher and create the Overlay, VRF, and L3 VXLAN objects in Nautobot. | No switch configuration is changed. |

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -112,7 +112,7 @@ The common operator path is:
    removal. Then run **SpX Overlay Deletion** to clean up the unused Nautobot
    objects.
 
-These overlay workflows are additional to the normal Spectrum-X switch
+These overlay workflows supplement the normal Spectrum-X switch
 management path. They are not required for ZTP, general configuration
 deployment, backup, validation, reprovisioning, software upgrades, or password
 rotation.

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -4,10 +4,10 @@ sidebar-title: Spectrum-X Switch Management
 position: 5
 ---
 
-NVIDIA Config Manager, also known internally as Kiwi, supports the day-0 and
-day-2 management of Spectrum-X Ethernet switches. A Spectrum-X switch running
-Cumulus Linux follows the same provisioning, configuration, validation, and
-lifecycle workflows as any other Cumulus Linux switch in Config Manager.
+NVIDIA Config Manager supports the day-0 and day-2 management of Spectrum-X
+Ethernet switches. A Spectrum-X switch running Cumulus Linux follows the same
+provisioning, configuration, validation, and lifecycle workflows as any other
+Cumulus Linux switch in Config Manager.
 
 Spectrum-X is therefore not a separate device platform in Config Manager.
 Model the switch with the appropriate Cumulus Linux platform and fabric role in

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -95,17 +95,17 @@ configuration.
 
 | Workflow | Purpose | Device impact |
 | :------- | :------ | :------------ |
-| [SpX Overlay Creation](../vpc-creation/index.mdx) | Allocate the route distinguisher and create the Overlay, VRF, and L3 VXLAN objects in Nautobot. | No switch configuration is changed. |
-| [SpX Overlay Assignment](../vpc-assignment/index.mdx) | Bind an existing overlay VRF to a device and selected interfaces in Nautobot. This is normally called by SpX Overlay Tenant Change; the standalone workflow is API-only. | No switch configuration is changed until a deploy runs. |
-| [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx) | Orchestrate assignment, tenant-scoped rendering, and deployment to a switch. | Applies the validated tenant configuration to the target switch. |
-| [SpX Overlay Deletion](../vpc-deletion/index.mdx) | Remove unused VRF, VXLAN, and Overlay metadata after assignments have been removed. | Deletes Nautobot intent; in-use VRFs are protected from deletion. |
+| [Spectrum-X Overlay Creation](../vpc-creation/index.mdx) | Allocate the route distinguisher and create the Overlay, VRF, and L3 VXLAN objects in Nautobot. | No switch configuration is changed. |
+| [Spectrum-X Overlay Assignment](../vpc-assignment/index.mdx) | Bind an existing overlay VRF to a device and selected interfaces in Nautobot. This is normally called by Spectrum-X Overlay Tenant Change; the standalone workflow is API-only. | No switch configuration is changed until a deploy runs. |
+| [Spectrum-X Overlay Tenant Change](../vpc-tenant-change/index.mdx) | Orchestrate assignment, tenant-scoped rendering, and deployment to a switch. | Applies the validated tenant configuration to the target switch. |
+| [Spectrum-X Overlay Deletion](../vpc-deletion/index.mdx) | Remove unused VRF, VXLAN, and Overlay metadata after assignments have been removed. | Deletes Nautobot intent; in-use VRFs are protected from deletion. |
 
 The common operator path is:
 
-1. Run **SpX Overlay Creation** once for the tenant overlay at the site.
-1. Run **SpX Overlay Tenant Change** to assign the overlay to a switch and its
+1. Run **Spectrum-X Overlay Creation** once for the tenant overlay at the site.
+1. Run **Spectrum-X Overlay Tenant Change** to assign the overlay to a switch and its
    ports, render the changed intent, and deploy it end to end.
-1. Before deletion, remove the overlay from all interfaces and deploy the resulting configuration change. Then, run **SpX Overlay Deletion** to clean up the unused Nautobot objects.
+1. Before deletion, remove the overlay from all interfaces and deploy the resulting configuration change. Then, run **Spectrum-X Overlay Deletion** to clean up the unused Nautobot objects.
 
 These overlay workflows supplement the normal Spectrum-X switch
 management path. They are not required for ZTP, general configuration

--- a/docs/user-guides/spectrum-x-switch-management/index.mdx
+++ b/docs/user-guides/spectrum-x-switch-management/index.mdx
@@ -107,9 +107,7 @@ The common operator path is:
 1. Run **SpX Overlay Creation** once for the tenant overlay at the site.
 1. Run **SpX Overlay Tenant Change** to assign the overlay to a switch and its
    ports, render the changed intent, and deploy it end to end.
-1. Before deletion, remove the overlay from all interfaces and deploy that
-   removal. Then run **SpX Overlay Deletion** to clean up the unused Nautobot
-   objects.
+1. Before deletion, remove the overlay from all interfaces and deploy the resulting configuration change. Then, run **SpX Overlay Deletion** to clean up the unused Nautobot objects.
 
 These overlay workflows supplement the normal Spectrum-X switch
 management path. They are not required for ZTP, general configuration

--- a/docs/user-guides/vpc-assignment/index.mdx
+++ b/docs/user-guides/vpc-assignment/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: SpX Overlay Assignment
-sidebar-title: SpX Overlay Assignment
+title: Spectrum-X Overlay Assignment
+sidebar-title: Spectrum-X Overlay Assignment
 position: 30
 ---
 
-The SpX Overlay Assignment workflow binds an existing overlay's VRF to a specific device and to a specific set of ports on that device. It updates Nautobot's IPAM intent and records matching device and interface `OverlayAssignment` entries in the overlays plugin without touching the device itself; the device-side change happens when a subsequent deploy applies the resulting intended configuration. Assignment is the second step in the SpX Overlay lifecycle, after [SpX Overlay Creation](../vpc-creation/index.mdx) provisions the VRF and Overlay objects.
+The Spectrum-X Overlay Assignment workflow binds an existing overlay's VRF to a specific device and to a specific set of ports on that device. It updates Nautobot's IPAM intent and records matching device and interface `OverlayAssignment` entries in the overlays plugin without touching the device itself; the device-side change happens when a subsequent deploy applies the resulting intended configuration. Assignment is the second step in the Spectrum-X Overlay lifecycle, after [Spectrum-X Overlay Creation](../vpc-creation/index.mdx) provisions the VRF and Overlay objects.
 
-For the end-to-end assign + render + deploy lifecycle, use [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx) — it calls this workflow as a child plus the render and deploy steps.
+For the end-to-end assign + render + deploy lifecycle, use [Spectrum-X Overlay Tenant Change](../vpc-tenant-change/index.mdx) — it calls this workflow as a child plus the render and deploy steps.
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ Before running, confirm:
 
 ## Running the workflow
 
-SpX Overlay Assignment is not exposed in the Config Manager UI today. It is invoked as a child of [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx), which orchestrates assignment plus the subsequent re-render and deploy. To run assignment in isolation, submit the workflow through the API with the target overlay, device, ports, and site.
+Spectrum-X Overlay Assignment is not exposed in the Config Manager UI today. It is invoked as a child of [Spectrum-X Overlay Tenant Change](../vpc-tenant-change/index.mdx), which orchestrates assignment plus the subsequent re-render and deploy. To run assignment in isolation, submit the workflow through the API with the target overlay, device, ports, and site.
 
 After submission, a status page shows the three stages.
 
@@ -46,13 +46,13 @@ After the workflow reports success, confirm:
 - **Result shape** — `assigned_ports` lists the ports actually changed; `vrf_assigned=true` means the device-level binding was new this run; `vrf` carries the bound VRF record.
 - **Nautobot** shows the VRF on the device and on each named interface.
 - **Nautobot overlays plugin** shows `OverlayAssignment` entries for the device and each named interface under the target overlay.
-- **Run a deploy** to push the resulting intended-config change to the device. The simplest path is [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx), which combines assignment with the subsequent re-render and deploy.
+- **Run a deploy** to push the resulting intended-config change to the device. The simplest path is [Spectrum-X Overlay Tenant Change](../vpc-tenant-change/index.mdx), which combines assignment with the subsequent re-render and deploy.
 
 ## Common issues
 
 **`get_device_and_vrf` raises `ApplicationError` "0 VRFs found".**
 
-The overlay has not been created yet at this site. Run [SpX Overlay Creation](../vpc-creation/index.mdx) first.
+The overlay has not been created yet at this site. Run [Spectrum-X Overlay Creation](../vpc-creation/index.mdx) first.
 
 **`get_device_and_vrf` raises `ApplicationError` "multiple VRFs found".**
 
@@ -68,7 +68,7 @@ Those ports were already bound to this VRF. Successful no-op for those ports —
 
 ## Related guides
 
-- [SpX Overlay Creation](../vpc-creation/index.mdx) — provision the VRF and Overlay metadata.
-- [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx) — assignment + render + deploy in one workflow.
-- [SpX Overlay Deletion](../vpc-deletion/index.mdx) — tear down an overlay (only after VRFs are unassigned).
-- [Tenant Deploy](../tenant-deploy/index.mdx) — the tenant-scoped deploy used by SpX Overlay Tenant Change to push the resulting config to the device.
+- [Spectrum-X Overlay Creation](../vpc-creation/index.mdx) — provision the VRF and Overlay metadata.
+- [Spectrum-X Overlay Tenant Change](../vpc-tenant-change/index.mdx) — assignment + render + deploy in one workflow.
+- [Spectrum-X Overlay Deletion](../vpc-deletion/index.mdx) — tear down an overlay (only after VRFs are unassigned).
+- [Tenant Deploy](../tenant-deploy/index.mdx) — the tenant-scoped deploy used by Spectrum-X Overlay Tenant Change to push the resulting config to the device.

--- a/docs/user-guides/vpc-assignment/index.mdx
+++ b/docs/user-guides/vpc-assignment/index.mdx
@@ -8,10 +8,6 @@ The SpX Overlay Assignment workflow binds an existing overlay's VRF to a specifi
 
 For the end-to-end assign + render + deploy lifecycle, use [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx) — it calls this workflow as a child plus the render and deploy steps.
 
-<Warning title="Experimental">
-This workflow is experimental and not intended for general use. Use it only in test or pilot environments.
-</Warning>
-
 ## Prerequisites
 
 Before running, confirm:

--- a/docs/user-guides/vpc-creation/index.mdx
+++ b/docs/user-guides/vpc-creation/index.mdx
@@ -8,10 +8,6 @@ The SpX Overlay Creation workflow provisions a SpectrumX overlay, VRFs, and L3 V
 
 Creation is idempotent on `overlay_id` — re-running with an existing ID returns the already-existing VRFs rather than creating new ones.
 
-<Warning title="Experimental">
-This workflow is experimental and not intended for general use. Use it only in test or pilot environments.
-</Warning>
-
 ## Prerequisites
 
 Before running, confirm:

--- a/docs/user-guides/vpc-creation/index.mdx
+++ b/docs/user-guides/vpc-creation/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: SpX Overlay Creation
-sidebar-title: SpX Overlay Creation
+title: Spectrum-X Overlay Creation
+sidebar-title: Spectrum-X Overlay Creation
 position: 10
 ---
 
-The SpX Overlay Creation workflow provisions a SpectrumX overlay, VRFs, and L3 VXLANs for a new overlay at a site. An overlay in this context is a tenant-scoped routing domain: creation allocates a route distinguisher (RD), registers the VRF objects in Nautobot, and creates an L3 VXLAN per namespace bound to a location-scoped Overlay object in the overlays plugin. No switches are touched by this workflow — applying the new overlay to a device happens through [SpX Overlay Assignment](../vpc-assignment/index.mdx), and re-rendering and redeploying tenant configuration happens through [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx).
+The Spectrum-X Overlay Creation workflow provisions a Spectrum-X overlay, VRFs, and L3 VXLANs for a new overlay at a site. An overlay in this context is a tenant-scoped routing domain: creation allocates a route distinguisher (RD), registers the VRF objects in Nautobot, and creates an L3 VXLAN per namespace bound to a location-scoped Overlay object in the overlays plugin. No switches are touched by this workflow — applying the new overlay to a device happens through [Spectrum-X Overlay Assignment](../vpc-assignment/index.mdx), and re-rendering and redeploying tenant configuration happens through [Spectrum-X Overlay Tenant Change](../vpc-tenant-change/index.mdx).
 
 Creation is idempotent on `overlay_id` — re-running with an existing ID returns the already-existing VRFs rather than creating new ones.
 
@@ -12,7 +12,7 @@ Creation is idempotent on `overlay_id` — re-running with an existing ID return
 
 Before running, confirm:
 
-- **Site exists in Nautobot** and has at least one namespace tagged for SpX overlay creation.
+- **Site exists in Nautobot** and has at least one namespace tagged for Spectrum-X overlay creation.
 - **Tenant exists in Nautobot.** The tenant is used to scope the created Overlay object.
 - **overlay_id chosen.** Pick a unique identifier; if the same ID is reused, the workflow short-circuits and returns the existing VRFs without creating new ones.
 - **Route-distinguisher range has free entries** within the site's allocated `rd_min`..`rd_max` window. The workflow's RD allocator pulls the first available RD in that window.
@@ -75,7 +75,7 @@ The overlay already existed — the workflow short-circuited. This is the expect
 
 ## Related guides
 
-- [SpX Overlay Deletion](../vpc-deletion/index.mdx) — tear down an overlay (only when it is not in use on any device).
-- [SpX Overlay Assignment](../vpc-assignment/index.mdx) — bind the new VRF to a device and specific ports.
-- [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx) — assign + render + deploy an overlay change against a device end-to-end.
+- [Spectrum-X Overlay Deletion](../vpc-deletion/index.mdx) — tear down an overlay (only when it is not in use on any device).
+- [Spectrum-X Overlay Assignment](../vpc-assignment/index.mdx) — bind the new VRF to a device and specific ports.
+- [Spectrum-X Overlay Tenant Change](../vpc-tenant-change/index.mdx) — assign + render + deploy an overlay change against a device end-to-end.
 - [Render Service](../../render/index.mdx) — produces the tenant-scoped configurations that get deployed onto devices once an overlay is assigned.

--- a/docs/user-guides/vpc-deletion/index.mdx
+++ b/docs/user-guides/vpc-deletion/index.mdx
@@ -6,10 +6,6 @@ position: 20
 
 The SpX Overlay Deletion workflow removes the VRF, L3 VXLAN, and Overlay metadata for an existing overlay from Nautobot. It is the cleanup counterpart to [SpX Overlay Creation](../vpc-creation/index.mdx) and refuses to delete VRFs that are still in use — any VRF currently bound to interfaces on a device is reported in the result's `in_use_vrfs` list rather than deleted. The Overlay object is only deleted once all of its VXLANs and member assignments are gone.
 
-<Warning title="Experimental">
-This workflow is experimental and not intended for general use. Use it only in test or pilot environments.
-</Warning>
-
 ## Prerequisites
 
 Before running, confirm:

--- a/docs/user-guides/vpc-deletion/index.mdx
+++ b/docs/user-guides/vpc-deletion/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: SpX Overlay Deletion
-sidebar-title: SpX Overlay Deletion
+title: Spectrum-X Overlay Deletion
+sidebar-title: Spectrum-X Overlay Deletion
 position: 20
 ---
 
-The SpX Overlay Deletion workflow removes the VRF, L3 VXLAN, and Overlay metadata for an existing overlay from Nautobot. It is the cleanup counterpart to [SpX Overlay Creation](../vpc-creation/index.mdx) and refuses to delete VRFs that are still in use — any VRF currently bound to interfaces on a device is reported in the result's `in_use_vrfs` list rather than deleted. The Overlay object is only deleted once all of its VXLANs and member assignments are gone.
+The Spectrum-X Overlay Deletion workflow removes the VRF, L3 VXLAN, and Overlay metadata for an existing overlay from Nautobot. It is the cleanup counterpart to [Spectrum-X Overlay Creation](../vpc-creation/index.mdx) and refuses to delete VRFs that are still in use — any VRF currently bound to interfaces on a device is reported in the result's `in_use_vrfs` list rather than deleted. The Overlay object is only deleted once all of its VXLANs and member assignments are gone.
 
 ## Prerequisites
 
@@ -47,13 +47,13 @@ After the workflow reports success, confirm:
 - **`delete_spx_overlay` shows green** and the result lists `deleted_vrfs` and `in_use_vrfs` as expected.
 - **Nautobot no longer shows the deleted VRFs.**
 - **Nautobot overlays plugin** shows the Overlay deleted (or still present with a note if members remain).
-- **Any `in_use_vrfs` entries** are VRFs still bound to interfaces. Unbind them directly in Nautobot, re-deploy the affected devices, then re-run SpX Overlay Deletion.
+- **Any `in_use_vrfs` entries** are VRFs still bound to interfaces. Unbind them directly in Nautobot, re-deploy the affected devices, then re-run Spectrum-X Overlay Deletion.
 
 ## Common issues
 
 **Result lists VRFs as `in_use_vrfs`.**
 
-Those VRFs are still bound to interfaces on at least one device. Open Nautobot, remove the VRF binding from each interface, re-deploy the affected devices so the running configuration drops the VRF, then re-run SpX Overlay Deletion.
+Those VRFs are still bound to interfaces on at least one device. Open Nautobot, remove the VRF binding from each interface, re-deploy the affected devices so the running configuration drops the VRF, then re-run Spectrum-X Overlay Deletion.
 
 **Workflow returns "No VRFs exist for this overlay at the site".**
 
@@ -69,6 +69,6 @@ A Nautobot transaction failed mid-delete. Some VRFs may have been deleted; other
 
 ## Related guides
 
-- [SpX Overlay Creation](../vpc-creation/index.mdx) — provision the VRF metadata in the first place.
-- [SpX Overlay Assignment](../vpc-assignment/index.mdx) — bind VRFs to devices and ports.
-- [SpX Overlay Tenant Change](../vpc-tenant-change/index.mdx) — full assign + render + deploy lifecycle workflow.
+- [Spectrum-X Overlay Creation](../vpc-creation/index.mdx) — provision the VRF metadata in the first place.
+- [Spectrum-X Overlay Assignment](../vpc-assignment/index.mdx) — bind VRFs to devices and ports.
+- [Spectrum-X Overlay Tenant Change](../vpc-tenant-change/index.mdx) — full assign + render + deploy lifecycle workflow.

--- a/docs/user-guides/vpc-tenant-change/index.mdx
+++ b/docs/user-guides/vpc-tenant-change/index.mdx
@@ -1,16 +1,16 @@
 ---
-title: SpX Overlay Tenant Change
-sidebar-title: SpX Overlay Tenant Change
+title: Spectrum-X Overlay Tenant Change
+sidebar-title: Spectrum-X Overlay Tenant Change
 position: 40
 ---
 
-The SpX Overlay Tenant Change workflow drives an end-to-end overlay change against a single device: assign the overlay to the device and ports, re-render the tenant configuration, wait for the new render to land in the Config Store, and deploy the rendered configuration to the device. It is the workflow most operators interact with when adding, moving, or expanding a tenant's footprint on a switch — the underlying [SpX Overlay Assignment](../vpc-assignment/index.mdx), [Render Service](../../render/index.mdx), and [Tenant Deploy](../tenant-deploy/index.mdx) workflows are exposed individually for advanced cases but are normally orchestrated by this workflow.
+The Spectrum-X Overlay Tenant Change workflow drives an end-to-end overlay change against a single device: assign the overlay to the device and ports, re-render the tenant configuration, wait for the new render to land in the Config Store, and deploy the rendered configuration to the device. It is the workflow most operators interact with when adding, moving, or expanding a tenant's footprint on a switch — the underlying [Spectrum-X Overlay Assignment](../vpc-assignment/index.mdx), [Render Service](../../render/index.mdx), and [Tenant Deploy](../tenant-deploy/index.mdx) workflows are exposed individually for advanced cases but are normally orchestrated by this workflow.
 
 ## Prerequisites
 
 Before running, confirm:
 
-- **Overlay exists at the site** ([SpX Overlay Creation](../vpc-creation/index.mdx) has been run, with the Overlay and L3 VXLANs created in Nautobot).
+- **Overlay exists at the site** ([Spectrum-X Overlay Creation](../vpc-creation/index.mdx) has been run, with the Overlay and L3 VXLANs created in Nautobot).
 - **Device exists in Nautobot** with a primary IPv4, a supported platform (Cumulus Linux or NVOS), and current credentials in the secrets store.
 - **Port names match Nautobot interface names** on the target device. Already-assigned ports are silently skipped.
 - **Render service is healthy.** The workflow waits up to a bounded window for the render service to produce the new tenant config; outages on render will stall the workflow.
@@ -39,9 +39,9 @@ The workflow runs five stages in order. None require manual approval.
 
    Resolves the device by UUID and attaches search attributes for observability.
 
-1. **`assign_spx_overlay` — Run SpX Overlay Assignment as a child workflow.**
+1. **`assign_spx_overlay` — Run Spectrum-X Overlay Assignment as a child workflow.**
 
-   Invokes [SpX Overlay Assignment](../vpc-assignment/index.mdx) with the same inputs to bind the VRF to the device and its ports. The stage display links to the child workflow as soon as it starts. If the child fails, the stage retains the link and the tenant-change workflow stops before rendering or deployment. On success, the display also shows the Overlay name, L3 VXLAN name, VRF, and assigned ports. If the assignment is a complete no-op (`vrf_assigned=false` and no `assigned_ports` changed), the workflow short-circuits — `render_tenant_config`, `wait_for_render`, and `deploy` are marked UNREACHABLE and the workflow exits successfully with `device_deployed=null`.
+   Invokes [Spectrum-X Overlay Assignment](../vpc-assignment/index.mdx) with the same inputs to bind the VRF to the device and its ports. The stage display links to the child workflow as soon as it starts. If the child fails, the stage retains the link and the tenant-change workflow stops before rendering or deployment. On success, the display also shows the Overlay name, L3 VXLAN name, VRF, and assigned ports. If the assignment is a complete no-op (`vrf_assigned=false` and no `assigned_ports` changed), the workflow short-circuits — `render_tenant_config`, `wait_for_render`, and `deploy` are marked UNREACHABLE and the workflow exits successfully with `device_deployed=null`.
 
 1. **`render_tenant_config` — Trigger a tenant-scoped re-render for the device.**
 
@@ -82,13 +82,13 @@ The tenant-scoped diff produced by the re-render exceeds the tenant-allowed `nv 
 
 **`get_device_and_vrf` (inside the assign_spx_overlay child) raises `ApplicationError`.**
 
-Either zero or multiple VRFs were returned for the `overlay_id` + `namespace_tag` combination. Run [SpX Overlay Creation](../vpc-creation/index.mdx) if the overlay does not exist; reconcile duplicates in Nautobot if it does.
+Either zero or multiple VRFs were returned for the `overlay_id` + `namespace_tag` combination. Run [Spectrum-X Overlay Creation](../vpc-creation/index.mdx) if the overlay does not exist; reconcile duplicates in Nautobot if it does.
 
 ## Related guides
 
-- [SpX Overlay Creation](../vpc-creation/index.mdx) — provision the VRF, VXLAN, and Overlay metadata before assigning it.
-- [SpX Overlay Assignment](../vpc-assignment/index.mdx) — the assignment child workflow this orchestration invokes.
-- [SpX Overlay Deletion](../vpc-deletion/index.mdx) — counterpart deletion lifecycle.
+- [Spectrum-X Overlay Creation](../vpc-creation/index.mdx) — provision the VRF, VXLAN, and Overlay metadata before assigning it.
+- [Spectrum-X Overlay Assignment](../vpc-assignment/index.mdx) — the assignment child workflow this orchestration invokes.
+- [Spectrum-X Overlay Deletion](../vpc-deletion/index.mdx) — counterpart deletion lifecycle.
 - [Tenant Deploy](../tenant-deploy/index.mdx) — the tenant-scoped deploy child this orchestration ends with.
 - [Render Service](../../render/index.mdx) — produces the tenant configurations this workflow waits on.
 - [Configuration Deploy](../configuration-deploy/index.mdx) — alternative path when a change is too broad for tenant deploy.

--- a/docs/user-guides/vpc-tenant-change/index.mdx
+++ b/docs/user-guides/vpc-tenant-change/index.mdx
@@ -6,10 +6,6 @@ position: 40
 
 The SpX Overlay Tenant Change workflow drives an end-to-end overlay change against a single device: assign the overlay to the device and ports, re-render the tenant configuration, wait for the new render to land in the Config Store, and deploy the rendered configuration to the device. It is the workflow most operators interact with when adding, moving, or expanding a tenant's footprint on a switch — the underlying [SpX Overlay Assignment](../vpc-assignment/index.mdx), [Render Service](../../render/index.mdx), and [Tenant Deploy](../tenant-deploy/index.mdx) workflows are exposed individually for advanced cases but are normally orchestrated by this workflow.
 
-<Warning title="Experimental">
-This workflow is experimental and not intended for general use. Use it only in test or pilot environments.
-</Warning>
-
 ## Prerequisites
 
 Before running, confirm:


### PR DESCRIPTION
## Description

Provide a landing page for getting started with NVCM management of Spectrum-X switches.

## Validation


- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **“Spectrum-X Switch Management”** guide for day-0/day-2 provisioning and ongoing operations, including prerequisites, an architecture diagram, and **DSX Air Simulation** validation; also includes an optional **Spectrum-X overlay lifecycle**.
  * Updated docs navigation and landing pages to link the new guide, and renamed **“SpX”** references to **“Spectrum-X”** across overlay workflow guides.
  * Removed **“Experimental”** warning callouts from VPC creation/deletion and Spectrum-X overlay assignment/creation/deletion/tenant change pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->