### PR TITLE
fix(security): address CodeQL findings

### DIFF
--- a/installer/src/nv_config_manager_installer/air_sim/orchestrator.py
+++ b/installer/src/nv_config_manager_installer/air_sim/orchestrator.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import logging
-import shlex
 import shutil
 import tempfile
 from collections.abc import Callable
@@ -65,6 +64,14 @@ STEPS: list[tuple[str, str]] = [
     ("run-deploy", "Run nvcm installer"),
     ("post-deploy", "Post-deploy setup"),
 ]
+
+
+def _monitor_setup_command(host: str, port: int) -> str:
+    """Return a monitor command that is safe to display or persist."""
+    return (
+        f"sshpass -p '<password>' ssh -p {port} "
+        f"{NVCM_BOX_USER}@{host} 'sudo tail -f /var/log/nvcm-setup.log'"
+    )
 
 
 class OrchestratorCallback(Protocol):
@@ -278,10 +285,7 @@ class SimOrchestrator:
         if not full_setup or cfg.wait_timeout == 0:
             for step_id in ("wait-setup", "upload-files", "run-deploy", "post-deploy"):
                 self._step(step_id, StepStatus.SKIPPED)
-            self._log(
-                f"\nMonitor setup: sshpass -p {shlex.quote(cfg.oob_ssh_password)} ssh -p {port} "
-                f"{NVCM_BOX_USER}@{host} 'sudo tail -f /var/log/nvcm-setup.log'"
-            )
+            self._log(f"\nMonitor setup: {_monitor_setup_command(host, port)}")
             return host, port
 
         self._step("wait-setup", StepStatus.RUNNING)
@@ -290,10 +294,7 @@ class SimOrchestrator:
             self._step("wait-setup", StepStatus.FAILED)
             for step_id in ("upload-files", "run-deploy", "post-deploy"):
                 self._step(step_id, StepStatus.SKIPPED)
-            self._log(
-                f"\nSetup timed out. Check: sshpass -p {shlex.quote(cfg.oob_ssh_password)} ssh -p {port} "
-                f"{NVCM_BOX_USER}@{host} 'sudo tail -f /var/log/nvcm-setup.log'"
-            )
+            self._log(f"\nSetup timed out. Check: {_monitor_setup_command(host, port)}")
             return host, port
         self._step("wait-setup", StepStatus.SUCCESS)
 

--- a/installer/src/nv_config_manager_installer/air_sim/sim_manager.py
+++ b/installer/src/nv_config_manager_installer/air_sim/sim_manager.py
@@ -1619,7 +1619,7 @@ class AirSimulationManager:
         ssh_password = self._require_ssh_password()
         socks_port = self._SOCKS_PORT
         ssh_cmd = (
-            f"sshpass -p {shlex.quote(ssh_password)}"
+            "sshpass -p '<password>'"
             f" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
             f" -D {socks_port} -N -p {port}"
             f" {NVCM_BOX_USER}@{host}"
@@ -2339,7 +2339,7 @@ class AirSimulationManager:
         LOG.info("\n2. Run the setup script:")
         LOG.info(f"   {NVCM_SERVER_SETUP_SCRIPT}")
         LOG.info("\n3. Run the deployment script:")
-        LOG.info(f"   {deploy_script}")
+        LOG.info("   Deployment script content omitted from logs because it contains credentials.")
         LOG.info("=" * 70 + "\n")
 
         return {
@@ -2353,6 +2353,7 @@ class AirSimulationManager:
             "switch_password": NVCM_SECRETS["nvcm_password"],
             "nautobot_user": NVCM_SECRETS["nautobot_superuser"],
             "nautobot_password": NVCM_SECRETS["nautobot_password"],
+            "deploy_script": deploy_script,
         }
 
     def _generate_nvcm_deploy_script(

--- a/installer/src/nv_config_manager_installer/tui/air_sim/screens/launch.py
+++ b/installer/src/nv_config_manager_installer/tui/air_sim/screens/launch.py
@@ -24,7 +24,6 @@ import tempfile
 import threading
 import time
 from collections import deque
-from datetime import datetime
 from pathlib import Path
 from queue import Empty, SimpleQueue
 from typing import IO
@@ -119,6 +118,13 @@ _BUFFER_LIMITS = {
 }
 _FOLLOW_LABEL_ON = "Follow: On"
 _FOLLOW_LABEL_OFF = "Follow: Off"
+
+
+def _create_deploy_log_path() -> Path:
+    """Create an owner-only deployment log and return its path."""
+    descriptor, path = tempfile.mkstemp(prefix="nvcm-deploy-", suffix=".log")
+    os.close(descriptor)
+    return Path(path)
 
 
 def _copy_button(
@@ -1259,8 +1265,7 @@ class LaunchScreen(Container):
             )
             return
 
-        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        self._deploy_log_path = Path(tempfile.gettempdir()) / f"nvcm-deploy-{stamp}.log"
+        self._deploy_log_path = _create_deploy_log_path()
         self._bringup_running = True
         self._monitor_stop.clear()
         self.query_one("#btn-launch", Button).disabled = True

--- a/installer/tests/air_sim/test_orchestrator.py
+++ b/installer/tests/air_sim/test_orchestrator.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import pytest
 
-from nv_config_manager_installer.air_sim.orchestrator import SimOrchestrator
+from nv_config_manager_installer.air_sim.orchestrator import (
+    SimOrchestrator,
+    _monitor_setup_command,
+)
 from nv_config_manager_installer.air_sim.sim_config import SimConfig
 
 
@@ -75,3 +78,11 @@ def test_resolve_topology_requires_direct_path_for_custom_flows() -> None:
 
     with pytest.raises(RuntimeError, match="topology_path is required"):
         orchestrator._resolve_topology_path(cfg)
+
+
+def test_monitor_setup_command_uses_password_placeholder() -> None:
+    command = _monitor_setup_command("worker.example", 17117)
+
+    assert command.startswith("sshpass -p '<password>'")
+    assert "worker.example" in command
+    assert "17117" in command

--- a/installer/tests/air_sim/test_sim_manager.py
+++ b/installer/tests/air_sim/test_sim_manager.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 import pytest
 
 import nv_config_manager_installer.air_sim.sim_manager as sim_manager_module
+from nv_config_manager_installer.air_sim.models import NVCMServerConfig
 from nv_config_manager_installer.air_sim.sim_manager import AirSimulationManager
 
 
@@ -129,3 +130,51 @@ def test_configure_nat_rules_enables_dhcp_relay(monkeypatch: pytest.MonkeyPatch)
     assert "sudo systemctl enable isc-dhcp-relay" in commands
     assert "sudo systemctl restart isc-dhcp-relay" in commands
     assert not any("disable --now isc-dhcp-relay" in command for command in commands)
+
+
+def test_print_socks_instructions_redacts_password(caplog: pytest.LogCaptureFixture) -> None:
+    manager = AirSimulationManager.__new__(AirSimulationManager)
+    manager.ssh_password = "do-not-log-this-password"
+
+    with caplog.at_level("INFO"):
+        manager.print_socks_instructions("worker.example", 17117)
+
+    assert manager.ssh_password not in caplog.text
+    assert "sshpass -p '<password>'" in caplog.text
+
+
+def test_setup_nvcm_server_does_not_log_deployment_script(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = AirSimulationManager.__new__(AirSimulationManager)
+    node = SimpleNamespace(name="oob-mgmt-server", state="RUNNING")
+    interface = SimpleNamespace(id="interface-id", name="eth0")
+    service = SimpleNamespace(
+        interface=interface,
+        node_port=22,
+        worker_fqdn="worker.example",
+        worker_port=17117,
+    )
+    manager.client = SimpleNamespace(
+        nodes=SimpleNamespace(list=lambda **_kwargs: [node]),
+        interfaces=SimpleNamespace(list=lambda **_kwargs: [interface]),
+        services=SimpleNamespace(list=lambda **_kwargs: [service]),
+    )
+    deployment_script = "export API_PASSWORD=do-not-log-this-script"
+    monkeypatch.setattr(
+        manager,
+        "_generate_nvcm_deploy_script",
+        lambda **_kwargs: deployment_script,
+    )
+    monkeypatch.setattr(sim_manager_module.time, "sleep", lambda _seconds: None)
+
+    with caplog.at_level("INFO"):
+        result = manager.setup_nvcm_server(
+            "simulation-id",
+            NVCMServerConfig(use_existing_server="oob-mgmt-server"),
+        )
+
+    assert deployment_script not in caplog.text
+    assert "content omitted from logs" in caplog.text
+    assert result["deploy_script"] == deployment_script

--- a/installer/tests/air_sim/test_tui_launch.py
+++ b/installer/tests/air_sim/test_tui_launch.py
@@ -29,6 +29,7 @@ from nv_config_manager_installer.tui.air_sim.screens.launch import (
     _MAX_DEPLOY_LOG_LINES,
     LaunchScreen,
     _clean_dhcp_line,
+    _create_deploy_log_path,
     _DeployStarted,
     _is_interesting_dhcp_line,
     _PodStatusWidget,
@@ -293,6 +294,14 @@ def test_tui_callback_streams_unfiltered_deploy_log_lines() -> None:
     callback.on_log("ordinary docker build output with no activity keyword")
 
     assert recorder.entries == [("ordinary docker build output with no activity keyword", "deploy")]
+
+
+def test_create_deploy_log_path_is_owner_only() -> None:
+    log_path = _create_deploy_log_path()
+    try:
+        assert log_path.stat().st_mode & 0o777 == 0o600
+    finally:
+        log_path.unlink()
 
 
 def test_dhcp_activity_helpers_include_refresh_and_config_events() -> None:

--- a/src/nv_config_manager/temporal/client/device.py
+++ b/src/nv_config_manager/temporal/client/device.py
@@ -2058,7 +2058,8 @@ class CumulusConnection(NetworkConnection):
     ) -> bytes:
         """Open a fresh paramiko SSH connection and download remote_path over SFTP."""
         ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh.load_system_host_keys()
+        ssh.set_missing_host_key_policy(paramiko.RejectPolicy())
         ssh.connect(
             hostname=self._host,
             port=22,

--- a/src/nv_config_manager/temporal/client/device.py
+++ b/src/nv_config_manager/temporal/client/device.py
@@ -2058,20 +2058,19 @@ class CumulusConnection(NetworkConnection):
     ) -> bytes:
         """Open a fresh paramiko SSH connection and download remote_path over SFTP."""
         ssh = paramiko.SSHClient()
-        ssh.load_system_host_keys()
-        ssh.set_missing_host_key_policy(paramiko.RejectPolicy())
-        ssh.connect(
-            hostname=self._host,
-            port=22,
-            username=self._username,
-            password=password,
-            timeout=30,
-            banner_timeout=30,
-            auth_timeout=30,
-            allow_agent=False,
-            look_for_keys=False,
-        )
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
+            ssh.connect(
+                hostname=self._host,
+                port=22,
+                username=self._username,
+                password=password,
+                timeout=30,
+                banner_timeout=30,
+                auth_timeout=30,
+                allow_agent=False,
+                look_for_keys=False,
+            )
             last_hb = [time.monotonic()]
 
             def _progress(transferred: int, total: int) -> None:

--- a/src/tests/temporal/clients/test_device.py
+++ b/src/tests/temporal/clients/test_device.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import json
 from configparser import ConfigParser
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import paramiko
 import pytest
@@ -250,22 +250,17 @@ def test_mock_get_tech_support_bundle_returns_bytes():
 
 
 @patch("nv_config_manager.temporal.client.device.paramiko.SSHClient")
-def test_sftp_download_rejects_unknown_host_keys(mock_ssh_client):
-    """SFTP loads trusted host keys and rejects hosts that are not present."""
-    ssh = MagicMock()
-    sftp = ssh.open_sftp.return_value
-    sftp.get_channel.return_value = None
-    sftp.getfo.side_effect = lambda _path, buffer, callback: buffer.write(b"bundle")
-    mock_ssh_client.return_value = ssh
+def test_sftp_download_closes_client_when_connect_fails(mock_ssh_client):
+    """SFTP closes the SSH client when connection setup fails."""
+    ssh = mock_ssh_client.return_value
+    ssh.connect.side_effect = paramiko.SSHException("connection failed")
     conn = CumulusConnection.__new__(CumulusConnection)
     conn._host = _TEST_HOST
     conn._username = "admin"
 
-    assert conn._sftp_download("password", "/tmp/support.tar", None) == b"bundle"
+    with pytest.raises(paramiko.SSHException, match="connection failed"):
+        conn._sftp_download("password", "/tmp/support.tar", None)
 
-    ssh.load_system_host_keys.assert_called_once_with()
-    policy = ssh.set_missing_host_key_policy.call_args.args[0]
-    assert isinstance(policy, paramiko.RejectPolicy)
     ssh.close.assert_called_once_with()
 
 

--- a/src/tests/temporal/clients/test_device.py
+++ b/src/tests/temporal/clients/test_device.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 import json
 from configparser import ConfigParser
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import paramiko
 import pytest
 
 from nv_config_manager.temporal.client.device import (
@@ -246,6 +247,26 @@ def test_mock_get_tech_support_bundle_returns_bytes():
     assert isinstance(content, bytes)
     assert content == b"[mock tech-support bundle]"
     assert isinstance(log, str)
+
+
+@patch("nv_config_manager.temporal.client.device.paramiko.SSHClient")
+def test_sftp_download_rejects_unknown_host_keys(mock_ssh_client):
+    """SFTP loads trusted host keys and rejects hosts that are not present."""
+    ssh = MagicMock()
+    sftp = ssh.open_sftp.return_value
+    sftp.get_channel.return_value = None
+    sftp.getfo.side_effect = lambda _path, buffer, callback: buffer.write(b"bundle")
+    mock_ssh_client.return_value = ssh
+    conn = CumulusConnection.__new__(CumulusConnection)
+    conn._host = _TEST_HOST
+    conn._username = "admin"
+
+    assert conn._sftp_download("password", "/tmp/support.tar", None) == b"bundle"
+
+    ssh.load_system_host_keys.assert_called_once_with()
+    policy = ssh.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, paramiko.RejectPolicy)
+    ssh.close.assert_called_once_with()
 
 
 # =============================================================================


### PR DESCRIPTION
## Description

Address five of the six CodeQL findings identified on `main`:

- redact DSX Air SSH passwords and credential-bearing deployment scripts from logs;
- create TUI deployment logs as owner-only (`0600`) files;
- close the Paramiko client when SFTP connection setup fails; and
- add focused regression coverage for each security boundary.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run locally because it is a manual, approximately 30-minute suite and
this pull request is still a draft. Commit `c71b1263242289da13a579edee7a041d8ec4c6a5` has DCO
signoff and a verified OpenPGP signature. Because the pull request is a draft, an authorized
maintainer must still approve that exact commit before copy-pr-bot can sync it.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **failure** for [`c71b126`](https://github.com/NVIDIA/nv-config-manager/commit/c71b1263242289da13a579edee7a041d8ec4c6a5) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30382958339).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. 
      docs screenshots, or Helm/rendered outputs. No generated artifacts are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - SSH/SOCKS and SSH “monitor setup”/timeout messages now redact passwords (displayed commands use a `'<password>'` placeholder).
  - Deployment script contents are omitted from logs to avoid exposing credentials.
- **Improvements**
  - Launch UI deploy logs are now created as owner-only temporary files (restricted permissions).
- **Tests**
  - Added coverage for password redaction, omitted deployment-script logging, secure deploy-log permissions, and ensuring SFTP clients close properly when SSH connect fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->