### PR TITLE
fix(sec): patch temporal ui cves

### DIFF
--- a/build/temporal.Dockerfile
+++ b/build/temporal.Dockerfile
@@ -23,6 +23,21 @@ COPY components/temporal/go.mod ./
 COPY components/temporal/cmd/ ./cmd/
 RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/temporal-bootstrap ./cmd/temporal-bootstrap
 
+# Rebuild the version-matched UI server until an upstream release includes the
+# patched Go toolchain and dependency versions. The released module contains
+# the same embedded frontend assets as the upstream image.
+FROM golang:1.26.5-alpine AS ui-server-builder
+ARG TEMPORAL_UI_VERSION
+WORKDIR /src
+RUN go mod download github.com/temporalio/ui-server/v2@v${TEMPORAL_UI_VERSION} && \
+    cp -R /go/pkg/mod/github.com/temporalio/ui-server/v2@v${TEMPORAL_UI_VERSION}/. . && \
+    chmod -R u+w . && \
+    go get golang.org/x/crypto@v0.52.0 \
+        golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
+        google.golang.org/grpc@v1.82.1 && \
+    CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/ui-server ./cmd/server/main.go
+
 # =============================================================================
 # Temporal Server
 # =============================================================================
@@ -51,5 +66,6 @@ ENTRYPOINT ["/usr/local/bin/temporal-bootstrap"]
 FROM nvcr.io/nvidia/distroless/go:v4.0.8 AS ui
 WORKDIR /home/ui-server
 COPY --from=ui-upstream /home/ui-server /home/ui-server
+COPY --from=ui-server-builder /out/ui-server /home/ui-server/ui-server
 USER nvs
 ENTRYPOINT ["/home/ui-server/ui-server", "--env", "docker", "start"]


### PR DESCRIPTION
## Description

patch temporal ui cves

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated the Temporal UI container build to compile and package a version-matched UI server.
  * Ensured the runtime image uses the newly built server for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->