### PR TITLE
fix(workflows): terminal execution statuses should take precedence

### DIFF
--- a/src/nv_config_manager/temporal/api/workflow_v1.py
+++ b/src/nv_config_manager/temporal/api/workflow_v1.py
@@ -364,6 +364,14 @@ class WorkflowSummaryResponse(WorkflowResponse):
             failed_stage = False
             workflow_input = None
 
+        # Stage-state search attributes record the last state observed by the
+        # workflow. Temporal termination does not give workflow code a chance
+        # to clear them, so they must not describe a closed execution as
+        # currently awaiting approval.
+        pending_approval = description.status == WorkflowExecutionStatus.RUNNING and bool(
+            pending_approval
+        )
+
         try:
             user = cast(str, description.search_attributes[USER_SEARCH_ATTRIBUTE][0])
         except (KeyError, IndexError):
@@ -451,6 +459,12 @@ class WorkflowDetailResponse(WorkflowSummaryResponse):
             failed_stage = False
             workflow_input = None
             stages = []
+
+        # A closed execution cannot still be waiting for an approval, even if
+        # its final indexed stage state was PENDING_APPROVAL.
+        pending_approval = description.status == WorkflowExecutionStatus.RUNNING and bool(
+            pending_approval
+        )
 
         result = None
         if description.status == WorkflowExecutionStatus.COMPLETED:

--- a/src/tests/temporal/api/test_main.py
+++ b/src/tests/temporal/api/test_main.py
@@ -27,6 +27,7 @@ from temporalio.client import WorkflowExecutionStatus, WorkflowHandle
 from nv_config_manager.temporal.api.links import temporal_ui_workflow_href
 from nv_config_manager.temporal.api.main import app
 from nv_config_manager.temporal.api.workflow_v1 import (
+    WorkflowDetailResponse,
     WorkflowSummaryResponse,
     cache_workflow_input,
     signal_workflow,
@@ -1030,6 +1031,49 @@ async def test_running_workflow_with_failed_stage_exposes_failed_stage_flag(
     assert result.workflow_input == {"user": "cached"}
     handle.query.assert_not_awaited()
     cache.cache_query.assert_not_awaited()
+    mock_redis.from_config.assert_called_once_with(mock_load_config.return_value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response_type", [WorkflowSummaryResponse, WorkflowDetailResponse])
+@patch("nv_config_manager.temporal.api.workflow_v1.load_config")
+@patch("nv_config_manager.temporal.api.workflow_v1.RedisClient")
+async def test_terminated_workflow_is_not_pending_approval(
+    mock_redis, mock_load_config, response_type
+):
+    """A stale search attribute must not override a terminated execution status."""
+    cache = mock_redis.from_config.return_value
+
+    async def get_cached_query(_workflow_id, query):
+        if query == "input":
+            return {"user": "cached"}
+        if query == "compressed_stages":
+            return StageMixin.compress_stages([])
+        return None
+
+    cache.get_cached_query = AsyncMock(side_effect=get_cached_query)
+    cache.cache_query = AsyncMock()
+
+    handle = MagicMock()
+    handle.id = "terminated-pending-workflow"
+    handle.query = AsyncMock()
+
+    description = MagicMock()
+    description.search_attributes = {
+        PENDING_APPROVAL_SEARCH_ATTRIBUTE: [True],
+        "User": ["test"],
+    }
+    description.status = WorkflowExecutionStatus.TERMINATED
+    description.start_time = datetime.fromisoformat("1970-01-01T00:00:00+00:00")
+    description.close_time = datetime.fromisoformat("1970-01-01T00:01:00+00:00")
+    description.workflow_type = "HelloWorldApproval"
+    handle.describe = AsyncMock(return_value=description)
+
+    result = await response_type.from_handle(handle)
+
+    assert result.status == "TERMINATED"
+    assert result.pending_approval is False
+    handle.query.assert_not_awaited()
     mock_redis.from_config.assert_called_once_with(mock_load_config.return_value)
 
 

--- a/ui/src/app/workflows/columns.tsx
+++ b/ui/src/app/workflows/columns.tsx
@@ -99,6 +99,9 @@ function getWorkflowStatusLabel(status: string): string {
 }
 
 function getWorkflowDisplayStatus(workflow: WorkflowColumns): string {
+  if (workflow.status !== "RUNNING") {
+    return workflow.status;
+  }
   if (workflow.failed_stage) {
     return "FAILED";
   }

--- a/ui/tests/e2e/workflowsPage.spec.ts
+++ b/ui/tests/e2e/workflowsPage.spec.ts
@@ -211,6 +211,47 @@ test.describe("Workflows Page", () => {
     );
   });
 
+  test("terminal status takes precedence over stale stage flags", async ({
+    page,
+  }) => {
+    await page.unroute(/.*\/v1\/workflow\/?(\?.*)?$/);
+    await page.route(/.*\/v1\/workflow\/?(\?.*)?$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        json: {
+          workflows: [
+            {
+              id: "terminated-pending-workflow",
+              workflow_type: "DeployWorkflow",
+              workflow_input: {},
+              started_by: "test",
+              start_time: "2025-03-04T02:32:38.087457Z",
+              close_time: "2025-03-04T02:33:38.087457Z",
+              status: "TERMINATED",
+              pending_approval: true,
+              failed_stage: false,
+              search_attributes: { PendingApproval: [true], User: ["test"] },
+              href: "https://temporal.example.com/terminated-pending-workflow",
+            },
+          ],
+          next_page_token: null,
+          total_count: 1,
+          page_count: 1,
+        },
+      });
+    });
+
+    await page.goto("/workflows");
+
+    const workflowRow = page.locator("tbody tr").first();
+    await expect(
+      workflowRow.getByText("Terminated", { exact: true })
+    ).toBeVisible();
+    await expect(
+      workflowRow.getByText("Pending Approval", { exact: true })
+    ).toHaveCount(0);
+  });
+
   test("shows user roles and disables workflows the user cannot execute", async ({
     page,
   }) => {


### PR DESCRIPTION
## Description
Pending Approval and Failed statuses were taking precedence over Terminal statuses due to them being tracked separately from the Temporal state enum. This gives terminal statuses precedence, and adjusts the pending_approval boolean in the API response to return False regardless of the search attribute when a workflow is no longer running. 

Holding til after promotion of 1.3.1
## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [ ] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [ ] Commits are signed off for DCO compliance.
- [ ] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [ ] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closed and terminated workflows now display their actual final status instead of incorrectly showing “Pending Approval” due to stale information.
  * Pending approval indicators are now limited to workflows that are actively running.

* **Tests**
  * Added coverage for workflow summary and detail responses.
  * Added end-to-end validation for terminal workflow status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->