### PR TITLE
resolve data duplication in multi-deploy workflow 

### DIFF
--- a/bindings/go/temporal/model_batch_deploy_input.go
+++ b/bindings/go/temporal/model_batch_deploy_input.go
@@ -21,8 +21,8 @@ var _ MappedNullable = &BatchDeployInput{}
 
 // BatchDeployInput Input for batch deploy child workflow.
 type BatchDeployInput struct {
-	// Devices whose configurations will be deployed in this batch.
-	BatchDevices []DeviceDiffData `json:"batch_devices"`
+	// Deprecated compatibility field. When omitted, devices are read from diff_group.devices.
+	BatchDevices []DeviceDiffData `json:"batch_devices,omitempty"`
 	// Sequence number of this batch within the parent workflow.
 	BatchNumber NullableInt32 `json:"batch_number,omitempty"`
 	// Whether to use commit-confirmed mode when the platform supports it.
@@ -39,9 +39,8 @@ type _BatchDeployInput BatchDeployInput
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBatchDeployInput(batchDevices []DeviceDiffData, diffGroup DiffGroup, parentWorkflowId string) *BatchDeployInput {
+func NewBatchDeployInput(diffGroup DiffGroup, parentWorkflowId string) *BatchDeployInput {
 	this := BatchDeployInput{}
-	this.BatchDevices = batchDevices
 	var commitConfirm bool = true
 	this.CommitConfirm = &commitConfirm
 	this.DiffGroup = diffGroup
@@ -59,26 +58,35 @@ func NewBatchDeployInputWithDefaults() *BatchDeployInput {
 	return &this
 }
 
-// GetBatchDevices returns the BatchDevices field value
+// GetBatchDevices returns the BatchDevices field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BatchDeployInput) GetBatchDevices() []DeviceDiffData {
 	if o == nil {
 		var ret []DeviceDiffData
 		return ret
 	}
-
 	return o.BatchDevices
 }
 
-// GetBatchDevicesOk returns a tuple with the BatchDevices field value
+// GetBatchDevicesOk returns a tuple with the BatchDevices field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+
 func (o *BatchDeployInput) GetBatchDevicesOk() ([]DeviceDiffData, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.BatchDevices) {
 		return nil, false
 	}
 	return o.BatchDevices, true
 }
 
-// SetBatchDevices sets field value
+// HasBatchDevices returns a boolean if a field has been set.
+func (o *BatchDeployInput) HasBatchDevices() bool {
+	if o != nil && !IsNil(o.BatchDevices) {
+		return true
+	}
+
+	return false
+}
+
+// SetBatchDevices gets a reference to the given []DeviceDiffData and assigns it to the BatchDevices field.
 func (o *BatchDeployInput) SetBatchDevices(v []DeviceDiffData) {
 	o.BatchDevices = v
 }
@@ -219,7 +227,9 @@ func (o BatchDeployInput) MarshalJSON() ([]byte, error) {
 
 func (o BatchDeployInput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["batch_devices"] = o.BatchDevices
+	if o.BatchDevices != nil {
+		toSerialize["batch_devices"] = o.BatchDevices
+	}
 	if o.BatchNumber.IsSet() {
 		toSerialize["batch_number"] = o.BatchNumber.Get()
 	}
@@ -236,7 +246,6 @@ func (o *BatchDeployInput) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := map[string]bool{
-		"batch_devices":      false,
 		"diff_group":         false,
 		"parent_workflow_id": false,
 	}

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -79,12 +79,20 @@
         "description": "Input for batch deploy child workflow.",
         "properties": {
           "batch_devices": {
-            "description": "Devices whose configurations will be deployed in this batch.",
-            "items": {
-              "$ref": "#/components/schemas/DeviceDiffData"
-            },
-            "title": "Batch Devices",
-            "type": "array"
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DeviceDiffData"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "deprecated": true,
+            "description": "Deprecated compatibility field. When omitted, devices are read from diff_group.devices.",
+            "title": "Batch Devices"
           },
           "batch_number": {
             "anyOf": [
@@ -116,7 +124,6 @@
         },
         "required": [
           "diff_group",
-          "batch_devices",
           "parent_workflow_id"
         ],
         "title": "BatchDeployInput",

--- a/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/multi_deploy.py
@@ -174,8 +174,13 @@ class BatchDeployInput(BaseModel):
     """Input for batch deploy child workflow."""
 
     diff_group: DiffGroup = Field(description="Shared configuration diff for the device batch.")
-    batch_devices: list[DeviceDiffData] = Field(
-        description="Devices whose configurations will be deployed in this batch."
+    batch_devices: list[DeviceDiffData] | None = Field(
+        default=None,
+        json_schema_extra={"deprecated": True},
+        description=(
+            "Deprecated compatibility field. When omitted, devices are read from "
+            "diff_group.devices."
+        ),
     )
     parent_workflow_id: str = Field(description="Identifier of the parent multi-deploy workflow.")
     batch_number: int | None = Field(
@@ -185,6 +190,12 @@ class BatchDeployInput(BaseModel):
         default=True,
         description="Whether to use commit-confirmed mode when the platform supports it.",
     )
+
+    def resolved_batch_devices(self) -> list[DeviceDiffData]:
+        """Return the legacy device field when present, otherwise the canonical group devices."""
+        # Legacy inputs supplied both collections and the child historically used
+        # batch_devices, so it must retain precedence when the collections differ.
+        return self.batch_devices if self.batch_devices is not None else self.diff_group.devices
 
 
 class BatchBackupResultData(BaseModel):
@@ -235,9 +246,9 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     class ReviewDiffStageInput(StageInput):
         """Review Diff Stage Input."""
 
-        diff_group: DiffGroup
+        diff_group: DiffGroup = Field(exclude=True)
         device_count: int
-        batch_devices: list[DeviceDiffData]
+        batch_devices: list[DeviceDiffData] = Field(exclude=True)
         batch_number: int | None = None
 
     class ReviewDiffStageOutput(StageOutput):
@@ -297,7 +308,7 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     class ApplyConfigsStageInput(StageInput):
         """Apply Configs Stage Input."""
 
-        batch_devices: list[DeviceDiffData]
+        batch_devices: list[DeviceDiffData] = Field(exclude=True)
         approved_diff: str
         commit_confirm: bool = True
 
@@ -374,7 +385,7 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     class BackupsStageInput(StageInput):
         """Backups Stage Input."""
 
-        successful_devices: list[DeviceDiffData]
+        successful_devices: list[DeviceDiffData] = Field(exclude=True)
 
     class BackupsStageOutput(StageOutput):
         """Backups Stage Output."""
@@ -496,13 +507,14 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     async def run(self, workflow_input: BatchDeployInput) -> dict[str, Any]:  # type: ignore[override, ty:invalid-method-override]
         """Execute batch deploy workflow."""
         self.set_input(workflow_input)
+        batch_devices = workflow_input.resolved_batch_devices()
 
         # Review the shared diff
         review_output = await self.review_shared_diff(
             BatchDeployWorkflow.ReviewDiffStageInput(
                 diff_group=workflow_input.diff_group,
-                device_count=len(workflow_input.batch_devices),
-                batch_devices=workflow_input.batch_devices,
+                device_count=len(batch_devices),
+                batch_devices=batch_devices,
                 batch_number=workflow_input.batch_number,
             )
         )
@@ -523,7 +535,7 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
             # Apply configurations
             apply_output = await self.apply_configurations(
                 BatchDeployWorkflow.ApplyConfigsStageInput(
-                    batch_devices=workflow_input.batch_devices,
+                    batch_devices=batch_devices,
                     approved_diff=workflow_input.diff_group.diff_content,
                     commit_confirm=workflow_input.commit_confirm,
                 )
@@ -535,7 +547,7 @@ class BatchDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
             # Perform backups for successful devices
             successful_device_data = [
                 device
-                for device in workflow_input.batch_devices
+                for device in batch_devices
                 if device.device.name in apply_output.successful_devices
             ]
 
@@ -617,7 +629,7 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     class DiscoverDevicesStageOutput(StageOutput):
         """Discover Devices Stage Output."""
 
-        devices: list[NetworkDeviceData]
+        devices: list[NetworkDeviceData] = Field(exclude=True)
 
     @stage_executor("discover_devices")
     async def discover_devices(
@@ -645,12 +657,12 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     class CollectDiffsStageInput(StageInput):
         """Collect Diffs Stage Input."""
 
-        devices: list[NetworkDeviceData]
+        devices: list[NetworkDeviceData] = Field(exclude=True)
 
     class CollectDiffsStageOutput(StageOutput):
         """Collect Diffs Stage Output."""
 
-        device_diffs: list[DeviceDiffData]
+        device_diffs: list[DeviceDiffData] = Field(exclude=True)
         failed_devices: dict[str, str]
 
     @stage_executor("collect_diffs")
@@ -728,14 +740,14 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     class GroupAndBatchStageInput(StageInput):
         """Group and Batch Stage Input."""
 
-        device_diffs: list[DeviceDiffData]
+        device_diffs: list[DeviceDiffData] = Field(exclude=True)
         max_batch_size: int
 
     class GroupAndBatchStageOutput(StageOutput):
         """Group and Batch Stage Output."""
 
-        batches: list[list[DeviceDiffData]]
-        diff_groups: list[DiffGroup]
+        batches: list[list[DeviceDiffData]] = Field(exclude=True)
+        diff_groups: list[DiffGroup] = Field(exclude=True)
 
     @stage_executor("group_and_batch")
     async def group_and_batch(
@@ -794,8 +806,8 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
     class ExecuteBatchesStageInput(StageInput):
         """Execute Batches Stage Input."""
 
-        batches: list[list[DeviceDiffData]]
-        diff_groups: list[DiffGroup]
+        batches: list[list[DeviceDiffData]] = Field(exclude=True)
+        diff_groups: list[DiffGroup] = Field(exclude=True)
         commit_confirm: bool = True
 
     class ExecuteBatchesStageOutput(StageOutput):
@@ -838,9 +850,10 @@ class MultiDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archiv
                 diff_hash = hashlib.sha256(first_device_diff.encode()).hexdigest()[:16]
                 diff_group = diff_group_map[diff_hash]
 
+                # Carry only this batch in the canonical device collection. Omitting
+                # deprecated batch_devices prevents serializing the devices twice.
                 batch_input = BatchDeployInput(
-                    diff_group=diff_group,
-                    batch_devices=batch,
+                    diff_group=diff_group.model_copy(update={"devices": batch}),
                     parent_workflow_id=workflow.info().workflow_id,
                     batch_number=i + 1,  # 1-indexed batch number for display
                     commit_confirm=stage_input.commit_confirm,

--- a/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_multi_deploy_workflow.py
@@ -15,6 +15,7 @@
 """Tests for Multi-Deploy Workflow."""
 
 import asyncio
+import json
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
@@ -46,7 +47,10 @@ from nv_config_manager.temporal.ngc.activities.nautobot import (
 )
 from nv_config_manager.temporal.ngc.workflows.backup import BackupInput, BackupWorkflow
 from nv_config_manager.temporal.ngc.workflows.multi_deploy import (
+    BatchDeployInput,
     BatchDeployWorkflow,
+    DeviceDiffData,
+    DiffGroup,
     MultiDeployInput,
     MultiDeployWorkflow,
     _format_batch_status,
@@ -129,6 +133,173 @@ class MockBatchBackupWorkflow:
         if workflow_input.device_id == "device_2":
             raise ApplicationError("mock backup failure", non_retryable=True)
         return True
+
+
+def _large_device_diffs(count: int, config_size: int = 30_000) -> list[DeviceDiffData]:
+    """Build representative multi-deploy device data without exposing real configurations."""
+    return [
+        DeviceDiffData(
+            device=NetworkDeviceData(
+                id=f"device_{index}",
+                name=f"spine-{index:03d}",
+                role="spine",
+                platform="cumulus-linux",
+                device_type="sn4000",
+                site="SITEA",
+                primary_ip4=f"10.0.{index // 255}.{index % 255}",
+                primary_ip6=None,
+                config_context={"device_index": index, "feature_flags": ["nvcm"]},
+            ),
+            diff="- old config line\n+ new config line",
+            intended_config=f"# device {index}\n" + ("x" * config_size),
+            commit_id=f"commit-{index}",
+        )
+        for index in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=0.0)
+async def test_group_and_batch_creates_batch_subsets(_):
+    """Group matching diffs and split their devices into bounded batches."""
+    workflow_instance = MultiDeployWorkflow()
+    device_diffs = _large_device_diffs(115)
+    stage_input = MultiDeployWorkflow.GroupAndBatchStageInput(
+        device_diffs=device_diffs,
+        max_batch_size=5,
+    )
+
+    output = await MultiDeployWorkflow.group_and_batch.__wrapped__(  # type: ignore[attr-defined]
+        workflow_instance,
+        stage_input,
+    )
+
+    assert len(output.diff_groups) == 1
+    assert len(output.diff_groups[0].devices) == 115
+    assert len(output.batches) == 23
+    assert all(len(batch) == 5 for batch in output.batches)
+
+
+def test_batch_deploy_input_supports_legacy_and_canonical_device_fields():
+    """Read legacy inputs while allowing new inputs to serialize each device once."""
+    device_diffs = _large_device_diffs(115)
+    assert BatchDeployInput.model_json_schema()["properties"]["batch_devices"]["deprecated"] is True
+    legacy_input = BatchDeployInput.model_validate(
+        {
+            "diff_group": {
+                "diff_hash": "shared-diff",
+                "diff_content": device_diffs[0].diff,
+                "devices": [device.model_dump(mode="json") for device in device_diffs],
+            },
+            "batch_devices": [device.model_dump(mode="json") for device in device_diffs[:5]],
+            "parent_workflow_id": "parent-workflow",
+            "batch_number": 1,
+        }
+    )
+
+    assert len(legacy_input.diff_group.devices) == 115
+    assert legacy_input.batch_devices is not None
+    assert len(legacy_input.batch_devices) == 5
+    assert len(legacy_input.resolved_batch_devices()) == 5
+
+    canonical_input = BatchDeployInput(
+        diff_group=DiffGroup(
+            diff_hash="shared-diff",
+            diff_content=str(device_diffs[0].diff),
+            devices=device_diffs[:5],
+        ),
+        parent_workflow_id="parent-workflow",
+        batch_number=1,
+    )
+    serialized = canonical_input.model_dump(mode="json")
+    assert canonical_input.resolved_batch_devices() == device_diffs[:5]
+    assert len(serialized["diff_group"]["devices"]) == 5
+    assert serialized["batch_devices"] is None
+    assert len(json.dumps(serialized).encode()) < 250_000
+
+
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=0.0)
+def test_parent_stage_serialization_excludes_operational_device_payloads(_):
+    """Keep intended configurations out of the parent stages query."""
+    workflow_instance = MultiDeployWorkflow()
+    device_diffs = _large_device_diffs(115)
+    diff_group = DiffGroup(
+        diff_hash="shared-diff",
+        diff_content=str(device_diffs[0].diff),
+        devices=device_diffs,
+    )
+    batch = device_diffs[:5]
+
+    workflow_instance.set_stage_input(
+        "collect_diffs",
+        MultiDeployWorkflow.CollectDiffsStageInput(
+            devices=[device_diff.device for device_diff in device_diffs]
+        ),
+    )
+    workflow_instance.set_stage_output(
+        "collect_diffs",
+        MultiDeployWorkflow.CollectDiffsStageOutput(
+            device_diffs=device_diffs,
+            failed_devices={},
+            display="Collected diffs from 115 devices.",
+        ),
+    )
+    workflow_instance.set_stage_input(
+        "group_and_batch",
+        MultiDeployWorkflow.GroupAndBatchStageInput(
+            device_diffs=device_diffs,
+            max_batch_size=5,
+        ),
+    )
+    workflow_instance.set_stage_output(
+        "group_and_batch",
+        MultiDeployWorkflow.GroupAndBatchStageOutput(
+            batches=[batch],
+            diff_groups=[diff_group],
+            display="Created one diff group.",
+        ),
+    )
+    workflow_instance.set_stage_input(
+        "execute_batches",
+        MultiDeployWorkflow.ExecuteBatchesStageInput(
+            batches=[batch],
+            diff_groups=[diff_group],
+        ),
+    )
+
+    serialized_stages = json.dumps(
+        [stage.model_dump(mode="json") for stage in workflow_instance.stages()]
+    )
+
+    assert device_diffs[0].intended_config not in serialized_stages
+    assert len(serialized_stages.encode()) < 50_000
+
+
+@patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=0.0)
+def test_child_stage_serialization_excludes_operational_device_payloads(_):
+    """Keep intended configurations out of the child stages query."""
+    workflow_instance = BatchDeployWorkflow()
+    device_diffs = _large_device_diffs(5)
+    workflow_instance.set_stage_input(
+        "review_shared_diff",
+        BatchDeployWorkflow.ReviewDiffStageInput(
+            diff_group=DiffGroup(
+                diff_hash="shared-diff",
+                diff_content=str(device_diffs[0].diff),
+                devices=device_diffs,
+            ),
+            device_count=len(device_diffs),
+            batch_devices=device_diffs,
+            batch_number=1,
+        ),
+    )
+
+    serialized_stages = json.dumps(
+        [stage.model_dump(mode="json") for stage in workflow_instance.stages()]
+    )
+
+    assert device_diffs[0].intended_config not in serialized_stages
+    assert len(serialized_stages.encode()) < 50_000
 
 
 @pytest.mark.asyncio
@@ -497,11 +668,6 @@ async def test_batch_deploy_workflow_directly(
 ):
     """Test the BatchDeployWorkflow directly."""
     from nv_config_manager.temporal.ngc.activities.nats import publish_nats
-    from nv_config_manager.temporal.ngc.workflows.multi_deploy import (
-        BatchDeployInput,
-        DeviceDiffData,
-        DiffGroup,
-    )
 
     task_queue_name = str(uuid.uuid4())
     client: Client = env.client


### PR DESCRIPTION

## Description

In situations where a large count of devices (e.g. 100+) have identical diffs, each batch receives data about all devices rather than just the devices relevant to that batch, this can cause the multi-deploy workflow queries to exceed the default 2MB limit on query size when the devices are broken up into small batches.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`4c0c63a`](https://github.com/NVIDIA/nv-config-manager/commit/4c0c63a4a7335f1ec1371b459a0d31348445856e) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30501290203).
<!-- kind-integration-result:end -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved batch deployment compatibility by treating legacy `batch_devices` as deprecated/optional while preferring the canonical `diff_group.devices`.
  * Batch deployment stages now consistently compute and pass device data using the resolved (canonical-first) device list.
* **Performance**
  * Reduced Temporal workflow payload sizes by excluding large operational device/config data from stage serialization.
* **Bug Fixes**
  * Improved batch splitting and device grouping behavior across deployment stages to match expected subsets.
* **Tests**
  * Added tests covering legacy compatibility, batching correctness, and serialization size/payload exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->