### PR TITLE
fix(oidc): support Entra ID tokens without profile lookup

### DIFF
--- a/deploy/helm/templates/oidc-proxy.yaml
+++ b/deploy/helm/templates/oidc-proxy.yaml
@@ -81,6 +81,10 @@ data:
     set_authorization_header = true
     set_xauthrequest = true
     oidc_groups_claim = {{ $.Values.oidc.groupsClaim | default "groups" | quote }}
+    # Some providers advertise a profile endpoint that does not accept access
+    # tokens issued for a custom API audience (for example, Entra UserInfo).
+    skip_claims_from_profile_url = {{ $.Values.oidc.proxy.skipClaimsFromProfileURL }}
+    insecure_oidc_allow_unverified_email = {{ $.Values.oidc.proxy.insecureAllowUnverifiedEmail }}
     silence_ping_logging = true
     {{- with $internalIssuerUrl }}
     # Keep the public issuer for token validation, but use explicit in-cluster

--- a/deploy/helm/templates/oidc-proxy.yaml
+++ b/deploy/helm/templates/oidc-proxy.yaml
@@ -85,6 +85,7 @@ data:
     # tokens issued for a custom API audience (for example, Entra UserInfo).
     skip_claims_from_profile_url = {{ $.Values.oidc.proxy.skipClaimsFromProfileURL }}
     insecure_oidc_allow_unverified_email = {{ $.Values.oidc.proxy.insecureAllowUnverifiedEmail }}
+    insecure_oidc_skip_nonce = false
     silence_ping_logging = true
     {{- with $internalIssuerUrl }}
     # Keep the public issuer for token validation, but use explicit in-cluster

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -942,6 +942,13 @@ oidc:
   proxy:
     replicas: 2
     cookieName: _nvcm_oidc_proxy
+    # Use only ID token claims instead of the OIDC discovery profile URL.
+    # Keep disabled by default for compatibility with providers that require
+    # claims to be resolved from their UserInfo endpoint.
+    skipClaimsFromProfileURL: false
+    # Allow an ID token that omits email_verified. Signature, issuer, audience,
+    # and nonce validation remain enabled.
+    insecureAllowUnverifiedEmail: false
     image:
       repository: quay.io/oauth2-proxy/oauth2-proxy
       tag: v7.15.3


### PR DESCRIPTION
## Description

Resolve incompatibility between oauth2-proxy OIDC flow and native clients

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`a2899ad`](https://github.com/NVIDIA/nv-config-manager/commit/a2899ad9fc3fbdfb46cf3ef29f737e6831417d2d) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/31123258062).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable OIDC proxy options to skip profile URL claims retrieval.
  * Added an option to accept ID tokens without an `email_verified` claim while preserving signature, issuer, audience, and nonce validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->