### PR TITLE
improve site bring-up and cable validation docs

### DIFF
--- a/docs/user-guides/cable-validation/index.mdx
+++ b/docs/user-guides/cable-validation/index.mdx
@@ -21,12 +21,68 @@ Cable validation can detect:
 - Incorrect MAC addresses supplied by a partner
 - Incorrect cable purchases
 
+## How each connection is evaluated
+
+Cable validation runs from the perspective of each in-scope network device. For each enabled interface with a connected interface modeled in Nautobot, it compares the intended far end with observations from the local device in this order:
+
+1. **Is the local link operationally up?** If not, the workflow reports `Link is down`. This check applies to both full validation and link-state-only validation.
+1. **Is the interface tagged for link-state-only validation?** If the link is up and the local interface has `cable-validation-link-state-only`, the connection passes without an identity check.
+1. **Does LLDP identify the intended neighbor?** The reported neighbor device and interface are compared with the far-end device and interface in Nautobot. The comparison is case-insensitive. The workflow also handles devices that advertise an interface MAC instead of a port or system name, including the supported DPU MAC-offset behavior.
+1. **Does the expected far-end MAC appear on the correct local interface?** The workflow takes the MAC from the connected far-end interface in Nautobot and looks for it in the local device's FDB or ARP table.
+1. **Classify the result.** A connection passes when either LLDP or the MAC check matches. If neither matches, the report distinguishes a wrong observed neighbor from a link that is up but has no usable neighbor data.
+
+The workflow also reports an LLDP neighbor on an interface that has no intended connection in Nautobot as `Unexpected connection found`. It does not treat every unmodeled FDB entry as an unexpected cable because a port can legitimately learn multiple MAC addresses.
+
+| Validation mode | Link state | LLDP identity | FDB/ARP MAC | Unexpected LLDP neighbor |
+| :-------------- | :--------: | :-----------: | :---------: | :----------------------: |
+| Full validation | Checked | Either LLDP or MAC must match | Either MAC or LLDP must match | Reported |
+| `cable-validation-link-state-only` | Checked | Skipped | Skipped | Not applicable to a modeled connection |
+| `cable-validation-ignore` | Skipped | Skipped | Skipped | Suppressed on the tagged interface |
+
+<Warning>
+An operationally up link does not prove that it reaches the intended host or port. Link-state-only validation is an intentionally temporary, lower-confidence result for cases where the data needed for full validation is not available yet.
+</Warning>
+
+## Validation tags
+
+Apply validation tags to the interface on the in-scope network device—the interface from which the workflow collects link, LLDP, FDB, and ARP state. For a high-speed leaf-to-host connection, this is normally the leaf switch interface. The cable and connected far-end interface must still be modeled in Nautobot.
+
+### `cable-validation-link-state-only`
+
+Use `cable-validation-link-state-only` when the intended connection is known but there is not yet enough neighbor identity data for a meaningful full check. The common initial bringup case is a high-speed host port whose MAC addresses are not delivered with the original inventory data. Those MACs become available only after the compute management system discovers the host and updates Nautobot. Hosts may also provide no reliable LLDP identity during this stage.
+
+With this tag, the workflow evaluates only whether the local switch interface is operationally up:
+
+- Link down: report `Link is down` with any available transceiver troubleshooting details.
+- Link up: consider the interface valid for this run without comparing LLDP, FDB, or ARP data to the intended far end.
+
+Use the tag during the first validation pass as follows:
+
+1. Confirm the cable and both endpoints are modeled correctly in Nautobot.
+1. Add `cable-validation-link-state-only` to each affected in-scope switch interface before the first cable-validation run.
+1. Run site cable validation and resolve all link-down results. Treat a clean link-state-only result as confirmation of physical signal only, not confirmation that the host is connected to the correct port.
+1. Allow the compute management system to discover the hosts and populate their high-speed interface MAC addresses in Nautobot.
+1. Verify that the MAC is assigned to the correct far-end host interface, then remove `cable-validation-link-state-only` from the switch interface.
+1. Re-run device or site cable validation. The connection now receives full LLDP-or-MAC validation and can detect swapped host links.
+
+Do not leave the tag in place after the required MAC or reliable LLDP data becomes available. Doing so permanently hides wrong-neighbor and cable-swap errors on an otherwise healthy link.
+
+The report lists findings, not every passing interface. An up link-state-only interface therefore does not appear with a special “partial validation” result. Before final site acceptance, filter Nautobot interfaces by the `cable-validation-link-state-only` tag, resolve every remaining temporary use, and run full validation again.
+
+To add or remove the tag in Nautobot, open the local switch interface, edit its **Tags** field, and save the interface. For many host-facing ports, use Nautobot's interface list and bulk-edit the selected interfaces. The workflow reads the current tags at the start of each run, so re-run validation after changing them.
+
+### `cable-validation-ignore`
+
+Use `cable-validation-ignore` only when an interface is deliberately outside the workflow's scope. It skips the intended-connection checks and suppresses unexpected-neighbor findings on that interface. It is not the right substitute for missing host MAC data when the physical link still needs an initial link-state check.
+
+Do not apply both validation tags to the same interface. If both are present, `cable-validation-ignore` takes precedence and even the link-state check is skipped.
+
 ## Prerequisites
 
 Before running cable validation, confirm the following are in place:
 
 - **Devices have completed ZTP** and reached the `Provisioned` (or `Active`) status in Nautobot. Running validation against devices that are still provisioning or unreachable produces noisy failures. See [New Site Bringup](../new-site-deployment/index.mdx) for the bringup sequence.
-- **Intended cabling is captured in Nautobot.** The workflow compares LLDP and FDB output against the cable list in Nautobot, so the Nautobot data must reflect the design. Connections that exist in Nautobot but should not be validated must carry the `cable-validation-ignore` interface tag.
+- **Intended cabling is captured in Nautobot.** The workflow compares observed state against enabled interfaces and connected endpoints in Nautobot, so the Nautobot data must reflect the design. Use `cable-validation-link-state-only` temporarily when an intended connection should be checked for link state but its far-end identity data is not available. Use `cable-validation-ignore` only for interfaces that are deliberately outside validation scope.
 - **Devices are running a supported platform** — Cumulus Linux, NVOS, or Arista EOS. Devices on other platforms are filtered out automatically.
 - **Network reachability from Config Manager** to every in-scope device's management address, so the workflow can query LLDP neighbors and the MAC/ARP tables.
 
@@ -74,7 +130,7 @@ Use this to re-validate a single device after fixing an issue without re-running
 | **Tenant** | Optional Nautobot tenant filter to narrow the device list. | No |
 | **Status** | Optional device-status filter to narrow the device list. | No |
 | **Device** | The target device. The list is filtered by the selections above. | Yes |
-| **Ignore No Neighbor** | Optional. If enabled, suppresses `Link is up, but no neighbor found` findings for this device run. Useful during partial bringup where some far-side neighbors are intentionally absent. | No |
+| **Ignore No Neighbor** | Optional. If enabled, suppresses `Link is up but no neighbor found` findings for this device run. Useful during partial bringup where some far-side neighbors are intentionally absent. | No |
 
 A typical device run completes in well under a minute, dominated by the round-trip time to query LLDP and the FDB.
 
@@ -110,7 +166,7 @@ The device workflow runs six stages. The three data-collection stages (`get_devi
 
 1. **`get_device_intended_neighbors` — Read intended cabling from Nautobot.**
 
-   Pulls the list of intended LLDP/MAC neighbors for every interface on the device from Nautobot, including any `cable-validation-ignore` tagging that should exclude an interface from the comparison.
+   Pulls every enabled interface with a connected interface from Nautobot. For each connection, it records the far-end device, interface, role, rack position, and interface MAC when present. It also records `cable-validation-ignore` and `cable-validation-link-state-only` tags on the local interface.
 
 1. **`get_device_actual_neighbors` — Read observed cabling from the device.**
 
@@ -122,7 +178,7 @@ The device workflow runs six stages. The three data-collection stages (`get_devi
 
 1. **`validate_connections` — Compare intended vs actual and produce the report.**
 
-   Joins the three data sources, classifies every interface mismatch (link down, wrong neighbor, no neighbor found, unexpected connection), decorates the findings with the stable `ID` hash used across runs, and formats the per-device Markdown report. This stage is not retryable — if validation logic raises, the run fails outright rather than masking a real bug behind a retry.
+   Joins the three data sources and applies the decision order in [How each connection is evaluated](#how-each-connection-is-evaluated). Link state is always checked first. An up interface marked link-state-only passes immediately; otherwise either LLDP or the expected far-end MAC must match. The stage then classifies every mismatch (link down, wrong neighbor, no neighbor found, unexpected connection), decorates findings with the stable `ID` hash used across runs, and formats the per-device Markdown report. This stage is not retryable — if validation logic raises, the run fails outright rather than masking a real bug behind a retry.
 
 The workflow's final output is a `DeviceCableValidationResult` whose `interfaces` field maps each invalid interface name to its findings.
 
@@ -170,7 +226,7 @@ The cabling modeled in Nautobot does not match what was found on the network. Th
 - **LLDP data** — the physical cabling does not match what is modeled in Nautobot.
 - **MAC address** — the MAC seen on the switch FDB does not match the expected MAC in Nautobot. Either the MAC in Nautobot is wrong, or the physical cabling is wrong. This is used when LLDP is not available, usually for IPMI/BMC connections.
 
-**`Link is up, but no neighbor found`**
+**`Link is up but no neighbor found`**
 
 A link is present but no LLDP neighbor or MAC address was found, so the link could not be validated. Retrying the validation may resolve the issue. If it does not, check the status of the devices on either end to see why they are not operating properly. This error may also occur when a cable mismatch leads to a low-light condition.
 
@@ -178,7 +234,7 @@ A link is present but no LLDP neighbor or MAC address was found, so the link cou
 
 A neighbor was found that is not modeled in Nautobot. This could mean Nautobot is out of date, or that there are connections not in scope for Config Manager validation (commonly custom cabling for the site or connections to non-Nautobot-managed devices).
 
-If there are connections in Nautobot that should be present but do not need to be validated, add the `cable-validation-ignore` tag to those interfaces and re-run the cable validation workflow to get a clean report.
+If there are connections in Nautobot that are deliberately outside validation scope, add the `cable-validation-ignore` tag to the in-scope switch interfaces and re-run the cable validation workflow. If the connection should be validated later but currently lacks host MAC or reliable LLDP data, use `cable-validation-link-state-only` instead.
 
 ## Common issues and troubleshooting
 
@@ -204,15 +260,19 @@ Unstable FDBs usually indicate a misbehaving device on one end of the link — i
 
 **Server links are flapping between runs.**
 
-Servers can churn LLDP/MAC state if they are stuck in a PXE boot loop on a partially provisioned site. Tag the leaf-side interfaces with `cable-validation-ignore` until the server side is provisioned, then remove the tag. On InfiniBand sites, server links are out of scope here — they are validated by a separate workflow.
+Servers can churn LLDP/MAC state if they are stuck in a PXE boot loop on a partially provisioned site. If the links are modeled and should be checked for physical signal during bringup, tag the leaf-side interfaces with `cable-validation-link-state-only`. Remove the tag and run full validation after the server-side identity data stabilizes. Reserve `cable-validation-ignore` for connections that are intentionally outside scope. On InfiniBand sites, server links are out of scope here — they are validated by a separate workflow.
 
-**`Link is up, but no neighbor found` on multiple links.**
+**`Link is up but no neighbor found` on multiple links.**
 
 LLDP and the FDB were both empty for those interfaces. Retry the workflow first — LLDP can briefly miss neighbors right after a port flap. If the issue persists, check the neighbor on the far side of each link; an unpowered or misconfigured neighbor is the most common cause. Setting `Ignore No Neighbor` to true on the device workflow will hide these from the report, which is appropriate during a partial bringup but should not be the default.
 
 **Validation found unexpected connections that are legitimately out of scope.**
 
 For connections that exist in Nautobot but should not be validated (custom site cabling, non-Nautobot-managed neighbors), add the `cable-validation-ignore` tag to those interfaces and re-run for a clean report.
+
+**High-speed host links fail because the intended MAC is empty or has not been discovered yet.**
+
+During initial bringup, add `cable-validation-link-state-only` to the leaf-side interfaces and validate physical link state first. After the compute management system populates the host interface MACs in Nautobot, verify their interface assignments, remove the tag, and re-run full validation. Do not use the temporary clean report as evidence that host links are in the correct order; only the later identity-aware pass can detect swaps.
 
 ## Related guides
 

--- a/docs/user-guides/cable-validation/index.mdx
+++ b/docs/user-guides/cable-validation/index.mdx
@@ -25,7 +25,8 @@ Cable validation can detect:
 
 Cable validation runs from the perspective of each in-scope network device. For each enabled interface with a connected interface modeled in Nautobot, it compares the intended far end with observations from the local device in this order:
 
-1. **Is the local link operationally up?** If not, the workflow reports `Link is down`. This check applies to both full validation and link-state-only validation.
+1. **Does the intended neighbor have the required Nautobot data?** The connected device must have a name and role. Missing required data stops validation for the device before any link-state result is produced.
+1. **Is the local link operationally up?** If not, the workflow reports `Link is down`. This check applies to both full validation and link-state-only validation after the required Nautobot data passes validation.
 1. **Is the interface tagged for link-state-only validation?** If the link is up and the local interface has `cable-validation-link-state-only`, the connection passes without an identity check.
 1. **Does LLDP identify the intended neighbor?** The reported neighbor device and interface are compared with the far-end device and interface in Nautobot. The comparison is case-insensitive. The workflow also handles devices that advertise an interface MAC instead of a port or system name, including the supported DPU MAC-offset behavior.
 1. **Does the expected far-end MAC appear on the correct local interface?** The workflow takes the MAC from the connected far-end interface in Nautobot and looks for it in the local device's FDB or ARP table.
@@ -178,7 +179,7 @@ The device workflow runs six stages. The three data-collection stages (`get_devi
 
 1. **`validate_connections` — Compare intended vs actual and produce the report.**
 
-   Joins the three data sources and applies the decision order in [How each connection is evaluated](#how-each-connection-is-evaluated). Link state is always checked first. An up interface marked link-state-only passes immediately; otherwise either LLDP or the expected far-end MAC must match. The stage then classifies every mismatch (link down, wrong neighbor, no neighbor found, unexpected connection), decorates findings with the stable `ID` hash used across runs, and formats the per-device Markdown report. This stage is not retryable — if validation logic raises, the run fails outright rather than masking a real bug behind a retry.
+   Joins the three data sources and applies the decision order in [How each connection is evaluated](#how-each-connection-is-evaluated). It validates the required intended-neighbor fields before checking link state. After that prerequisite passes, an up interface marked link-state-only passes immediately; otherwise either LLDP or the expected far-end MAC must match. The stage then classifies every mismatch (link down, wrong neighbor, no neighbor found, unexpected connection), decorates findings with the stable `ID` hash used across runs, and formats the per-device Markdown report. This stage is not retryable — if validation logic raises, the run fails outright rather than masking a real bug behind a retry.
 
 The workflow's final output is a `DeviceCableValidationResult` whose `interfaces` field maps each invalid interface name to its findings.
 

--- a/docs/user-guides/new-site-deployment/index.mdx
+++ b/docs/user-guides/new-site-deployment/index.mdx
@@ -8,6 +8,8 @@ This guide walks operators through bringing up a new site managed by Config Mana
 
 The guide assumes Nautobot has already been populated with the site's device data (serial numbers, MAC addresses, IP addresses, cabling, and config contexts).
 
+The Config Manager, Nautobot, Kea, relay, and packet-flow checks in this guide apply across supported network operating systems. Device commands and file paths vary by vendor. Cumulus Linux-specific material is explicitly labeled, with its main command and recovery reference grouped in [Cumulus Linux device checks and recovery](#cumulus-linux-device-checks-and-recovery).
+
 ## Prerequisites
 
 Before starting bringup, confirm the following are in place:
@@ -27,21 +29,21 @@ Before starting bringup, confirm the following are in place:
 
 Follow these steps in order. Each step assumes the previous one has completed successfully.
 
-1. **Power up all network switches.** All switches can be powered up at once. Each switch will boot, attempt DHCP, and retry in a boot loop until it receives a response — so downstream switches will simply keep trying until the relay chain through their upstream neighbors is operational. Provisioning will naturally fan out from Config Manager along the documented [ZTP provisioning order](../../network-topology-requirements/index.mdx#defined-ztp-provisioning-order) as each upstream layer comes online.
+1. **Power up all network switches.** All switches can be powered up at once. Each switch will boot and attempt DHCP. Provisioning will naturally fan out from Config Manager along the documented [ZTP provisioning order](../../network-topology-requirements/index.mdx#defined-ztp-provisioning-order) as each upstream layer comes online.
 
    <Tip>
-   **Stuck boot loop:** if a switch fails to leave the DHCP retry loop after its upstream relay path is up, power-cycle the switch to restart the boot process.
+   Do not assume a switch is still retrying because its console says that ZTP is in progress. After fixing cabling or relay connectivity, verify that DHCP or the NOS provisioning log has a recent attempt (`/var/log/autoprovision` on Cumulus Linux). If its attempts stopped while the path was broken, power-cycle the switch to restart DHCP and ZTP.
    </Tip>
 
 1. **ZTP device configurations from Config Manager.** Each switch boots with factory defaults, requests an IP via DHCP, and downloads its boot script and rendered configuration from the Config Manager ZTP service. See [Network ZTP](../../network-ztp/index.mdx) for how this works under the hood.
 
-   When ZTP completes successfully, the device's status in Nautobot transitions to **Provisioned**. If a switch does not reach Provisioned within a reasonable window, work through the [Monitoring DHCP and ZTP](#monitoring-dhcp-and-ztp) and [Common errors](#common-errors-and-troubleshooting) sections below. Where the underlying issue is physical (miscabled, unpowered, factory reset required), DC Ops will need to investigate on-site.
+   When ZTP completes successfully, the device's status in Nautobot transitions to **Provisioned**. If a switch does not reach Provisioned within a reasonable window, work through the [Monitoring DHCP and ZTP](#monitoring-dhcp-and-ztp) and [Common errors](#common-errors-and-troubleshooting) sections below. Where the underlying issue is physical (miscabled, unpowered, factory reset required), the on-site operations team will need to investigate.
 
 1. **Run the Cable Validation workflow.** Once switches have reached Provisioned, run the cable validation workflow to confirm cabling matches the design. See the [Cable Validation Guide](../cable-validation/index.mdx) for how to run the workflow and interpret the report.
 
-   Incorrect cabling typically surfaces as a MAC mismatch or a down link. The report identifies the device and port to investigate. Devices that do not respond require DC Ops to confirm power and connectivity.
+   Incorrect cabling typically surfaces as a MAC mismatch or a down link. The report identifies the device and port to investigate. Devices that do not respond require the on-site operations team to confirm power and connectivity.
 
-1. **Run the hardware error check workflow.** This collects hardware diagnostic command output from each switch into a per-device file for review by DC Ops.
+1. **Run the hardware error check workflow.** This collects hardware diagnostic command output from each switch into a per-device file for review by the on-site operations team.
 
 ## Monitoring DHCP and ZTP
 
@@ -49,9 +51,48 @@ When a device fails to provision, the first step is to look at the DHCP and ZTP 
 
 Config Manager streams DHCP (Kea), ZTP, and render-service logs to whatever observability stack the deployment uses. Filtering by MAC address, IP address, or device UUID is the fastest way to isolate a single device's activity.
 
+Start from the Config Manager overview dashboard for the site and deployment under investigation:
+
+1. Open the **DHCP logs** panel and switch to the log explorer before filtering DHCP traffic. The dashboard panel itself is useful for a quick health check, but the explorer is better for following a single device and widening the time range.
+1. Open the **ZTP logs** panel and switch to the log explorer before filtering by device UUID.
+1. Use the **DHCP lease activity** dashboard in Config Manager to inspect active leases, reservations, and pools, or to clear a stale lease. This dashboard shows current Kea state; the log explorer shows the packet history.
+
+Do not use a generic application-log panel to decide that DHCP traffic is absent. Select the Kea container logs and confirm that the dashboard is scoped to the correct cluster and Config Manager namespace.
+
 Deployments without an aggregated log backend can read the same logs directly with `kubectl logs`. Each section below shows both the aggregated-query form and the `kubectl` equivalent.
 
-### Filtering DHCP logs by MAC address
+### Follow one device through the provisioning path
+
+Use this sequence to avoid mixing results from nearby devices:
+
+| Check | Evidence | Conclusion |
+| :---- | :------- | :--------- |
+| Device sends a discover | A console-side packet capture shows `DHCPDISCOVER` | The device is trying; this does not prove that Kea received it. |
+| Kea receives the discover | Kea logs contain `DHCP4_PACKET_RECEIVED` for the same transaction ID, MAC, client ID, or relay address | The relay and routing path to Config Manager works. |
+| Kea sends an offer | Kea logs contain `DHCP4_PACKET_SEND` and `DHCPOFFER` for the same transaction | Kea selected a subnet and an address. Confirm that the return path reaches the device. |
+| Device installs the lease | The expected interface has a dynamic address and remaining lease lifetime | DHCP completed. Move to ZTP; repeated DHCP-client restart messages are not the root cause. |
+| Device downloads a boot script | The NOS provisioning log contains a recent script-start entry. On Cumulus Linux, this is `/var/log/autoprovision` with `ztp starting script`. | DHCP supplied usable ZTP options and the device started the script. |
+| ZTP serves the device | ZTP service logs contain the Nautobot device UUID | Follow the last endpoint and HTTP status to find the failed stage. |
+| Provisioning completes | ZTP logs show the device calling the `provisioned` endpoint and Nautobot shows **Provisioned** | ZTP completed. If the intended config is still wrong, inspect render logs and the current rendered configuration. |
+
+Record the device name, device UUID, serial number, relevant MAC, expected subnet, expected leased address, and DHCP transaction ID before searching. A client ID in Kea logs is commonly a leading type byte followed by the serial number encoded as colon-separated hexadecimal; decode it before attributing a lease to a device.
+
+### Confirm the expected DHCP model
+
+The interface used to provision determines what should exist in Kea:
+
+| Provisioning path | Nautobot model | Best search keys |
+| :---------------- | :------------- | :--------------- |
+| Device management interface such as `eth0` | The containing prefix has `dhcp-subnet`; the device IP has `dhcp-reserve` and is assigned to the correct interface. The reservation matches a MAC or client ID. | Management MAC, serial/client ID, reserved IP |
+| Front-panel point-to-point management link | The /31 prefix has `dhcp-subnet`; the device-side address has `dhcp-pool`. The resulting pool contains one address and is not tied to a client ID. | /31 network address, relay/source address, pool IP |
+
+Do not add `dhcp-reserve` to a pool-of-one address to bind it to a switch. On a front-panel /31, physical topology and the relay path select the pool. A switch on the wrong link can therefore consume another switch's lease even when the Nautobot pool data is correct.
+
+Use the DHCP lease activity dashboard to confirm that the expected subnet and either its reservation or pool are present. If they are absent after the configuration refresh interval, correct the Nautobot tags and assignments first. If they are present, continue with packet and lease troubleshooting instead of repeatedly toggling tags.
+
+For a lower-level check, use the DHCP API's `/config` endpoint from the deployment's API documentation and search the returned Kea configuration for the exact subnet. A subnet that is missing entirely points to the prefix or `dhcp-subnet` tag. A subnet with no expected pool or reservation points to the IP assignment or tag. If the complete subnet data is present, move on to active leases and packet flow.
+
+### Filtering DHCP logs
 
 In your log explorer, filter the Kea container logs in the Config Manager namespace and search for the device's eth0 MAC address. A typical aggregated-log query:
 
@@ -71,12 +112,16 @@ kubectl -n <config-manager-namespace> logs \
 
 - **By MAC address** (lowercase) — for devices that provision over the management interface, the eth0 MAC is the right identifier.
 - **By uplink network address** — for management-network switches that provision via Front Panel Ports (FPP) using a /31 DHCP pool of size 1, the MAC is not known ahead of time. Instead query by the /31 prefix; for example, an uplink of `10.0.0.1/31` is searchable as `10.0.0.0/31`.
-- **By serial number (hex)** — Cumulus 5.10+ switches send the serial number as DHCP client ID. Convert the serial to colon-separated hex and query for it:
+- **By serial number (hex; Cumulus Linux 5.10+)** — these switches send the serial number as DHCP client ID. Convert the serial to colon-separated hex and query for it:
 
   ```bash
-  python3 -c "import sys; print(':'.join(f'{ord(c):02x}' for c in sys.argv[1]))" "MT2519J002PD"
+  uv run python -c "import sys; print(':'.join(f'{ord(c):02x}' for c in sys.argv[1]))" "MT2519J002PD"
   # 4d:54:32:35:31:39:4a:30:30:32:50:44
   ```
+
+Keep the DHCP transaction ID (`tid`) in the result when following a discover through an offer and acknowledgement. A MAC or IP search can return packets from different devices, especially after cabling changes. Compare the decoded client ID, observed interface MAC, expected device serial, and transaction ID before concluding which device holds a lease.
+
+For a front-panel /31, Kea may log the relay-side or peer address rather than the one-address pool value you expect the device to receive. Search for both addresses in the /31 and the complete prefix.
 
 ### ZTP logs by device ID
 
@@ -116,6 +161,20 @@ Renders are triggered by Nautobot change events or by template version changes, 
 
 ## Common errors and troubleshooting
 
+### Fast triage
+
+Work from the first missing signal rather than resetting the device immediately:
+
+| Last confirmed signal | Investigate next |
+| :-------------------- | :--------------- |
+| No discover on the device | Device interface state, DHCP client state, and factory/ZTP state |
+| Discover on device, nothing in Kea logs | VLAN, relay configuration, routing, firewall rules, and whether the selected log dashboard targets the right Config Manager instance |
+| Discover in Kea, no offer | Generated subnet/reservation/pool data, Kea allocation messages, and active leases |
+| Offer in Kea, no address on device | Return routing, relay behavior, packet loss, and device interface selection |
+| Address on device, no NOS provisioning log | DHCP ZTP options and HTTP/HTTPS reachability to the ZTP service |
+| Recent NOS provisioning failure | The final command and HTTP status in the vendor-specific provisioning log, then the matching ZTP service log by device UUID |
+| ZTP succeeds, intended config absent | Render status, rendered configuration, and render-service logs |
+
 ### DHCP errors
 
 **`No pools were available for the address allocation`** *(or the device received a dynamic IP from a pool instead of a static reservation)*
@@ -136,7 +195,9 @@ This occurs for /31 allocations on the management network when ZTP is not enable
 **No DHCP requests incoming for a specific MAC**
 
 - The device may not be cabled to the upstream router. Check interface status on the upstream port.
-- The MAC supplied by the vendor or DC Ops may be incorrect. Check LLDP data on the upstream switch: if the serial matches but the MAC does not, update the MAC in Nautobot.
+- The MAC supplied by the vendor or on-site operations team may be incorrect. Check LLDP data on the upstream switch: if the serial matches but the MAC does not, update the MAC in Nautobot.
+
+If the device provisions over a front-panel /31, searching only for its management MAC is insufficient. Search the Kea logs for the observed front-panel MAC, both addresses in the /31, and the serial/client ID. Confirm the actual interface MAC on the device rather than relying only on inventory data.
 
 **No DHCP requests incoming for any device**
 
@@ -154,6 +215,19 @@ sudo tcpdump -i any -nn 'port 67 or port 68'
 
 You should see a `BOOTP/DHCP` `Request from` the device's MAC, followed by a relayed copy whose source becomes the relay agent's IP and whose destination is the Config Manager DHCP VIP. If the discover appears on the device but never reaches the relay (or never leaves the relay), the gap identifies which hop is dropping the traffic.
 
+If the device capture shows discovers but the correctly scoped Kea log explorer has no matching MAC, client ID, or relay address, the request did not reach Kea. Investigate the network path; changing Nautobot DHCP tags cannot repair an absent packet.
+
+**Kea receives a discover but does not offer an address**
+
+1. In the DHCP lease activity dashboard, confirm the exact subnet and expected reservation or pool exist.
+1. For an `eth0` reservation, confirm the reservation identifier matches the request's MAC or decoded client ID.
+1. For a front-panel /31, confirm there is a one-address pool. The pool is not expected to contain a client ID.
+1. Inspect active leases for the expected address. After miscabling, another interface or device may still hold the lease for the configured valid lifetime.
+1. Search historical Kea logs for both addresses in the subnet, the offered address, and `DHCP4_LEASE_ALLOC`. Decode the client ID and compare it with the serial on the physical device.
+1. If the lease holder is stale and the cabling is now correct, clear that address from the DHCP lease activity dashboard. Otherwise wait for expiry. Power-cycle or restart ZTP on the intended device afterward if it stopped retrying.
+
+Clearing a lease before correcting the cabling lets the wrong device acquire it again. Confirm LLDP and the local interface MAC first.
+
 For local reproduction of DHCP config generation issues, run the DHCP config-gen tooling against a copy of the Nautobot data — see the DHCP service README for the procedure.
 
 ### ZTP errors
@@ -164,19 +238,30 @@ A transient backend issue, most often a Nautobot timeout. Engage the platform te
 
 **HTTP 400 on `POST /v1/device/<device-uuid>/validate_serial`**
 
-The device's reported serial number does not match the serial Nautobot expects for this configuration. This almost always indicates miscabling — the device is trying to claim a /31 that does not belong to it. Check LLDP on the upstream switch to identify the actual neighbor; for example, on Cumulus:
+The device's reported serial number does not match the serial Nautobot expects for this configuration. This usually indicates miscabling or incorrect inventory data: the device may be trying to claim a /31 that belongs to another device, or the recorded serial may contain an error. Serial comparison is case-insensitive, so letter case alone is not a mismatch. Compare the complete serial reported by the device with Nautobot and the physical chassis label, then check LLDP on the upstream switch to identify the actual neighbor. For example, on Cumulus:
 
 ```bash
 nv show interface <port> lldp nei cumulus
 ```
 
+On the device, use `nv show platform` to read the serial and interface commands such as `ip link show <interface>` to read the MAC. Do not infer identity from a DHCP pool address alone.
+
 **HTTP 403 unauthorized**
 
 The source IP of the request does not match any IP Nautobot has for the device. Either Nautobot data is wrong, the DHCP-generated pool is wrong, or — more commonly — the device is miscabled and is sending from an IP that belongs to a different device. Check Nautobot IPs, the rendered DHCP config, and LLDP on the upstream switch.
 
-**Stuck requesting `startup.yaml` and not progressing**
+**Cumulus Linux: stuck requesting `startup.yaml` and not progressing**
 
 The rendered configuration is failing to apply or has broken connectivity back to Config Manager. Access the switch via [console or upstream SSH](#options-for-logging-into-a-stuck-device) and inspect `/var/log/autoprovision`.
+
+**Cumulus Linux: console reports that ZTP is in progress for hours**
+
+The banner or `nv show system ztp` state says that ZTP is enabled or incomplete; it does not prove that attempts are still occurring. Check the newest timestamp in `/var/log/autoprovision` and the ZTP service logs for the device UUID.
+
+- If `/var/log/autoprovision` does not exist, return to DHCP troubleshooting. The device has not received and started a boot script.
+- If the file exists, read the final command and error rather than only the final line. A recent `ztp starting script` entry proves that DHCP and boot-script delivery worked.
+- If the last attempt predates a cabling, routing, data, or firewall fix, restart ZTP using the supported device command or power-cycle the switch. On-site operators should power-cycle affected devices after correcting a provisioning-path cabling fault when attempts have stopped.
+- Messages such as `Restarting dhclients`, `Execution lock acquired`, and `Execution lock released` only describe ZTP service mechanics. They do not show that Kea offered a lease or explain why provisioning stalled.
 
 **Device received a DHCP lease but no ZTP traffic follows**
 
@@ -184,7 +269,7 @@ The rendered configuration is failing to apply or has broken connectivity back t
 - Routing between the device and Config Manager may be broken. Access via console or upstream SSH to investigate.
 - The device may be on Cumulus pre-5.x, which cannot ZTP. Upgrade and retry.
 
-  From the Cumulus shell, you can verify that the ZTP URL is reachable by fetching the boot script directly. On a non-management switch, run the request in the management VRF so it leaves the switch over eth0:
+  From a Cumulus Linux shell, you can verify that the ZTP URL is reachable by fetching the boot script directly. On a non-management switch, run the request in the management VRF so it leaves the switch over eth0:
 
   ```bash
   sudo ip vrf exec mgmt curl -v http://<ztp-server>/v1/device/<device-uuid>/boot-script
@@ -209,7 +294,7 @@ After committing a template change, follow the template repo's release process a
 
 ## Device swaps
 
-When two devices end up swapped in the inventory system — for example, racked in each other's positions — it is usually faster to swap them in Nautobot and let Config Manager swap their configurations than to ask DC Ops to re-rack or re-cable.
+When two devices end up swapped in the inventory system — for example, racked in each other's positions — it is usually faster to swap them in Nautobot and let Config Manager swap their configurations than to ask the on-site operations team to re-rack or re-cable.
 
 To perform the swap:
 
@@ -220,7 +305,7 @@ To perform the swap:
    **Do not rename the devices in Nautobot** — renaming forces you to rebuild all of the cabling relationships.
    </Warning>
 
-1. On the console for both switches, reset the DHCP/ZTP state and reboot:
+1. On the console for both switches, reset the DHCP/ZTP state and reboot. The following commands are for Cumulus Linux; use the vendor's equivalent procedure for another NOS:
 
    ```bash
    nv unset interface eth0
@@ -234,7 +319,34 @@ To perform the swap:
 
 After reboot, each switch will ZTP again and pick up the configuration that now corresponds to its physical position.
 
-## Rerunning ZTP on a live device
+## Cumulus Linux device checks and recovery
+
+The commands and paths in this section apply to Cumulus Linux. For another NOS, use the vendor's commands for inspecting platform identity, DHCP state, provisioning state, and provisioning logs. Keep using the vendor-neutral Kea, ZTP service, render service, and DHCP lease activity checks from the earlier sections.
+
+### Inspect device identity, DHCP, and ZTP
+
+From the console, collect the following before changing state:
+
+```bash
+# Chassis serial number and platform identity
+nv show platform
+
+# Neighbor identity and physical cabling
+nv show interface <port> lldp
+
+# Address, MAC, and remaining DHCP lease lifetime
+ip address show <interface>
+
+# ZTP state; this does not prove that attempts are current
+nv show system ztp
+
+# Actual ZTP script attempts and failures
+sudo tail -100 /var/log/autoprovision
+```
+
+Match the observed serial, interface MAC, neighbor, address, and log timestamps to the same Nautobot device before taking recovery action.
+
+### Rerunning ZTP on a live device
 
 The Cumulus user account can occasionally be dropped during ZTP — for example, if ZTP was triggered via `ztp -r` (which does not pass through DHCP) and the user-creation step failed. This leaves the switch with no sudo-capable account.
 
@@ -246,7 +358,7 @@ nv action run system ztp
 
 This re-executes the boot script — including the cumulus-user creation steps — and restores the cumulus user with the latest password from the secrets store. If the device is already on the correct firmware version, this will not trigger a reboot.
 
-## Options for logging into a stuck device
+### Options for logging into a stuck device
 
 If a device has not attempted ZTP yet, log in with the factory default credentials (`cumulus` / `cumulus`) and set the password to the current site root password from your secrets store.
 

--- a/docs/user-guides/new-site-deployment/index.mdx
+++ b/docs/user-guides/new-site-deployment/index.mdx
@@ -115,7 +115,7 @@ kubectl -n <config-manager-namespace> logs \
 - **By serial number (hex; Cumulus Linux 5.10+)** — these switches send the serial number as DHCP client ID. Convert the serial to colon-separated hex and query for it:
 
   ```bash
-  uv run python -c "import sys; print(':'.join(f'{ord(c):02x}' for c in sys.argv[1]))" "MT2519J002PD"
+  python3 -c "import sys; print(':'.join(f'{ord(c):02x}' for c in sys.argv[1]))" "MT2519J002PD"
   # 4d:54:32:35:31:39:4a:30:30:32:50:44
   ```
 
@@ -241,7 +241,7 @@ A transient backend issue, most often a Nautobot timeout. Engage the platform te
 The device's reported serial number does not match the serial Nautobot expects for this configuration. This usually indicates miscabling or incorrect inventory data: the device may be trying to claim a /31 that belongs to another device, or the recorded serial may contain an error. Serial comparison is case-insensitive, so letter case alone is not a mismatch. Compare the complete serial reported by the device with Nautobot and the physical chassis label, then check LLDP on the upstream switch to identify the actual neighbor. For example, on Cumulus:
 
 ```bash
-nv show interface <port> lldp nei cumulus
+nv show interface <port> lldp neighbor
 ```
 
 On the device, use `nv show platform` to read the serial and interface commands such as `ip link show <interface>` to read the MAC. Do not infer identity from a DHCP pool address alone.
@@ -305,15 +305,19 @@ To perform the swap:
    **Do not rename the devices in Nautobot** — renaming forces you to rebuild all of the cabling relationships.
    </Warning>
 
-1. On the console for both switches, reset the DHCP/ZTP state and reboot. The following commands are for Cumulus Linux; use the vendor's equivalent procedure for another NOS:
+1. On the console for both switches, reset the DHCP configuration. The following commands are for Cumulus Linux; use the vendor's equivalent procedure for another NOS:
 
    ```bash
    nv unset interface eth0
    nv set interface eth0 ip address dhcp
    nv config apply
    nv config save
-   sudo ztp -X
-   nv action enable system ztp force
+   ```
+
+1. Reset ZTP to its original state and reboot. The documented reset command applies to Cumulus Linux 5.10 and later:
+
+   ```bash
+   sudo ztp -R
    sudo reboot
    ```
 


### PR DESCRIPTION
## Description

* Improve detail on the cable validation user guide
* Improve troubleshooting information on the site bring-up guide

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded cable-validation guidance with validation modes, tag handling, evaluation order, MAC-based checks, and troubleshooting for link-state and ignored interfaces.
  * Enhanced new-site deployment guidance with DHCP/ZTP monitoring, device identity checks, lease troubleshooting, log filtering, recovery procedures, and cabling diagnostics.
  * Added vendor-neutral workflows and clarified platform-specific commands and terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->