### PR TITLE
fix(workflows): bound workflow list queries

### DIFF
--- a/src/nv_config_manager/temporal/api/workflow_v1.py
+++ b/src/nv_config_manager/temporal/api/workflow_v1.py
@@ -84,6 +84,7 @@ router = APIRouter(prefix="/workflow", tags=["workflow"])
 
 _VISIBILITY_SAFE_VALUE = re.compile(r"^[\w.@:/ -]+$")
 _WORKFLOW_LIST_QUERY_CONCURRENCY = 25
+_WORKFLOW_LIST_QUERY_TIMEOUT_SECONDS = 2
 _WORKFLOW_STAGE_QUERY_CACHE_NAMES = ("pending_approval", "compressed_stages")
 _PENDING_APPROVAL_STATUS_VALUES = {
     StateEnum.PENDING_APPROVAL.value,
@@ -273,6 +274,7 @@ class WorkflowSummaryResponse(WorkflowResponse):
         handle: WorkflowHandle,
         description: WorkflowExecutionDescription,
         queries: list[str],
+        query_timeout_seconds: float | None = None,
     ) -> dict[str, Any]:
         is_active = description.status in WorkflowSummaryResponse._ACTIVE_WORKFLOW_STATUSES
         cache = RedisClient.from_config(load_config())
@@ -286,7 +288,23 @@ class WorkflowSummaryResponse(WorkflowResponse):
                         results[query] = data
                         continue
 
-                data = await handle.query(query)
+                if query_timeout_seconds is None:
+                    data = await handle.query(query)
+                else:
+                    try:
+                        async with asyncio.timeout(query_timeout_seconds):
+                            data = await handle.query(query)
+                    except TimeoutError:
+                        logger.warning(
+                            "Workflow %s of type %s timed out after %s seconds running the %s "
+                            "query while building a list response.",
+                            handle.id,
+                            description.workflow_type,
+                            query_timeout_seconds,
+                            query,
+                        )
+                        results[query] = None
+                        continue
 
                 if WorkflowSummaryResponse._should_cache(query, data, is_active):
                     await cache.cache_query(handle.id, query, data)
@@ -324,7 +342,10 @@ class WorkflowSummaryResponse(WorkflowResponse):
             )
             queries = ["input"] if pending_approval is not None else ["pending_approval", "input"]
             query_results = await WorkflowSummaryResponse._execute_queries(
-                handle, description, queries
+                handle,
+                description,
+                queries,
+                query_timeout_seconds=_WORKFLOW_LIST_QUERY_TIMEOUT_SECONDS,
             )
             workflow_input = query_results.get("input")
             if pending_approval is None:

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 from configparser import ConfigParser
 from datetime import datetime
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -928,6 +929,44 @@ async def test_active_workflow_query_miss_uses_durable_cache(mock_redis, mock_lo
     assert result == {"pending_approval": True, "input": {"user": "live"}}
     cache.cache_query.assert_any_await("active-workflow", "pending_approval", True)
     cache.cache_query.assert_any_await("active-workflow", "input", {"user": "live"})
+    mock_redis.from_config.assert_called_once_with(mock_load_config.return_value)
+
+
+@pytest.mark.asyncio
+@patch(
+    "nv_config_manager.temporal.api.workflow_v1._WORKFLOW_LIST_QUERY_TIMEOUT_SECONDS",
+    0.01,
+)
+@patch("nv_config_manager.temporal.api.workflow_v1.load_config")
+@patch("nv_config_manager.temporal.api.workflow_v1.RedisClient")
+async def test_active_workflow_query_timeout_does_not_block_summary(mock_redis, mock_load_config):
+    """A workerless workflow cannot block list enrichment or cached query data."""
+    cache = mock_redis.from_config.return_value
+    cache.get_cached_query = AsyncMock(side_effect=[None, {"user": "cached"}])
+    cache.cache_query = AsyncMock()
+
+    async def workerless_query(_query: str):
+        await asyncio.Event().wait()
+
+    handle = MagicMock()
+    handle.id = "workerless-workflow"
+    handle.query = AsyncMock(side_effect=workerless_query)
+
+    description = MagicMock()
+    description.status = WorkflowExecutionStatus.RUNNING
+    description.workflow_type = "UnavailableWorkflow"
+    description.search_attributes = {"User": ["test"]}
+    description.start_time = datetime.fromisoformat("1970-01-01T00:00:00+00:00")
+    description.close_time = None
+    handle.describe = AsyncMock(return_value=description)
+
+    result = await asyncio.wait_for(WorkflowSummaryResponse.from_handle(handle), timeout=0.2)
+
+    assert result.id == "workerless-workflow"
+    assert result.pending_approval is False
+    assert result.workflow_input == {"user": "cached"}
+    handle.query.assert_awaited_once_with("pending_approval")
+    cache.cache_query.assert_not_awaited()
     mock_redis.from_config.assert_called_once_with(mock_load_config.return_value)
 
 


### PR DESCRIPTION
## Description

Apply a timeout to live workflow queries used for list summaries so workerless executions cannot block the entire response.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`d49ff56`](https://github.com/NVIDIA/nv-config-manager/commit/d49ff5604af1bb085eab188e6f97227112482254) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/30958859782).
<!-- kind-integration-result:end -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow summaries so unresponsive queries time out instead of blocking the entire summary.
  * Workflow lists now continue loading when individual queries fail or exceed the timeout.
  * Cached workflow information remains available, with pending approvals safely defaulting when query results are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->