### PR TITLE
bump temporal admin tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,9 @@ NAUTOBOT_NV_CONFIG_MANAGER_VERSION_ARG = $(if $(NAUTOBOT_NV_CONFIG_MANAGER_VERSI
 # Keep this aligned with the currently approved production server version.
 # A Temporal server upgrade is a separately planned schema migration.
 TEMPORAL_SERVER_VERSION ?= 1.29.7
-# Admin tools run only in the bootstrap init containers.  Temporal does not
-# publish an admin-tools:1.29.7 tag, so retain the available 1.29.6 release.
-TEMPORAL_ADMIN_TOOLS_VERSION ?= 1.29.6
+# Admin tools run only in the bootstrap init containers. Temporal publishes
+# 1.29.7 under its fully qualified server/tctl/CLI tag.
+TEMPORAL_ADMIN_TOOLS_VERSION ?= 1.29.7-tctl-1.18.4-cli-1
 # UI is independently deployable and does not change Temporal persistence.
 TEMPORAL_UI_VERSION ?= 2.52.1
 TEMPORAL_BUILD_ARGS = --build-arg TEMPORAL_SERVER_VERSION=$(TEMPORAL_SERVER_VERSION) --build-arg TEMPORAL_ADMIN_TOOLS_VERSION=$(TEMPORAL_ADMIN_TOOLS_VERSION) --build-arg TEMPORAL_UI_VERSION=$(TEMPORAL_UI_VERSION)

--- a/build/temporal.Dockerfile
+++ b/build/temporal.Dockerfile
@@ -8,8 +8,8 @@
 # version.  Changing it requires the Temporal database-upgrade procedure.
 ARG TEMPORAL_SERVER_VERSION=1.29.7
 # The bootstrap-only admin-tools image supplies Temporal's schema files and
-# command-line tools. Temporal does not publish an admin-tools:1.29.7 tag.
-ARG TEMPORAL_ADMIN_TOOLS_VERSION=1.29.6
+# command-line tools. Temporal publishes 1.29.7 under this fully qualified tag.
+ARG TEMPORAL_ADMIN_TOOLS_VERSION=1.29.7-tctl-1.18.4-cli-1
 # The UI is independently deployable and does not change Temporal persistence.
 ARG TEMPORAL_UI_VERSION=2.52.1
 


### PR DESCRIPTION
## Description

Temporal Admin Tools has been recently patched with fixes for:
      - GHSA-rm3j-f69w-wqmq
      - GHSA-jppx-rxg9-jmrx

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`d6eee8b`](https://github.com/NVIDIA/nv-config-manager/commit/d6eee8b889600b4d09a9c2f1801a19147a2a739b) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/31128972085).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Temporal administration tools to the latest fully qualified release.
  * Ensured development and containerized environments use the same tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->