### PR TITLE
fix(test-pipeline): Update build to use a properly usable token for triggering build

### DIFF
--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -209,6 +209,7 @@ untrusted `pull-request/*` builds. Never protect `pull-request/*` refs.
 | Variable | Purpose |
 | -------- | ------- |
 | `NVCM_MIRROR_API_TOKEN` | Project access token (Reporter, `read_api`) used to poll build pipelines and list jobs; protected + masked |
+| `NVCM_BUILD_TRIGGER_TOKEN` | Pipeline trigger token (Settings → CI/CD → Pipeline triggers) used to start the secret-free build on `pull-request/<n>`. A job token cannot trigger a pipeline in its own project (GitLab returns HTTP 422), and a trigger token can only start pipelines, nothing else. Protected + masked, expand off |
 | `NVCM_TEST_ENV_TARGETS` | One record per env: `env\|env_branch\|namespace\|release_name\|baseline_values\|state_dir` (see `scripts/test_env_config.sh`) |
 | `NVCM_CHART_REPO` | Helm repo URL ArgoCD reads the promoted chart from, e.g. `https://helm.ngc.nvidia.com/nvidian/cfa` (must match the `ngc` target in `NVCM_CHART_TARGETS`); written into deploy-state as `chartRepo` |
 | `NVCM_UPSTREAM_GITHUB_REPO` | Optional override for the upstream GitHub repo checked by the stale-HEAD guard (default `NVIDIA/nv-config-manager`) |

--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -209,7 +209,7 @@ untrusted `pull-request/*` builds. Never protect `pull-request/*` refs.
 | Variable | Purpose |
 | -------- | ------- |
 | `NVCM_MIRROR_API_TOKEN` | Project access token (Reporter, `read_api`) used to poll build pipelines and list jobs; protected + masked |
-| `NVCM_BUILD_TRIGGER_TOKEN` | Pipeline trigger token (Settings → CI/CD → Pipeline triggers) used to start the secret-free build on `pull-request/<n>`. A job token cannot trigger a pipeline in its own project (GitLab returns HTTP 422), and a trigger token can only start pipelines, nothing else. Protected + masked, expand off |
+| `NVCM_BUILD_TRIGGER_TOKEN` | Starts the secret-free build on `pull-request/<n>`. Two steps: create a token under **Settings → CI/CD → Pipeline triggers**, then store its value as this variable under **Settings → CI/CD → Variables** with protected + masked set, expand off. A job token cannot trigger a pipeline in its own project (GitLab returns HTTP 422), and a trigger token can only start pipelines, nothing else |
 | `NVCM_TEST_ENV_TARGETS` | One record per env: `env\|env_branch\|namespace\|release_name\|baseline_values\|state_dir` (see `scripts/test_env_config.sh`) |
 | `NVCM_CHART_REPO` | Helm repo URL ArgoCD reads the promoted chart from, e.g. `https://helm.ngc.nvidia.com/nvidian/cfa` (must match the `ngc` target in `NVCM_CHART_TARGETS`); written into deploy-state as `chartRepo` |
 | `NVCM_UPSTREAM_GITHUB_REPO` | Optional override for the upstream GitHub repo checked by the stale-HEAD guard (default `NVIDIA/nv-config-manager`) |

--- a/.gitlab/ci/pr-build.yml
+++ b/.gitlab/ci/pr-build.yml
@@ -45,6 +45,16 @@ pr-build-image:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_TLS_CERTDIR: ""
     DOCKER_DRIVER: overlay2
+  # The registry proxy's auth endpoint intermittently times out from this runner
+  # pool, failing the image pull before the job starts. That is a runner system
+  # failure, not a build failure, so retry it without masking real build errors.
+  # Only a mitigation: the underlying latency is an infrastructure issue, and
+  # GitLab caps retry attempts at 2, so a bad spell can still fail the job.
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
   rules: *pr-build-rules
   parallel:
     matrix:
@@ -122,6 +132,12 @@ pr-build-chart:
     - linux/amd64
   needs: []
   image: $NVCM_CI_IMAGE_ALPINE
+  # Same registry-proxy flakiness as pr-build-image; retry system failures.
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
   rules: *pr-build-rules
   before_script:
     - apk add -q bash git curl helm yq

--- a/.gitlab/ci/scripts/promote_build_pipeline.sh
+++ b/.gitlab/ci/scripts/promote_build_pipeline.sh
@@ -165,8 +165,10 @@ if [ -z "$BUILD_PIPELINE_ID" ]; then
         echo "Common causes:"
         echo "  - 'No stages / jobs for this pipeline': nothing matched on ${PR_REF}."
         echo "    The PR branch predates the pr-build CI definitions - rebase it onto main."
-        echo "  - 403/404: the job token cannot trigger pipelines in this project"
-        echo "    (check Settings > CI/CD > Job token permissions)."
+        echo "  - 403/404: several possible causes - NVCM_BUILD_TRIGGER_TOKEN may be"
+        echo "    invalid, revoked, or from another project, or ${PR_REF} may not"
+        echo "    exist or not be accessible. Check Settings > CI/CD > Pipeline"
+        echo "    triggers, and confirm the ref exists on the mirror."
         echo "  - 'Insufficient permissions': the trigger token lacks access to ${PR_REF}."
         exit 1
     fi

--- a/.gitlab/ci/scripts/promote_build_pipeline.sh
+++ b/.gitlab/ci/scripts/promote_build_pipeline.sh
@@ -16,7 +16,9 @@
 #             NVCM_PROMOTE_REQUIRE_PR_HEAD (default false),
 #             NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE (default false)
 # Requires: NVCM_MIRROR_API_TOKEN (read_api; polling/job-listing endpoints are
-#           not in the CI_JOB_TOKEN allowlist), CI_JOB_TOKEN (trigger + clone)
+#           not in the CI_JOB_TOKEN allowlist), NVCM_BUILD_TRIGGER_TOKEN
+#           (pipeline trigger token - a job token cannot trigger a pipeline in
+#           its own project), CI_JOB_TOKEN (repo clone)
 # Output:   promote.env (dotenv + file artifact) - PR_NUM, PR_REF, PR_SHA,
 #           PR_SHORT_SHA,
 #           PROMOTE_VERSION, BUILD_PIPELINE_ID, BUILD_JOB_ID_<IMAGE> x9,
@@ -26,6 +28,8 @@ set -euo pipefail
 : "${NVCM_PROMOTE_PR:?Set NVCM_PROMOTE_PR to the GitHub PR number}"
 : "${NVCM_PROMOTE_ENV:?Set NVCM_PROMOTE_ENV to the target environment}"
 : "${NVCM_MIRROR_API_TOKEN:?NVCM_MIRROR_API_TOKEN (read_api) is required}"
+# NVCM_BUILD_TRIGGER_TOKEN is checked lazily at the trigger site rather than
+# here: a run that reuses an existing successful build never needs it.
 
 if ! printf '%s' "$NVCM_PROMOTE_PR" | grep -Eq '^[0-9]+$'; then
     echo "ERROR: NVCM_PROMOTE_PR must be a PR number, got '${NVCM_PROMOTE_PR}'"
@@ -133,20 +137,37 @@ fi
 
 # -----------------------------------------------------------------------------
 # Otherwise trigger a fresh build on the pull-request ref and poll it.
-# CI_JOB_TOKEN is a valid same-project trigger token. NO variables are passed.
+# Uses a pipeline trigger token (NVCM_BUILD_TRIGGER_TOKEN): GitLab returns 422
+# for a job token triggering its own project. NO variables are passed.
 # -----------------------------------------------------------------------------
 if [ -z "$BUILD_PIPELINE_ID" ]; then
+    : "${NVCM_BUILD_TRIGGER_TOKEN:?NVCM_BUILD_TRIGGER_TOKEN required to trigger a build (Settings > CI/CD > Pipeline triggers)}"
     echo "Triggering build pipeline on ${PR_REF}..."
-    trigger_response="$(curl -fsS --max-time 30 -X POST \
-        -F "token=${CI_JOB_TOKEN}" \
+    # No `-f`: it suppresses the response body on an HTTP error and, under
+    # `set -e`, aborts before the diagnostics below can run. GitLab puts the
+    # actual reason (e.g. "No stages / jobs for this pipeline") in the body, so
+    # capture status and body and always surface them.
+    # A pipeline TRIGGER token, not CI_JOB_TOKEN: GitLab rejects a job token
+    # triggering a pipeline in its own project (HTTP 422). A trigger token is
+    # also the tighter credential - it can only start pipelines, nothing else.
+    # Still no variables are passed, so nothing leaks into the untrusted build.
+    trigger_raw="$(curl -sS --max-time 30 -X POST -w '\n%{http_code}' \
+        -F "token=${NVCM_BUILD_TRIGGER_TOKEN}" \
         -F "ref=${PR_REF}" \
-        "${api}/trigger/pipeline")"
-    BUILD_PIPELINE_ID="$(printf '%s' "$trigger_response" | jq -r '.id // empty')"
+        "${api}/trigger/pipeline" || true)"
+    trigger_http="$(printf '%s' "$trigger_raw" | tail -n 1)"
+    trigger_response="$(printf '%s' "$trigger_raw" | sed '$d')"
+    BUILD_PIPELINE_ID="$(printf '%s' "$trigger_response" | jq -r '.id // empty' 2>/dev/null || true)"
     if [ -z "$BUILD_PIPELINE_ID" ]; then
-        echo "ERROR: failed to trigger build pipeline:"
+        echo "ERROR: failed to trigger build pipeline (HTTP ${trigger_http:-000}):"
         printf '%s\n' "$trigger_response"
-        echo "Hint: if GitLab reports an empty pipeline, the PR branch predates"
-        echo "the pr-build CI definitions - ask the author to rebase onto main."
+        echo ""
+        echo "Common causes:"
+        echo "  - 'No stages / jobs for this pipeline': nothing matched on ${PR_REF}."
+        echo "    The PR branch predates the pr-build CI definitions - rebase it onto main."
+        echo "  - 403/404: the job token cannot trigger pipelines in this project"
+        echo "    (check Settings > CI/CD > Job token permissions)."
+        echo "  - 'Insufficient permissions': the trigger token lacks access to ${PR_REF}."
         exit 1
     fi
     echo "Build pipeline: ${CI_PROJECT_URL}/-/pipelines/${BUILD_PIPELINE_ID}"


### PR DESCRIPTION
## Description

Fixes two defects found during the first end-to-end run of the test-env promote pipeline (added in #143). Both are in `test-promote-build`; nothing else in the flow changes.

**1. The build trigger used the wrong token.** `promote_build_pipeline.sh` triggered the secret-free build with `CI_JOB_TOKEN`, but GitLab rejects a job token triggering a pipeline in its **own** project — it returns HTTP 422. Confirmed by hitting the pipelines API directly with a PAT on the same ref: that returns 201 and creates a pipeline, so the ref, workflow rules, and job matching were all fine and the token was the only problem.

Now uses a dedicated **pipeline trigger token** (`NVCM_BUILD_TRIGGER_TOKEN`). That's also the tighter credential — a trigger token can only start pipelines, unlike a job token. It's checked lazily at the trigger site, so a promote that reuses an existing successful build doesn't require it. No variables are passed on the trigger, so the untrusted build's isolation is unchanged.

**2. The trigger failure was undiagnosable.** The call used `curl -fsS`, which suppresses the response body on an HTTP error, and under `set -euo pipefail` the script aborted before the error branch below it could run — so the existing "empty pipeline → rebase onto main" hint was unreachable and the job died with a bare `exit code 22`. It now captures status and body and prints GitLab's actual message plus the likely causes. (Same class as the unreachable digest fallback fixed in #143.)

**3. Registry pull flakiness.** pr-build jobs intermittently fail before starting, with the image pull timing out against the registry proxy's auth endpoint (.../v2/token, context deadline exceeded at ~16s). Added retry: max: 2 on runner_system_failure/stuck_or_timeout_failure to both build jobs — these are runner system failures, not script failures, so this doesn't mask genuine build errors. This is a mitigation only: the underlying latency is an infrastructure issue on the dgxc-corp-restricted path, and GitLab caps retries at 2, so it can still fail.

Also corrects a comment that claimed `CI_JOB_TOKEN` was a valid same-project trigger token, which this run disproved.

## New CI/CD variable

`NVCM_BUILD_TRIGGER_TOKEN` — New protected + masked token. Documented in `.gitlab/ci/README.md`. Required only when the promote pipeline needs to trigger a fresh build; reuse-only runs work without it.

## Validation

- `bash -n` on the changed script.
- Verified the failure path now surfaces the body: a simulated 422 prints `HTTP 422` plus `{"message":{"base":["No stages / jobs for this pipeline."]}}` instead of dying silently.
- Root cause confirmed empirically against the mirror — `POST /projects/:id/pipeline?ref=pull-request/197` with a PAT returned 201 (`source: "api"`), proving the ref and rules were valid and isolating the fault to the job token on `/trigger/pipeline`.
- End-to-end promote validation continues once this lands and the trigger token is configured.

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

Kind integration not run — not applicable. This changes only a GitLab CI shell script and CI documentation; it touches no application code, Helm chart output, or anything the Kind suite exercises.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for triggering builds with a dedicated CI/CD token.
  * Existing successful builds can still be reused without requiring the trigger token.
* **Bug Fixes**
  * Improved build-trigger error reporting with HTTP status and response details.
  * Added automatic retries for transient runner, stuck, and timeout failures.
  * Repository cloning continues to use the standard job token.
* **Documentation**
  * Documented configuration, security settings, limitations, and variable-expansion behavior for the new CI/CD variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->