### PR TITLE
fix(ui): improve tenant search and workflow table layout

### DIFF
--- a/ui/src/app/workflows/columns.tsx
+++ b/ui/src/app/workflows/columns.tsx
@@ -150,9 +150,16 @@ function FilterableValue({
   param: string;
   value: string;
 }) {
+  const title =
+    typeof children === "string" || typeof children === "number"
+      ? String(children)
+      : value;
+
   return (
-    <span className="inline-flex items-center gap-0.5">
-      <span>{children}</span>
+    <span className="inline-flex max-w-full min-w-0 items-center gap-0.5">
+      <span className="min-w-0 truncate" title={title}>
+        {children}
+      </span>
       <FilterValueIcon label={label} param={param} value={value} />
     </span>
   );
@@ -227,7 +234,7 @@ function SearchAttributeCell({
   }
 
   return (
-    <div className="flex flex-wrap gap-x-2 gap-y-1">
+    <div className="flex max-w-full min-w-0 flex-wrap gap-x-2 gap-y-1">
       {values.map((value, index) => {
         const stringValue = String(value);
 
@@ -271,8 +278,14 @@ export const getWorkflowColumns = (
       cell: ({ row }) => {
         const id = row.original.id;
         return (
-          <Link href={`/workflows/${id}`} title="View workflow details">
-            {id}
+          <Link
+            className="block max-w-full min-w-0"
+            href={`/workflows/${id}`}
+            title="View workflow details"
+          >
+            <span className="block truncate" title={id}>
+              {id}
+            </span>
           </Link>
         );
       },

--- a/ui/src/app/workflows/loading.tsx
+++ b/ui/src/app/workflows/loading.tsx
@@ -26,7 +26,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 const WorkflowsListSkeleton = () => {
   return (
-    <div className="container py-6">
+    <div className="w-full px-8 py-6">
       <div className="mb-4 flex flex-row items-center justify-between">
         <div className="space-y-4">
           <Skeleton className="h-8 w-36" />

--- a/ui/src/app/workflows/workflow-table.tsx
+++ b/ui/src/app/workflows/workflow-table.tsx
@@ -31,7 +31,7 @@ const WorkflowTable: React.FC<WorkflowTableProps> = ({
   );
 
   return (
-    <div className="container py-6" key={title}>
+    <div className="w-full px-8 py-6" key={title}>
       <div className="mb-4 flex flex-row items-center justify-between">
         <h1 className="mr-4 text-2xl font-semibold">{title}</h1>
       </div>

--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -848,7 +848,7 @@ export function DataTable<TData, TValue>({ columns }: DataTableProps<TData, TVal
                   {row.getVisibleCells().map((cell) => (
                     <TableCell
                       className={cn(
-                        "border-r border-border/30 px-3 py-3 last:border-r-0",
+                        "overflow-hidden border-r border-border/30 px-3 py-3 last:border-r-0",
                         cell.column.columnDef.meta?.className
                       )}
                       key={cell.id}

--- a/ui/src/components/ui/selectbox.tsx
+++ b/ui/src/components/ui/selectbox.tsx
@@ -33,7 +33,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface Option {
   value: string;
@@ -52,6 +51,29 @@ interface SelectBoxProps {
   disabled?: boolean;
   searchable?: boolean;
 }
+
+const filterOption = (
+  value: string,
+  search: string,
+  keywords: string[] = [],
+) => {
+  const normalizedSearch = search.trim().toLowerCase();
+  if (!normalizedSearch) return 1;
+
+  const candidates = [value, ...keywords].map((candidate) =>
+    candidate.toLowerCase(),
+  );
+
+  if (candidates.some((candidate) => candidate === normalizedSearch)) return 1;
+  if (candidates.some((candidate) => candidate.startsWith(normalizedSearch))) {
+    return 0.75;
+  }
+  if (candidates.some((candidate) => candidate.includes(normalizedSearch))) {
+    return 0.5;
+  }
+
+  return 0;
+};
 
 const SelectBox = React.forwardRef<HTMLInputElement, SelectBoxProps>(
   (
@@ -189,7 +211,7 @@ const SelectBox = React.forwardRef<HTMLInputElement, SelectBoxProps>(
           className="w-[var(--radix-popover-trigger-width)] p-0"
           align="start"
         >
-          <Command>
+          <Command filter={filterOption}>
             {searchable ? (
               <div className="relative">
                 <CommandInput
@@ -212,50 +234,47 @@ const SelectBox = React.forwardRef<HTMLInputElement, SelectBoxProps>(
               </div>
             ) : null}
 
-            <CommandList>
+            <CommandList className="max-h-64">
               <CommandEmpty>
                 {emptyPlaceholder ?? "No results found."}
               </CommandEmpty>
               <CommandGroup>
-                <ScrollArea>
-                  <div className="max-h-64">
-                    {options?.map((option) => {
-                      const isSelected =
-                        Array.isArray(value) && value.includes(option.value);
-                      return (
-                        <CommandItem
-                          key={option.value}
-                          // value={option.value}
-                          onSelect={() => handleSelect(option.value)}
+                {options?.map((option) => {
+                  const isSelected =
+                    Array.isArray(value) && value.includes(option.value);
+                  return (
+                    <CommandItem
+                      key={option.value}
+                      value={option.value}
+                      keywords={[option.key]}
+                      onSelect={() => handleSelect(option.value)}
+                    >
+                      {multiple && (
+                        <div
+                          className={cn(
+                            "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
+                            isSelected
+                              ? "bg-primary text-primary-foreground"
+                              : "opacity-50 [&_svg]:invisible",
+                          )}
                         >
-                          {multiple && (
-                            <div
-                              className={cn(
-                                "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
-                                isSelected
-                                  ? "bg-primary text-primary-foreground"
-                                  : "opacity-50 [&_svg]:invisible",
-                              )}
-                            >
-                              <CheckIcon />
-                            </div>
+                          <CheckIcon />
+                        </div>
+                      )}
+                      <span>{option.key}</span>
+                      {!multiple && option.value === value && (
+                        <CheckIcon
+                          className={cn(
+                            "ml-auto",
+                            option.value === value
+                              ? "opacity-100"
+                              : "opacity-0",
                           )}
-                          <span>{option.key}</span>
-                          {!multiple && option.value === value && (
-                            <CheckIcon
-                              className={cn(
-                                "ml-auto",
-                                option.value === value
-                                  ? "opacity-100"
-                                  : "opacity-0",
-                              )}
-                            />
-                          )}
-                        </CommandItem>
-                      );
-                    })}
-                  </div>
-                </ScrollArea>
+                        />
+                      )}
+                    </CommandItem>
+                  );
+                })}
               </CommandGroup>
             </CommandList>
           </Command>

--- a/ui/tests/e2e/spxOverlayCreationForm.spec.ts
+++ b/ui/tests/e2e/spxOverlayCreationForm.spec.ts
@@ -27,6 +27,13 @@ const VPC_DATA = {
   rd_max: 65000,
 };
 
+const SEARCH_TENANTS = [
+  { id: "engineering-cloud", name: "Engineering Cloud" },
+  { id: "ngc-platform", name: "NGC Platform" },
+  { id: "pre-ngc", name: "Pre-NGC Tenant" },
+  { id: "ngc", name: "NGC" },
+];
+
 test.describe("New SpX Overlay Creation Workflow", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/workflows/spxoverlaycreationworkflow/form");
@@ -90,6 +97,31 @@ test.describe("New SpX Overlay Creation Workflow", () => {
       { timeout: TEST_TIMEOUT }
     );
   });
+});
+
+test("filters tenants by contiguous text and ranks an exact match first", async ({
+  page,
+}) => {
+  await page.unroute(/.*\/v1\/parameter\/tenant/);
+  await page.route(/.*\/v1\/parameter\/tenant/, async (route) => {
+    await route.fulfill({ status: 200, json: SEARCH_TENANTS });
+  });
+  await page.goto("/workflows/spxoverlaycreationworkflow/form");
+
+  await page.getByRole("button", { name: "Tenant" }).click();
+  const tenantDialog = page.getByRole("dialog");
+  const tenantSearch = tenantDialog.getByPlaceholder("Search Tenant");
+  await tenantSearch.fill("NGC");
+
+  await expect(
+    tenantDialog.getByText("Engineering Cloud", { exact: true }),
+  ).toBeHidden();
+  await expect(tenantDialog.locator("[cmdk-item]:visible")).toHaveCount(3);
+
+  await tenantSearch.press("Enter");
+  await expect(
+    page.getByRole("button", { name: "NGC. Open options", exact: true }),
+  ).toBeVisible();
 });
 
 // Tests that handle their own navigation with URL parameters

--- a/ui/tests/e2e/workflowsPage.spec.ts
+++ b/ui/tests/e2e/workflowsPage.spec.ts
@@ -27,6 +27,8 @@ applicationUrl.hostname = `nautobot.${gatewayUrl.hostname}`;
 const applicationHome = new URL("/", applicationUrl).toString();
 const providerEndSessionUrl = "https://idp.example.com/oidc/logout";
 const providerReturnUrl = "https://nautobot.config-manager.example.com/";
+const LONG_USERNAME =
+  "thisusernameisintentionallylongenoughtoexceedtheusercolumnwidth";
 
 const providerLogoutUrl = (clientId?: string): URL => {
   const redirect = providerLogoutRedirect(
@@ -148,6 +150,64 @@ test.describe("Workflows Page", () => {
       .getByRole("checkbox", { name: "Toggle Device ID column" })
       .click();
     await expect(tableHeader.getByText("Device ID")).toBeVisible();
+  });
+
+  test("contains long text values within their workflow columns", async ({
+    page,
+  }) => {
+    await page.unroute(/.*\/v1\/workflow\/?(\?.*)?$/);
+    await page.route(/.*\/v1\/workflow\/?(\?.*)?$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        json: {
+          workflows: [
+            {
+              id: "long-content-workflow",
+              workflow_type: "DeployWorkflow",
+              workflow_input: {},
+              started_by: LONG_USERNAME,
+              start_time: "2025-03-04T02:32:38.087457Z",
+              close_time: null,
+              status: "RUNNING",
+              pending_approval: false,
+              search_attributes: {
+                Site: ["PDX01"],
+                DeviceName: ["LEAF2-GP1-CIN2-PDX01"],
+                User: [LONG_USERNAME],
+              },
+              href: "https://temporal.example.com/long-content-workflow",
+            },
+          ],
+          next_page_token: null,
+          total_count: 1,
+          page_count: 1,
+        },
+      });
+    });
+
+    await page.goto("/workflows");
+
+    const workflowRow = page.locator("tbody tr").first();
+    const userCell = workflowRow.locator("td").filter({
+      hasText: LONG_USERNAME,
+    });
+    const userValue = userCell.getByTitle(LONG_USERNAME, { exact: true });
+
+    await expect(userValue).toHaveCSS("overflow", "hidden");
+    await expect(userValue).toHaveCSS("text-overflow", "ellipsis");
+    await expect(userValue).toHaveCSS("white-space", "nowrap");
+
+    const cellsContainOverflow = await workflowRow.locator("td").evaluateAll(
+      (cells) =>
+        cells.every((cell) => getComputedStyle(cell).overflow === "hidden"),
+    );
+    expect(cellsContainOverflow).toBe(true);
+
+    const cellBox = await userCell.boundingBox();
+    const valueBox = await userValue.boundingBox();
+    expect((valueBox?.x ?? 0) + (valueBox?.width ?? 0)).toBeLessThanOrEqual(
+      (cellBox?.x ?? 0) + (cellBox?.width ?? 0),
+    );
   });
 
   test("shows user roles and disables workflows the user cannot execute", async ({
@@ -536,6 +596,39 @@ test.describe("Workflows Page", () => {
 
     const restoredBox = await workflowIdHeader.boundingBox();
     expect(restoredBox?.width ?? 0).toBeCloseTo(initialWidth, 0);
+  });
+
+  test("uses available viewport width for optional workflow columns", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto("/workflows");
+    await expect(page.getByText("LEAF1-GP1-CIN2-PDX01").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Columns" }).click();
+    for (const columnName of [
+      "Device ID",
+      "Device Role",
+      "Device Platform",
+    ]) {
+      await page
+        .getByRole("checkbox", { name: `Toggle ${columnName} column` })
+        .click();
+    }
+
+    const tableViewport = page.locator("table").first().locator("xpath=..");
+    await expect.poll(async () => {
+      return tableViewport.evaluate(
+        (element) => element.scrollWidth <= element.clientWidth + 1,
+      );
+    }).toBe(true);
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await expect.poll(async () => {
+      return tableViewport.evaluate(
+        (element) => element.scrollWidth > element.clientWidth,
+      );
+    }).toBe(true);
   });
 
   test("persists the selected row count", async ({ page }) => {


### PR DESCRIPTION
## Description

Fix three related UI usability issues:

- replace fuzzy subsequence matching in searchable selects with case-insensitive contiguous matching that ranks exact results before prefix and substring results;
- contain long workflow-table values within their columns using ellipsis truncation while preserving full values in hover titles;
- allow the Workflows page to consume the available viewport width so optional Device ID, Device Role, and Device Platform columns avoid unnecessary horizontal scrolling on wide displays.

The tenant-search issue was caused by cmdk's default fuzzy matcher and a nested scroll wrapper that prevented cmdk from reordering individual results. The table issues were caused by unconstrained cell content and the Workflows page's 1400px container cap.

Users can now find exact tenant matches without scrolling, read tables without values crossing column boundaries, and use optional workflow columns without scrolling when the browser is wide enough.

## Validation

- `npm run lint -- --max-warnings=0`
- `npx playwright test tests/e2e/spxOverlayCreationForm.spec.ts --project=chromium --reporter=line` (10 passed)
- `npx playwright test tests/e2e/workflowsPage.spec.ts --project=chromium --reporter=line` (22 passed)
- `npm run build`
- `git diff --check`
- Kind integration was not run because these are isolated UI behavior and browser-test changes; the PR remains draft for normal CI and review.

- [ ] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **failure** for [`7dd22f2`](https://github.com/NVIDIA/nv-config-manager/commit/7dd22f22fc2a77c15d526a6b768b8b85a9e327d0) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30826355015).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dropdown search with exact, prefix, and partial matching.
  * Added clearer handling for long workflow values with truncation and tooltips.
  * Improved responsive workflow table layouts, including horizontal scrolling when needed.

* **Bug Fixes**
  * Prevented lengthy table content from overflowing its cells.
  * Preserved workflow filtering and selection behavior across layouts.

* **Tests**
  * Added coverage for tenant filtering, long-value truncation, and responsive table behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
