### PR TITLE
fix(workflow): show site name for cable validation

### DIFF
--- a/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
@@ -87,6 +87,7 @@ ACTIVITY_NO_RETRY_POLICY = RetryPolicy(maximum_attempts=1)
 DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=3)
 DEFAULT_CONFIG_MANAGER_STATUS = ["Active", "Provisioned"]
 DEFAULT_CONFIG_MANAGER_TENANT = None
+CANONICAL_SITE_SEARCH_ATTRIBUTE_PATCH = "site-cable-validation-canonical-site-v1"
 # list of search attributes to clone from parent to child
 CLONE_SEARCH_ATTRS = [
     USER_SEARCH_ATTRIBUTE,
@@ -432,6 +433,13 @@ class SiteCableValidationWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixi
                 device_type_ids=workflow_input.device_type_ids,
             )
         )
+
+        # The UI submits the Nautobot location ID, while device records contain
+        # the human-readable site name expected in workflow search results.
+        if devices_output.devices and workflow.patched(CANONICAL_SITE_SEARCH_ATTRIBUTE_PATCH):
+            workflow.upsert_search_attributes(
+                {SITE_SEARCH_ATTRIBUTE: [devices_output.devices[0].site]}
+            )
 
         if not devices_output.devices:
             self.set_stage_state("validate_devices", StateEnum.UNREACHABLE)

--- a/src/tests/temporal/ngc/workflows/test_cable_validation_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_cable_validation_workflow.py
@@ -101,6 +101,7 @@ async def mock_get_network_devices_by_site_id(
         devices=[
             NetworkDeviceData.from_nautobot_graphql(device)
             for device in DEVICE_CONNECTION_DATA_VALID.values()
+            if device["location"]["name"] == "SITEA"
         ]
     )
 

--- a/src/tests/temporal/ngc/workflows/test_cable_validation_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_cable_validation_workflow.py
@@ -76,6 +76,7 @@ ROLES_FOR_CABLE_VALIDATION = [
     "smn-spine",
     "smn-leaf",
 ]
+SITE_ID = "00000000-0000-0000-0000-000000000001"
 
 
 @activity.defn(name="get_network_devices")
@@ -87,6 +88,19 @@ async def mock_get_network_devices(
             NetworkDeviceData.from_nautobot_graphql(device)
             for device in DEVICE_CONNECTION_DATA_VALID.values()
             if device["location"]["name"] == activity_input.site
+        ]
+    )
+
+
+@activity.defn(name="get_network_devices")
+async def mock_get_network_devices_by_site_id(
+    activity_input: GetNetworkDevicesInput,
+) -> GetNetworkDevicesOutput:
+    assert activity_input.site == SITE_ID
+    return GetNetworkDevicesOutput(
+        devices=[
+            NetworkDeviceData.from_nautobot_graphql(device)
+            for device in DEVICE_CONNECTION_DATA_VALID.values()
         ]
     )
 
@@ -625,7 +639,7 @@ async def test_cable_validation_workflow_all_valid(_, mock_nb_client, env):
         task_queue=task_queue_name,
         workflows=[SiteCableValidationWorkflow, MockedDeviceCableValidationAllValid],
         activities=[
-            mock_get_network_devices,
+            mock_get_network_devices_by_site_id,
             mock_get_ui_base_url,
             mock_publish_nats,
             format_results,
@@ -633,7 +647,7 @@ async def test_cable_validation_workflow_all_valid(_, mock_nb_client, env):
         activity_executor=ThreadPoolExecutor(5),
     ):
         workflow_input = SiteCableValidationInput(
-            site="SITEA",
+            site=SITE_ID,
             roles=ROLES_FOR_CABLE_VALIDATION,
             raise_for_invalid=False,
         )
@@ -650,6 +664,9 @@ async def test_cable_validation_workflow_all_valid(_, mock_nb_client, env):
         result = await handle.result()
 
         assert result.markdown == "No invalid cabling found."
+
+        description = await handle.describe()
+        assert description.search_attributes["Site"] == ["SITEA"]
 
         stages = await handle.query("stages")
         assert stages[2]["output"]["display"] == "No invalid cabling found."


### PR DESCRIPTION
## Description

Fix site cable validation workflows so the workflow list displays the site name instead of the submitted location UUID, Guarded by a Temporal patch marker so workflows started on older code remain replay-safe.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`d0ba36b`](https://github.com/NVIDIA/nv-config-manager/commit/d0ba36b0595ede2ac07fe35bba9d2042d887fd58) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30825888276).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
      No documentation change is needed because this restores the documented site-name display.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs. No generated contracts or artifacts are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Site cable validation now records the canonical, human-readable site name when devices are found.
  * Workflow results provide clearer site identification for improved visibility and searchability.

* **Bug Fixes**
  * Corrected site resolution during cable validation by retrieving devices using the submitted site identifier and associating results with the corresponding site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->