### PR TITLE
fix(workflow): report unchanged backup persistence

### DIFF
--- a/src/nv_config_manager/temporal/ngc/activities/backup.py
+++ b/src/nv_config_manager/temporal/ngc/activities/backup.py
@@ -100,15 +100,25 @@ async def record_backup_config_manager_plugin(  # pylint: disable=too-many-argum
         existing_backup = await nbclient.load_config_manager_plugin_backup_config(
             activity_input.device_id
         )
-        if (
-            existing_backup.get("commit_id") == activity_input.commit_id
-            and existing_backup.get("deployed_commit_id") == activity_input.deployed_commit_id
-        ):
+        config_store_changed = existing_backup.get("commit_id") != activity_input.commit_id
+        deployed_commit_changed = (
+            existing_backup.get("deployed_commit_id") or None
+        ) != activity_input.deployed_commit_id
+        if not config_store_changed and not deployed_commit_changed:
             # Check if it was updated by this workflow,
             # if so this may be a retry that occurred despite the update succeeding
             if existing_backup.get("workflow_id") == activity_input.workflow_id:
                 return True, f"Persisted new backup configuration:\n{markdown}"
             return False, f"No diff to previous backup execution:\n{markdown}"
+
+        # Updating only the deployed commit metadata does not represent a new Config Store
+        # backup. Preserve the workflow that wrote the existing backup so an activity retry
+        # cannot incorrectly report this metadata-only update as a new backup.
+        workflow_id = (
+            activity_input.workflow_id
+            if config_store_changed
+            else existing_backup.get("workflow_id") or activity_input.workflow_id
+        )
 
         await nbclient.update_config_manager_plugin_backup_config(
             activity_input.device_id,
@@ -117,7 +127,9 @@ async def record_backup_config_manager_plugin(  # pylint: disable=too-many-argum
             fname,
             activity_input.user,
             activity_input.commit_message,
-            activity_input.workflow_id,
+            workflow_id,
             activity_input.deployed_commit_id,
         )
-    return True, f"Persisted new backup configuration:\n{markdown}"
+    if config_store_changed:
+        return True, f"Persisted new backup configuration:\n{markdown}"
+    return False, f"No diff to previous backup execution:\n{markdown}"

--- a/src/nv_config_manager/temporal/ngc/activities/backup.py
+++ b/src/nv_config_manager/temporal/ngc/activities/backup.py
@@ -100,10 +100,11 @@ async def record_backup_config_manager_plugin(  # pylint: disable=too-many-argum
         existing_backup = await nbclient.load_config_manager_plugin_backup_config(
             activity_input.device_id
         )
+        deployed_commit_id = activity_input.deployed_commit_id or None
         config_store_changed = existing_backup.get("commit_id") != activity_input.commit_id
         deployed_commit_changed = (
             existing_backup.get("deployed_commit_id") or None
-        ) != activity_input.deployed_commit_id
+        ) != deployed_commit_id
         if not config_store_changed and not deployed_commit_changed:
             # Check if it was updated by this workflow,
             # if so this may be a retry that occurred despite the update succeeding
@@ -128,7 +129,7 @@ async def record_backup_config_manager_plugin(  # pylint: disable=too-many-argum
             activity_input.user,
             activity_input.commit_message,
             workflow_id,
-            activity_input.deployed_commit_id,
+            deployed_commit_id,
         )
     if config_store_changed:
         return True, f"Persisted new backup configuration:\n{markdown}"

--- a/src/tests/temporal/ngc/activities/test_backup.py
+++ b/src/tests/temporal/ngc/activities/test_backup.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test configuration backup activities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import nv_config_manager.temporal.ngc.activities.backup as backup_activities
+from nv_config_manager.temporal.ngc.activities.backup import (
+    RecordBackupConfigManagerPluginInput,
+    record_backup_config_manager_plugin,
+)
+
+
+def _record_input(
+    *, commit_id: str = "7", deployed_commit_id: str | None = None
+) -> RecordBackupConfigManagerPluginInput:
+    return RecordBackupConfigManagerPluginInput(
+        workflow_id="current-workflow",
+        device_id="device-id",
+        commit_id=commit_id,
+        path="SITE/device/startup.yaml",
+        user="test-user",
+        commit_message="Backup trigger: API User: test-user",
+        deployed_commit_id=deployed_commit_id,
+    )
+
+
+@pytest.fixture
+def clients(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, AsyncMock]:
+    """Patch the external clients used by the backup metadata activity."""
+    config_store_client = MagicMock()
+    config_store_client.file_url.return_value = "https://config-store.example/backup"
+
+    nautobot_client = AsyncMock()
+    nautobot_client.__aenter__.return_value = nautobot_client
+    monkeypatch.setattr(
+        backup_activities, "config_store_client", lambda _file_type: config_store_client
+    )
+    monkeypatch.setattr(backup_activities, "NautobotClient", lambda: nautobot_client)
+    monkeypatch.setattr(
+        backup_activities, "config_store_ui_url", lambda: "https://config-store.example"
+    )
+    return config_store_client, nautobot_client
+
+
+@pytest.mark.asyncio
+async def test_record_backup_does_not_report_metadata_only_update_as_new_backup(
+    clients: tuple[MagicMock, AsyncMock],
+) -> None:
+    """A changed intended commit must not imply that Config Store wrote a new backup."""
+    _, nautobot_client = clients
+    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
+        "commit_id": "7",
+        "deployed_commit_id": "previous-intended-commit",
+        "workflow_id": "previous-workflow",
+    }
+
+    changed, display = await record_backup_config_manager_plugin(_record_input())
+
+    assert changed is False
+    assert display.startswith("No diff to previous backup execution:")
+    nautobot_client.update_config_manager_plugin_backup_config.assert_awaited_once_with(
+        "device-id",
+        "https://config-store.example",
+        "7",
+        "startup.yaml",
+        "test-user",
+        "Backup trigger: API User: test-user",
+        "previous-workflow",
+        None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_backup_reports_new_config_store_version(
+    clients: tuple[MagicMock, AsyncMock],
+) -> None:
+    """A new Config Store commit is reported as a changed backup."""
+    _, nautobot_client = clients
+    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
+        "commit_id": "6",
+        "deployed_commit_id": "intended-commit",
+        "workflow_id": "previous-workflow",
+    }
+
+    changed, display = await record_backup_config_manager_plugin(
+        _record_input(commit_id="7", deployed_commit_id="intended-commit")
+    )
+
+    assert changed is True
+    assert display.startswith("Persisted new backup configuration:")
+    assert (
+        nautobot_client.update_config_manager_plugin_backup_config.await_args.args[6]
+        == "current-workflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_backup_retry_preserves_original_changed_result(
+    clients: tuple[MagicMock, AsyncMock],
+) -> None:
+    """A retry after a completed plugin update still reports the original backup write."""
+    _, nautobot_client = clients
+    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
+        "commit_id": "7",
+        "deployed_commit_id": "intended-commit",
+        "workflow_id": "current-workflow",
+    }
+
+    changed, display = await record_backup_config_manager_plugin(
+        _record_input(deployed_commit_id="intended-commit")
+    )
+
+    assert changed is True
+    assert display.startswith("Persisted new backup configuration:")
+    nautobot_client.update_config_manager_plugin_backup_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_record_backup_treats_empty_deployed_commit_as_none(
+    clients: tuple[MagicMock, AsyncMock],
+) -> None:
+    """The plugin's empty-string representation of no deployed commit is unchanged."""
+    _, nautobot_client = clients
+    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
+        "commit_id": "7",
+        "deployed_commit_id": "",
+        "workflow_id": "previous-workflow",
+    }
+
+    changed, display = await record_backup_config_manager_plugin(_record_input())
+
+    assert changed is False
+    assert display.startswith("No diff to previous backup execution:")
+    nautobot_client.update_config_manager_plugin_backup_config.assert_not_awaited()

--- a/src/tests/temporal/ngc/activities/test_backup.py
+++ b/src/tests/temporal/ngc/activities/test_backup.py
@@ -131,6 +131,39 @@ async def test_record_backup_retry_preserves_original_changed_result(
 
 
 @pytest.mark.asyncio
+async def test_record_backup_metadata_only_retry_does_not_rewrite(
+    clients: tuple[MagicMock, AsyncMock],
+) -> None:
+    """A retry after a metadata-only update remains unchanged without another write."""
+    _, nautobot_client = clients
+    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
+        "commit_id": "7",
+        "deployed_commit_id": "previous-intended-commit",
+        "workflow_id": "previous-workflow",
+    }
+    activity_input = _record_input(deployed_commit_id="current-intended-commit")
+
+    changed, display = await record_backup_config_manager_plugin(activity_input)
+
+    assert changed is False
+    assert display.startswith("No diff to previous backup execution:")
+    nautobot_client.update_config_manager_plugin_backup_config.assert_awaited_once()
+
+    nautobot_client.update_config_manager_plugin_backup_config.reset_mock()
+    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
+        "commit_id": "7",
+        "deployed_commit_id": "current-intended-commit",
+        "workflow_id": "previous-workflow",
+    }
+
+    retry_changed, retry_display = await record_backup_config_manager_plugin(activity_input)
+
+    assert retry_changed is False
+    assert retry_display.startswith("No diff to previous backup execution:")
+    nautobot_client.update_config_manager_plugin_backup_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_record_backup_treats_empty_deployed_commit_as_none(
     clients: tuple[MagicMock, AsyncMock],
 ) -> None:

--- a/src/tests/temporal/ngc/activities/test_backup.py
+++ b/src/tests/temporal/ngc/activities/test_backup.py
@@ -147,3 +147,24 @@ async def test_record_backup_treats_empty_deployed_commit_as_none(
     assert changed is False
     assert display.startswith("No diff to previous backup execution:")
     nautobot_client.update_config_manager_plugin_backup_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_record_backup_normalizes_empty_input_deployed_commit(
+    clients: tuple[MagicMock, AsyncMock],
+) -> None:
+    """An empty input deployed commit matches a stored null value."""
+    _, nautobot_client = clients
+    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
+        "commit_id": "7",
+        "deployed_commit_id": None,
+        "workflow_id": "previous-workflow",
+    }
+
+    changed, display = await record_backup_config_manager_plugin(
+        _record_input(deployed_commit_id="")
+    )
+
+    assert changed is False
+    assert display.startswith("No diff to previous backup execution:")
+    nautobot_client.update_config_manager_plugin_backup_config.assert_not_awaited()

--- a/src/tests/temporal/ngc/activities/test_backup.py
+++ b/src/tests/temporal/ngc/activities/test_backup.py
@@ -131,39 +131,6 @@ async def test_record_backup_retry_preserves_original_changed_result(
 
 
 @pytest.mark.asyncio
-async def test_record_backup_metadata_only_retry_does_not_rewrite(
-    clients: tuple[MagicMock, AsyncMock],
-) -> None:
-    """A retry after a metadata-only update remains unchanged without another write."""
-    _, nautobot_client = clients
-    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
-        "commit_id": "7",
-        "deployed_commit_id": "previous-intended-commit",
-        "workflow_id": "previous-workflow",
-    }
-    activity_input = _record_input(deployed_commit_id="current-intended-commit")
-
-    changed, display = await record_backup_config_manager_plugin(activity_input)
-
-    assert changed is False
-    assert display.startswith("No diff to previous backup execution:")
-    nautobot_client.update_config_manager_plugin_backup_config.assert_awaited_once()
-
-    nautobot_client.update_config_manager_plugin_backup_config.reset_mock()
-    nautobot_client.load_config_manager_plugin_backup_config.return_value = {
-        "commit_id": "7",
-        "deployed_commit_id": "current-intended-commit",
-        "workflow_id": "previous-workflow",
-    }
-
-    retry_changed, retry_display = await record_backup_config_manager_plugin(activity_input)
-
-    assert retry_changed is False
-    assert retry_display.startswith("No diff to previous backup execution:")
-    nautobot_client.update_config_manager_plugin_backup_config.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_record_backup_treats_empty_deployed_commit_as_none(
     clients: tuple[MagicMock, AsyncMock],
 ) -> None:


### PR DESCRIPTION
## Description

Fix Configuration Backup Stage 3 reporting so metadata-only changes do not claim that Config Store persisted a new backup.

- reports a new backup only when the Config Store commit changes
- continues updating the deployed commit association without marking the backup as changed
- preserves the workflow ID that created the existing backup during metadata-only updates, retaining correct retry behavior
- normalizes the plugin's empty-string representation of a missing deployed commit
- adds regression coverage for metadata-only updates, real backup versions, retries, and empty deployed commit IDs

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

In an air sim, validated this works:
- Run backup, confirm no diff and no backup reported
- Change the network management config context in nautobot to add a new DNS server
- Wait for new intended config to render
- Run backup, confirm it reports the intended/actual drift but does not report a new backup since actual hasn't changed since the previous backup
- Deploy the config, confirm a new backup is reported

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`93387dd`](https://github.com/NVIDIA/nv-config-manager/commit/93387dd8375f9bb7478019809e5043ab2711f390) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30665424952).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. No documentation change is required because this restores the documented backup semantics.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs. No generated artifacts are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup status reporting by distinguishing configuration changes from metadata-only updates.
  * Preserved workflow information during metadata updates and maintained retry behavior for repeated updates.
  * Improved handling of empty deployed-commit values for consistent results.

* **Tests**
  * Added coverage for metadata-only updates, new configuration versions, retries, and empty commit values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->