### PR TITLE
fix(build): Kea image build error handling

### DIFF
--- a/build/kea.Dockerfile
+++ b/build/kea.Dockerfile
@@ -32,9 +32,9 @@ RUN set -eux; \
         isc-kea-hooks && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    # Create kea user if it doesn't exist
-    groupadd -r kea 2>/dev/null || true && \
-    useradd -r -g kea kea 2>/dev/null || true
+    # Create the kea group and user if they don't exist
+    { getent group kea >/dev/null || groupadd -r kea; } && \
+    { id -u kea >/dev/null 2>&1 || useradd -r -g kea kea; }
 
 # Install Stork agent (pinned to 2.4.x for Go dependency CVE fixes)
 COPY build/setup.stork.deb.sh /tmp/setup.stork.deb.sh


### PR DESCRIPTION
## Description
Fix the Kea image installation layer so apt configuration and package installation failures are no longer silently ignored.

## Validation

```bash
docker build --no-cache \
  --provenance=false \
  --progress=plain \
  --build-context scripts=build/ \
  -t nv-config-manager-kea:local \
  -f build/kea.Dockerfile .
```

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`e502850`](https://github.com/NVIDIA/nv-config-manager/commit/e5028503508fff45220c4b15daa69a45173c088e) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30956508228).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container setup to safely handle environments where the `kea` user or group already exists.
  * Prevented setup errors during image creation in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->