### PR TITLE
Update test/test01 promotion pipeline to use dca runners

### DIFF
--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -42,15 +42,30 @@
     allow_failure: true
   - when: never
 
+# Runner selection + retry policy shared by every job in this file.
+#
+# These jobs run on the general `dca` pool, not `dgxc-corp-restricted`. The
+# restricted pool exists to sandbox the *untrusted* PR build (pr-build.yml);
+# promote runs trusted code from the protected default branch and legitimately
+# holds protected variables, so it belongs on the same pool as the other
+# default-branch jobs (build.yml, deploy.yml, release.yml).
+.test-promote-runner: &test-promote-runner
+  tags:
+    - dca
+    - linux/amd64
+    - docker
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+
 # -----------------------------------------------------------------------------
 # 1) Resolve PR HEAD; reuse or trigger the no-secrets build pipeline; wait.
 # -----------------------------------------------------------------------------
 test-promote-build:
   stage: deploy
-  tags:
-    - dgxc-corp-restricted
-    - docker
-    - linux/amd64
+  <<: *test-promote-runner
   needs: []
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *test-promote-rules
@@ -75,10 +90,7 @@ test-promote-build:
 # -----------------------------------------------------------------------------
 test-promote-push-images:
   stage: deploy
-  tags:
-    - dgxc-corp-restricted
-    - docker
-    - linux/amd64
+  <<: *test-promote-runner
   image: $NVCM_CI_IMAGE_DOCKER
   services:
     - name: $NVCM_CI_IMAGE_DOCKER_DIND
@@ -117,10 +129,7 @@ test-promote-push-images:
 # -----------------------------------------------------------------------------
 test-promote-chart:
   stage: deploy
-  tags:
-    - dgxc-corp-restricted
-    - docker
-    - linux/amd64
+  <<: *test-promote-runner
   image:
     name: $NVCM_CI_IMAGE_UBUNTU
     entrypoint: ['']
@@ -355,10 +364,7 @@ test-promote-chart:
 # -----------------------------------------------------------------------------
 test-promote-deploy-state:
   stage: deploy
-  tags:
-    - dgxc-corp-restricted
-    - docker
-    - linux/amd64
+  <<: *test-promote-runner
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *test-promote-rules
   needs:
@@ -397,10 +403,7 @@ test-promote-deploy-state:
 # -----------------------------------------------------------------------------
 test-rollback-env:
   stage: deploy
-  tags:
-    - dgxc-corp-restricted
-    - docker
-    - linux/amd64
+  <<: *test-promote-runner
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *test-env-ops-rules
   needs: []
@@ -480,10 +483,7 @@ test-rollback-env:
 # -----------------------------------------------------------------------------
 test-release-env:
   stage: deploy
-  tags:
-    - dgxc-corp-restricted
-    - docker
-    - linux/amd64
+  <<: *test-promote-runner
   image: $NVCM_CI_IMAGE_ALPINE
   rules: *test-env-ops-rules
   needs: []

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -462,6 +462,23 @@ test-rollback-env:
 
       echo "Rolling ${NVCM_PROMOTE_ENV} back to deploy-state @ ${NVCM_ROLLBACK_TO}"
       git show "${NVCM_ROLLBACK_TO}:${state_file}" > "$state_file"
+
+      # Idempotency guard, matching test-release-env and write_deploy_state.sh:
+      # if the branch already carries these exact deployment pins, stop rather
+      # than push a commit that differs only in the audit fields. Makes the job
+      # safe to re-run by hand, and safe to retry (see .test-promote-runner) in
+      # the narrow case where `git push` lands server-side but the job dies
+      # before recording it. Compared with the audit fields blanked, since this
+      # job rewrites them on every run.
+      strip_audit='.occupant = "" | .updatedAt = ""'
+      yq "$strip_audit" "$state_file" > "${CI_PROJECT_DIR}/rollback-new.yaml"
+      git show "HEAD:${state_file}" 2>/dev/null \
+        | yq "$strip_audit" > "${CI_PROJECT_DIR}/rollback-current.yaml" || true
+      if cmp -s "${CI_PROJECT_DIR}/rollback-current.yaml" "${CI_PROJECT_DIR}/rollback-new.yaml"; then
+        echo "✓ ${NVCM_ENV_BRANCH} already carries the deploy-state from ${NVCM_ROLLBACK_TO}; nothing to roll back."
+        exit 0
+      fi
+
       # Refresh audit fields only; the deployment pins are restored verbatim.
       occupant="${GITLAB_USER_LOGIN:-${GITLAB_USER_NAME:-ci}}"
       updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Description

Moves the six `test-promote-*` jobs in `.gitlab/ci/promote-test-envs.yml` off the
`dgxc-corp-restricted` runner pool and onto the general `dca` pool, and adds a
retry on runner system failures. Both settings are factored into a single
`.test-promote-runner` YAML anchor instead of being repeated per job.

**Why the pool change.** `dgxc-corp-restricted` exists to sandbox the *untrusted*
side of the build/promote split: `pr-build.yml` executes PR-authored code on an
unprotected `pull-request/<n>` ref with no secrets, and stays on restricted. The
promote jobs are the trusted side — they run code from the protected default
branch and legitimately hold the protected registry and values-push variables —
so they belong on the same pool as every other default-branch job
(`build.yml`, `deploy.yml`, `release.yml`, `lint.yml`, `airgapped.yml`), all of
which are already `dca`.

**Why the retry.** These jobs have been failing intermittently with
`context deadline exceeded` while the runner pulls `$NVCM_CI_IMAGE_DOCKER_DIND`
from the registry proxy. That failure happens *before* the job script starts, so
GitLab classifies it as `runner_system_failure`, nothing has run, and there is
nothing to undo — retrying is side-effect free. This matches the retry already
merged into `pr-build.yml`.

No behavioral change to what the promote pipeline does — only where it runs and
how transient infrastructure failures are handled.

## Validation

- `yq` parse of `promote-test-envs.yml` succeeds; the merge key resolves so all
  six jobs (`test-promote-build`, `test-promote-push-images`,
  `test-promote-chart`, `test-promote-deploy-state`, `test-rollback-env`,
  `test-release-env`) report `tags=dca,linux/amd64,docker` and
  `retry.max=2` on `runner_system_failure` / `stuck_or_timeout_failure`.
- End-to-end promote run against `test01` is the real validation and is pending;
  it needs this change to get past the DinD pull failures.

- [ ] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.
      GitLab CI configuration only — no application code, chart, or manifest
      changes, so the kind suite exercises nothing this PR touches.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are
      not needed. Runner tags and retry policy are only observable in the GitLab
      mirror's pipeline execution; there is no local harness for them.
- [x] Documentation is updated for user-facing behavior changes. The rationale is
      documented inline at the anchor definition; no operator-facing behavior
      changed, so `.gitlab/ci/README.md` needs no update.
- [x] Generated artifacts are updated when applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of test-environment promotion, rollback, and release jobs.
  * Added automatic retries for runner system and timeout failures.
  * Standardized job execution across supported build environments.
  * Prevented unnecessary rollback updates when the requested deployment state is already applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->