### PR TITLE
fix(workflow): accept valid device UUIDs and ensure validation failures are surfaced in UI

### DIFF
--- a/src/nv_config_manager/temporal/common/workflow_references.py
+++ b/src/nv_config_manager/temporal/common/workflow_references.py
@@ -39,20 +39,18 @@ class WorkflowReference:
 
 
 def validate_device_uuid(value: Any) -> str:
-    """Validate a device UUIDv4 while preserving the workflow's string input."""
+    """Validate a device UUID while preserving the workflow's string input."""
     if not isinstance(value, str):
-        raise ValueError("Device identifier must be a UUID v4")
+        raise ValueError("Device identifier must be a valid UUID")
     try:
-        parsed_value = UUID(value)
+        UUID(value)
     except ValueError as error:
-        raise ValueError("Device identifier must be a UUID v4") from error
-    if parsed_value.version != 4:
-        raise ValueError("Device identifier must be a UUID v4")
+        raise ValueError("Device identifier must be a valid UUID") from error
     return value
 
 
 def validate_device_value(value: Any) -> Any:
-    """Reject preloaded API objects and validate a string device UUIDv4."""
+    """Reject preloaded API objects and validate a string device UUID."""
     if not isinstance(value, str):
         raise ValueError("Preloaded device objects are not accepted by the Workflow API")
     validate_device_uuid(value)

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -343,9 +343,9 @@ async def test_start_workflow(mock_rbac_config, mock_uuid, mock_connect, mock_ca
     assert exc_info.value.status_code == 422
     mock_connect.return_value.start_workflow.assert_not_called()
 
-    # Device identifiers must be UUIDv4 values before Nautobot is queried.
+    # Device identifiers must be valid UUID values before Nautobot is queried.
     mock_connect.reset_mock()
-    with pytest.raises(HTTPException, match="Device identifier must be a UUID v4") as exc_info:
+    with pytest.raises(HTTPException, match="Device identifier must be a valid UUID") as exc_info:
         await start_workflow(request, DeployWorkflow, DeployInput(device_id="LEAF01"))
     assert exc_info.value.status_code == 422
     mock_connect.return_value.start_workflow.assert_not_called()

--- a/src/tests/temporal/api/test_workflow_submission.py
+++ b/src/tests/temporal/api/test_workflow_submission.py
@@ -44,6 +44,7 @@ from nv_config_manager.temporal.ngc.workflows.multi_deploy import MultiDeployInp
 from nv_config_manager.temporal.ngc.workflows.spx_overlay import SpXOverlayAssignmentInput
 
 DEVICE_ID = "910b85f8-e83c-48ad-9bbd-12b15e97a2d4"
+DEVICE_ID_V5 = "7a8ca199-040a-5994-916f-c6de90cc9959"
 OTHER_DEVICE_ID = "83db83ba-f626-4566-9f93-8bd0ccbe7182"
 LOCATION_ID = "b6f4972a-c6ab-4be1-96ac-72f4efc4f328"
 
@@ -128,6 +129,32 @@ async def test_device_references_are_batched_and_enriched_from_same_query() -> N
         DEVICE_ID_SEARCH_ATTRIBUTE: [DEVICE_ID],
         DEVICE_NAME_SEARCH_ATTRIBUTE: ["LEAF01"],
     }
+
+
+@pytest.mark.asyncio
+async def test_uuid_v5_device_reference_is_accepted() -> None:
+    """Nautobot device IDs may be deterministic UUIDv5 values."""
+    client = _client()
+    client.get_devices.return_value = [
+        {
+            "id": DEVICE_ID_V5,
+            "name": "UFM01",
+            "role": None,
+            "platform": {"name": "UFM"},
+            "location": None,
+        }
+    ]
+    body = DeviceCollectionInput(primary_device=DEVICE_ID_V5, related_devices=[])
+
+    with patch(
+        "nv_config_manager.temporal.api.workflow_submission.NautobotClient",
+        return_value=client,
+    ):
+        attributes = await resolve_workflow_references(body)
+
+    client.get_devices.assert_awaited_once_with(ANY, device_ids=[DEVICE_ID_V5])
+    assert attributes[DEVICE_ID_SEARCH_ATTRIBUTE] == [DEVICE_ID_V5]
+    assert attributes[DEVICE_NAME_SEARCH_ATTRIBUTE] == ["UFM01"]
 
 
 @pytest.mark.asyncio
@@ -221,7 +248,7 @@ async def test_optional_device_reference_is_resolved() -> None:
 @pytest.mark.parametrize(
     ("body", "message"),
     [
-        (DeviceCollectionInput(primary_device="LEAF01", related_devices=[]), "UUID v4"),
+        (DeviceCollectionInput(primary_device="LEAF01", related_devices=[]), "valid UUID"),
         (LocationAndDeviceInput(location_scope=" ", target_device=DEVICE_ID), "must not be empty"),
     ],
 )

--- a/ui/src/app/workflows/backupworkflow/form/page.tsx
+++ b/ui/src/app/workflows/backupworkflow/form/page.tsx
@@ -37,12 +37,13 @@ const BackupWorkflowForm = () => {
       workflow_id: "", //NOTE: not relevant for trigger type API
       intended_config_commit_id: "", //NOTE: not relevant for trigger type API
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/app/workflows/connectedhostmetadataworkflow/form/page.tsx
+++ b/ui/src/app/workflows/connectedhostmetadataworkflow/form/page.tsx
@@ -32,12 +32,13 @@ const ConnectedHostMetadataWorkflowForm = () => {
     const params: ConnectedDeviceMetadataWorkflowInput = {
       device_id: data.device,
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `Failed to create workflow: ${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/app/workflows/deployworkflow/form/page.tsx
+++ b/ui/src/app/workflows/deployworkflow/form/page.tsx
@@ -33,12 +33,13 @@ const ConfigDeployWorkflowForm = () => {
       device_id: data.device,
       commit_confirm: data.commit_confirm ?? true,
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `Failed to create workflow: ${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/app/workflows/devicecablevalidationworkflow/form/page.tsx
+++ b/ui/src/app/workflows/devicecablevalidationworkflow/form/page.tsx
@@ -32,12 +32,13 @@ const CableValidationWorkflowForm = () => {
     const params: DeviceCableValidationWorkflowInput = {
       device_id: data.device,
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `Failed to create workflow: ${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/app/workflows/infinibandgetunhealthyportsworkflow/form/page.tsx
+++ b/ui/src/app/workflows/infinibandgetunhealthyportsworkflow/form/page.tsx
@@ -32,12 +32,13 @@ const IBValidationWorkflowForm = () => {
     const params: IBValidationWorkflowInput = {
       device_id: data.device,
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `Failed to create workflow: ${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/app/workflows/infinibandmlnxosupgradeworkflow/form/page.tsx
+++ b/ui/src/app/workflows/infinibandmlnxosupgradeworkflow/form/page.tsx
@@ -32,12 +32,13 @@ const IBOSUpgradeWorkflowForm = () => {
     const params: IBOSUpgradeWorkflowInput = {
       device_id: data.device,
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `Failed to create workflow: ${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/app/workflows/reprovisionworkflow/form/page.tsx
+++ b/ui/src/app/workflows/reprovisionworkflow/form/page.tsx
@@ -32,12 +32,13 @@ const ReprovisionWorkflowForm = () => {
     const params: ReprovisionWorkflowInput = {
       device_id: data.device,
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/app/workflows/switchosupgradeworkflow/form/page.tsx
+++ b/ui/src/app/workflows/switchosupgradeworkflow/form/page.tsx
@@ -32,12 +32,13 @@ const SwitchOSUpgradeWorkflowForm = () => {
     const params: SwitchOsUpgradeWorkflowInput = {
       device_id: data.device,
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/app/workflows/tenantdeployworkflow/form/page.tsx
+++ b/ui/src/app/workflows/tenantdeployworkflow/form/page.tsx
@@ -33,12 +33,13 @@ const TenantDeployWorkflowForm = () => {
     const params: TenantDeployWorkflowInput = {
       device: data.device,
     };
-    startWorkflow(endpoint, params).catch((error) => {
+    return startWorkflow(endpoint, params).catch((error) => {
       toast({
         variant: "destructive",
         title: "Workflow Failed",
         description: `Failed to create workflow: ${error}`,
       });
+      throw error;
     });
   };
 

--- a/ui/src/components/forms/workflow.tsx
+++ b/ui/src/components/forms/workflow.tsx
@@ -19,7 +19,7 @@
 import * as React from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSearchParams } from "next/navigation";
-import { SubmitHandler, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -48,7 +48,7 @@ export type DeviceWorkflowFormSchema = z.infer<typeof deviceWorkflowFormSchema>;
 
 type WorkflowFormProps = {
   title: string;
-  onSubmit: SubmitHandler<DeviceWorkflowFormSchema>;
+  onSubmit: (data: DeviceWorkflowFormSchema) => Promise<void>;
   deviceFilterParams?: string[][];
   destructiveWarning?: string;
   /** When true, show the commit-confirm checkbox (for deploy workflow) */

--- a/ui/src/lib/utils.tsx
+++ b/ui/src/lib/utils.tsx
@@ -168,8 +168,9 @@ export const startWorkflow = async (endpoint: string, params: object) => {
   }).then(async (response) => {
     if (!response.ok) {
       const result = await response.json();
-      if (result.error) {
-        throw new Error(String(result.error));
+      const message = result.error ?? result.detail;
+      if (message) {
+        throw new Error(String(message));
       } else {
         throw new Error("Failed to submit workflow.");
       }

--- a/ui/tests/e2e/ibGetUnhealthyPortsForm.spec.ts
+++ b/ui/tests/e2e/ibGetUnhealthyPortsForm.spec.ts
@@ -362,6 +362,44 @@ test.describe("IB Validation Form - Additional Tests", () => {
     ).toBeDisabled();
   });
 
+  test("shows API validation details and allows resubmission", async ({ page }) => {
+    let submissionCount = 0;
+    await page.route(
+      "**/v1/workflow/ngc/infiniband_get_unhealthy_ports",
+      async (route) => {
+        submissionCount += 1;
+        await route.fulfill({
+          status: 422,
+          json: { detail: "Device identifier must be a valid UUID" },
+        });
+      }
+    );
+
+    const site = SITES_LIST.pdx01;
+    const ufmDevice = DEVICES_LIST[site].find(
+      (device) => device.platform === "UFM"
+    );
+    expect(ufmDevice).toBeDefined();
+
+    await page.getByRole("button", { name: "Site" }).click();
+    await page.getByRole("dialog").getByText(site).click();
+    await page.getByRole("button", { name: "Device" }).click();
+    await page.getByRole("dialog").getByText(ufmDevice!.name).click();
+
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    await expect(
+      page.getByText(
+        "Failed to create workflow: Error: Device identifier must be a valid UUID",
+        { exact: true }
+      )
+    ).toBeVisible({ timeout: TEST_TIMEOUT });
+    await expect(page.getByRole("button", { name: "Submit" })).toBeEnabled();
+
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expect.poll(() => submissionCount).toBe(2);
+  });
+
   test("displays forbidden error notification when submitting with forbidden values", async ({
     page,
   }) => {

--- a/ui/tests/e2e/shared/workflowFormTests.ts
+++ b/ui/tests/e2e/shared/workflowFormTests.ts
@@ -313,6 +313,7 @@ export const runWorkflowFormTests = (config: WorkflowTestConfig) => {
 
       await expect(errorTitle).toBeVisible({ timeout: TEST_TIMEOUT });
       await expect(errorMessage).toBeVisible({ timeout: TEST_TIMEOUT });
+      await expect(page.getByRole("button", { name: "Submit" })).toBeEnabled();
     });
   });
 };


### PR DESCRIPTION
## Description

Accept any valid UUID version for input validation.

When workflow input validation fails, ensure the form can be resubmitted without requiring a page reload.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`0da4cfa`](https://github.com/NVIDIA/nv-config-manager/commit/0da4cfaaf7677777ca39c1c3d7c70bbe66b46cc9) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30955608056).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Device references now accept any valid UUID format, including UUIDv5 values.
  - Workflow errors are surfaced more reliably to calling screens.

- **Bug Fixes**
  - Improved workflow failure messages using detailed validation information when available.
  - Submit buttons are re-enabled after failed submissions, allowing users to retry.
  - UUID validation messages now accurately describe accepted formats.

- **Tests**
  - Added coverage for UUIDv5 references, validation errors, retry behavior, and enriched workflow search attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->