### PR TITLE
resolve ONIE race condition

### DIFF
--- a/components/network-templates/src/nv_config_manager_templates/templates/cumulus-linux/role_common/base/boot-script.j2
+++ b/components/network-templates/src/nv_config_manager_templates/templates/cumulus-linux/role_common/base/boot-script.j2
@@ -56,7 +56,11 @@ if ! grep -q "VERSION_ID={{ device_data|desired_firmware }}" /etc/os-release; th
   FIRMWARE_URL="http://{{ (device_data|ztp_servers)[0] }}/v1/device/{{ device_data|uuid }}/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/src/nv_config_manager_templates/templates/cumulus-linux/role_common/base/boot-script.j2
+++ b/components/network-templates/src/nv_config_manager_templates/templates/cumulus-linux/role_common/base/boot-script.j2
@@ -46,10 +46,18 @@ trap error ERR
 
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID={{ device_data|desired_firmware }}" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
+
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://{{ (device_data|ztp_servers)[0] }}/v1/device/{{ device_data|uuid }}/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.13.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/73cd8d4d-2af7-4088-9758-22d8ee401900/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.13.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/73cd8d4d-2af7-4088-9758-22d8ee401900/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.14.0/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/73cd8d4d-2af7-4088-9758-22d8ee401900/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.14.0/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/73cd8d4d-2af7-4088-9758-22d8ee401900/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.16.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/73cd8d4d-2af7-4088-9758-22d8ee401900/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a04-u44-p01-tor-01/5.16.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/73cd8d4d-2af7-4088-9758-22d8ee401900/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.13.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/8096224f-96b0-4f65-8b3e-2f3c4f47d1c4/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.13.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/8096224f-96b0-4f65-8b3e-2f3c4f47d1c4/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.14.0/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/8096224f-96b0-4f65-8b3e-2f3c4f47d1c4/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.14.0/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/8096224f-96b0-4f65-8b3e-2f3c4f47d1c4/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.16.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/8096224f-96b0-4f65-8b3e-2f3c4f47d1c4/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u28-p01-oobspine-01/5.16.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/8096224f-96b0-4f65-8b3e-2f3c4f47d1c4/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.13.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/c9e574df-2295-4258-b5b2-16247b6e3aa7/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.13.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/c9e574df-2295-4258-b5b2-16247b6e3aa7/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.14.0/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/c9e574df-2295-4258-b5b2-16247b6e3aa7/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.14.0/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/c9e574df-2295-4258-b5b2-16247b6e3aa7/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.16.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/c9e574df-2295-4258-b5b2-16247b6e3aa7/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u32-p01-cleaf-01/5.16.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/c9e574df-2295-4258-b5b2-16247b6e3aa7/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.13.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/833d1c59-47dc-4fe9-8f7d-245218caaa01/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.13.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/833d1c59-47dc-4fe9-8f7d-245218caaa01/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.14.0/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/833d1c59-47dc-4fe9-8f7d-245218caaa01/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.14.0/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/833d1c59-47dc-4fe9-8f7d-245218caaa01/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.16.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/833d1c59-47dc-4fe9-8f7d-245218caaa01/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a08-u44-p01-mleaf-01/5.16.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/833d1c59-47dc-4fe9-8f7d-245218caaa01/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.13.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/a1f9b61c-f9df-4093-b791-8e07ff425d1d/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.13.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/a1f9b61c-f9df-4093-b791-8e07ff425d1d/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.14.0/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/a1f9b61c-f9df-4093-b791-8e07ff425d1d/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.14.0/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/a1f9b61c-f9df-4093-b791-8e07ff425d1d/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.16.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/a1f9b61c-f9df-4093-b791-8e07ff425d1d/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u28-p01-bleaf-01/5.16.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/a1f9b61c-f9df-4093-b791-8e07ff425d1d/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.13.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/696e142c-ff53-4b3a-9724-3d509a1eb73b/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.13.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/696e142c-ff53-4b3a-9724-3d509a1eb73b/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.14.0/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/696e142c-ff53-4b3a-9724-3d509a1eb73b/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.14.0/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/696e142c-ff53-4b3a-9724-3d509a1eb73b/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.16.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/696e142c-ff53-4b3a-9724-3d509a1eb73b/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u32-p01-sleaf-01/5.16.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/696e142c-ff53-4b3a-9724-3d509a1eb73b/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.13.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/faf21128-fc9d-4bf3-8bce-a293c1c27b05/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.13.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/faf21128-fc9d-4bf3-8bce-a293c1c27b05/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.14.0/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/faf21128-fc9d-4bf3-8bce-a293c1c27b05/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.14.0/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/faf21128-fc9d-4bf3-8bce-a293c1c27b05/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.16.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/faf21128-fc9d-4bf3-8bce-a293c1c27b05/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u36-p01-spine-01/5.16.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/faf21128-fc9d-4bf3-8bce-a293c1c27b05/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.13.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/16e65652-12f0-4b89-b7d7-4d8fd8bca0b5/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.13.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.13.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.13.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/16e65652-12f0-4b89-b7d7-4d8fd8bca0b5/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.14.0/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/16e65652-12f0-4b89-b7d7-4d8fd8bca0b5/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"

--- a/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.14.0/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.14.0/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.14.0" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/16e65652-12f0-4b89-b7d7-4d8fd8bca0b5/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.16.1/boot-script
@@ -41,10 +41,17 @@ date "+%FT%T ztp starting script $0"
 trap error ERR
 # Check current image and upgrade firmware first if needed
 if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
+  FIRMWARE_REBOOT_MARKER="/tmp/ztp-firmware-reboot-pending"
+  if [ -f "$FIRMWARE_REBOOT_MARKER" ]; then
+    echo "Firmware installation already completed; waiting for reboot."
+    exit 0
+  fi
   # Load firmware with onie and reboot, DHCP will run after reboot
   FIRMWARE_URL="http://192.0.2.10/v1/device/16e65652-12f0-4b89-b7d7-4d8fd8bca0b5/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
+    touch "$FIRMWARE_REBOOT_MARKER"
     reboot
+    exit 0
   else
     echo "Firmware installation failed with exit code $?"
     exit 1

--- a/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.16.1/boot-script
+++ b/components/network-templates/tests/resources/expected_config/a09-u44-p01-pleaf-01/5.16.1/boot-script
@@ -50,7 +50,11 @@ if ! grep -q "VERSION_ID=5.16.1" /etc/os-release; then
   FIRMWARE_URL="http://192.0.2.10/v1/device/16e65652-12f0-4b89-b7d7-4d8fd8bca0b5/firmware"
   if /usr/cumulus/bin/onie-install -fa -i "$FIRMWARE_URL"; then
     touch "$FIRMWARE_REBOOT_MARKER"
-    reboot
+    if ! reboot; then
+      rm -f "$FIRMWARE_REBOOT_MARKER"
+      echo "Failed to initiate reboot."
+      exit 1
+    fi
     exit 0
   else
     echo "Firmware installation failed with exit code $?"


### PR DESCRIPTION
## Description

* Fixes a ZTP race where the script continued after requesting a firmware reboot, allowing a retry to start another OS download before shutdown completed and potentially corrupt the image. A volatile /tmp marker now prevents duplicate firmware installation during the pending reboot while allowing ZTP to retry normally after the next boot if ONIE fails.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware upgrade handling across supported network configurations.
  * Prevented repeated firmware installation when devices restart during upgrades.
  * Added clearer completion handling after successful installation and reboot requests.
  * Improved error handling by reporting failed reboot initiation and allowing a retry.

* **Tests**
  * Updated expected boot-script configurations to validate the revised firmware upgrade flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->