### PR TITLE
feat(config): restart services when their configuration file changes

### DIFF
--- a/src/nv_config_manager/common/config.py
+++ b/src/nv_config_manager/common/config.py
@@ -54,7 +54,7 @@ from nv_config_manager.common.client import (
 # =============================================================================
 # LOGGING (re-exported from nv_config_manager.common.log to avoid circular imports)
 # =============================================================================
-from nv_config_manager.common.ini import FileFingerprint, file_fingerprint
+from nv_config_manager.common.ini import FileFingerprint, config_path, file_fingerprint
 from nv_config_manager.common.log import (  # noqa: F401, E402
     LogCategory,
     configure_logging,
@@ -109,8 +109,8 @@ def load_config() -> ConfigParser:
     Returns:
         Loaded ConfigParser instance for the current file version
     """
-    config_path = os.getenv("NV_CONFIG_MANAGER_INI", "/etc/vault/nv-config-manager.ini")
-    return _load_config(config_path, file_fingerprint(config_path))
+    path = config_path()
+    return _load_config(path, file_fingerprint(path))
 
 
 def clear_config_cache() -> None:

--- a/src/nv_config_manager/common/config_watch.py
+++ b/src/nv_config_manager/common/config_watch.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ask a service to restart once its configuration file has changed.
+
+Kubernetes propagates a Secret update into a running pod, so rotated
+credentials and renamed streams reach the INI without the pod being replaced.
+Anything a service built from the INI at startup keeps using the values it was
+given, and a NATS or Nautobot connection keeps presenting its original
+credentials even across its own automatic reconnects. Rebuilding each of those
+in place would mean tracking every piece of state derived from the file, in
+every service, forever. Restarting replaces all of it at once.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import signal
+import threading
+from configparser import ConfigParser
+
+from nv_config_manager.common.ini import config_path, file_digest
+from nv_config_manager.common.log import LogCategory, get_logger
+
+logger = get_logger(__name__, category=LogCategory.CONFIG)
+
+# Kubernetes takes up to about a minute to surface a Secret update in a running
+# pod, so polling faster than this only burns syscalls.
+DEFAULT_POLL_INTERVAL_SECONDS = 30.0
+
+# Every replica of a service reads the same file and sees the change within the
+# same window. Waiting a random part of this spreads their restarts out, which a
+# Deployment rollout would otherwise have arranged.
+DEFAULT_MAX_JITTER_SECONDS = 20.0
+
+_watch_started = threading.Lock()
+
+
+def changed_keys(before: str, after: str) -> list[str]:
+    """Name the settings that differ between two versions of an INI file.
+
+    Only names are returned. The file holds credentials, so the values behind
+    them must not reach the logs.
+
+    Args:
+        before: Contents of the previous version
+        after: Contents of the current version
+
+    Returns:
+        Sorted "section.option" names whose values differ, added or removed
+    """
+
+    def flatten(text: str) -> dict[str, str]:
+        parser = ConfigParser(interpolation=None, delimiters=("=",))
+        try:
+            parser.read_string(text)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # A half-written file should still be reported as a change.
+            return {}
+        return {
+            f"{section}.{option}": value
+            for section in parser.sections()
+            for option, value in parser[section].items()
+        }
+
+    old, new = flatten(before), flatten(after)
+    return sorted(name for name in old.keys() | new.keys() if old.get(name) != new.get(name))
+
+
+def _read(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def _watch(
+    path: str,
+    poll_interval: float,
+    max_jitter: float,
+    stop: threading.Event,
+) -> None:
+    """Poll until the file's contents change, then signal a shutdown.
+
+    Args:
+        path: File to watch
+        poll_interval: Seconds between checks
+        max_jitter: Upper bound on the delay before signalling
+        stop: Set this to abandon the watch without touching the process
+    """
+    digest = file_digest(path)
+    contents = _read(path)
+
+    while not stop.wait(poll_interval):
+        current = file_digest(path)
+        if current is None or current == digest:
+            # An unreadable file is treated as a transient mount problem rather
+            # than a change, so a service is never restarted for losing sight of
+            # its configuration.
+            continue
+
+        logger.info(
+            "Configuration file %s changed, restarting to pick it up. Changed settings: %s",
+            path,
+            ", ".join(changed_keys(contents, _read(path))) or "none identified",
+        )
+        if stop.wait(random.uniform(0, max_jitter)):  # noqa: S311 - spreading load, not crypto
+            return
+
+        # Each service already shuts down cleanly on SIGTERM, the same way it
+        # would if Kubernetes had replaced the pod, so reuse that path instead
+        # of adding a second kind of exit.
+        os.kill(os.getpid(), signal.SIGTERM)
+        return
+
+
+def restart_on_config_change(
+    poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    max_jitter: float = DEFAULT_MAX_JITTER_SECONDS,
+) -> bool:
+    """Watch the unified INI file and stop this process when it changes.
+
+    Call once while a long-lived service starts up. The watch runs on a daemon
+    thread so it suits the synchronous and asyncio services equally and does not
+    hold up interpreter shutdown.
+
+    Args:
+        poll_interval: Seconds between checks of the file
+        max_jitter: Upper bound on the delay before shutting down
+
+    Returns:
+        True when a watch was started, False when one was already running
+    """
+    if not _watch_started.acquire(blocking=False):
+        return False
+
+    path = config_path()
+    threading.Thread(
+        target=_watch,
+        args=(path, poll_interval, max_jitter, threading.Event()),
+        name="config-watch",
+        daemon=True,
+    ).start()
+    logger.info("Watching %s for configuration changes", path)
+    return True

--- a/src/nv_config_manager/common/ini.py
+++ b/src/nv_config_manager/common/ini.py
@@ -16,9 +16,21 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 
 type FileFingerprint = tuple[int, int, int, int, int]
+
+DEFAULT_CONFIG_PATH = "/etc/vault/nv-config-manager.ini"
+
+
+def config_path() -> str:
+    """Return the path of the unified INI file this process reads.
+
+    Returns:
+        NV_CONFIG_MANAGER_INI when set, otherwise the packaged default
+    """
+    return os.getenv("NV_CONFIG_MANAGER_INI", DEFAULT_CONFIG_PATH)
 
 
 def file_fingerprint(path: str | None) -> FileFingerprint | None:
@@ -43,3 +55,27 @@ def file_fingerprint(path: str | None) -> FileFingerprint | None:
         stat_result.st_mtime_ns,
         stat_result.st_ctime_ns,
     )
+
+
+def file_digest(path: str | None) -> str | None:
+    """Return a hash of the file's contents.
+
+    A fingerprint reports that the file was rewritten, which is what a parse
+    cache needs. Deciding to restart a process needs the stronger question of
+    whether anything actually changed, because Kubernetes and Vault Agent both
+    rewrite these files on their own schedules with identical contents.
+
+    Args:
+        path: File to hash
+
+    Returns:
+        Hex digest of the contents, or None when the file cannot be read
+    """
+    if not path:
+        return None
+
+    try:
+        with open(path, "rb") as handle:
+            return hashlib.sha256(handle.read()).hexdigest()
+    except OSError:
+        return None

--- a/src/nv_config_manager/common/log.py
+++ b/src/nv_config_manager/common/log.py
@@ -53,6 +53,7 @@ class LogCategory:
     API = "api"  # Deprecated: use per-service variants (RENDER_API, etc.)
     NATS = "nats"
     CACHE = "cache"
+    CONFIG = "config"
 
 
 # =============================================================================

--- a/src/nv_config_manager/config_store/api/main.py
+++ b/src/nv_config_manager/config_store/api/main.py
@@ -24,6 +24,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator import metrics as instrumentator_metrics
 
 from nv_config_manager.common.auth import install_identity_probe
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import LogCategory, configure_logging, get_logger
 from nv_config_manager.common.telemetry import (
     group_fastapi_status_codes,
@@ -125,6 +126,7 @@ install_identity_probe(app)
 
 def main() -> None:
     """CLI entrypoint for Config Store API."""
+    restart_on_config_change()
 
     uvicorn.run(
         "nv_config_manager.config_store.api.main:app",

--- a/src/nv_config_manager/config_store/cache_refresh_service.py
+++ b/src/nv_config_manager/config_store/cache_refresh_service.py
@@ -23,6 +23,7 @@ import signal
 import sys
 from typing import Any
 
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import LogCategory, configure_logging, get_logger
 from nv_config_manager.config_store.config import settings
 from nv_config_manager.config_store.core.device_cache_redis import (
@@ -112,6 +113,8 @@ def cli_main() -> None:
     # Setup signal handlers for graceful shutdown
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
+
+    restart_on_config_change()
 
     # Run the service
     try:

--- a/src/nv_config_manager/dhcp/api.py
+++ b/src/nv_config_manager/dhcp/api.py
@@ -35,6 +35,7 @@ from pydantic import IPvAnyAddress, IPvAnyNetwork
 
 from nv_config_manager.common.auth import install_identity_probe
 from nv_config_manager.common.config import load_config
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import configure_logging
 from nv_config_manager.common.telemetry import (
     group_fastapi_status_codes,
@@ -323,6 +324,7 @@ def main() -> None:
     parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to bind to")
     args = parser.parse_args()
 
+    restart_on_config_change()
     uvicorn.run(
         "nv_config_manager.dhcp.api:app",
         host=args.host,

--- a/src/nv_config_manager/mcp/main.py
+++ b/src/nv_config_manager/mcp/main.py
@@ -25,6 +25,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import configure_logging
 from nv_config_manager.common.telemetry import instrument_asgi_app, setup_tracing
 from nv_config_manager.mcp.auth import (
@@ -186,6 +187,7 @@ def main() -> None:
     parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to bind to")
     args = parser.parse_args()
 
+    restart_on_config_change()
     uvicorn.run(
         create_app(),
         host=args.host,

--- a/src/nv_config_manager/render/api/main.py
+++ b/src/nv_config_manager/render/api/main.py
@@ -22,6 +22,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator import metrics as instrumentator_metrics
 
 from nv_config_manager.common.auth import install_identity_probe
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import configure_logging
 from nv_config_manager.common.telemetry import (
     group_fastapi_status_codes,
@@ -39,6 +40,7 @@ instrument_fastapi_app(app)
 
 def main() -> None:
     """CLI entrypoint for render API."""
+    restart_on_config_change()
     uvicorn.run(
         "nv_config_manager.render.api.main:app",
         host="0.0.0.0",

--- a/src/nv_config_manager/render/pull_consumer.py
+++ b/src/nv_config_manager/render/pull_consumer.py
@@ -46,6 +46,7 @@ from nv_config_manager.common.config import (
     nats_nautobot_change_config,
     nats_render_change_config,
 )
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.nats_admin import (
     CONSUMER_ACK_WAIT_SECONDS,
     CONSUMER_MAX_DELIVER,
@@ -585,6 +586,8 @@ def main() -> None:
     """Entry point for the pull consumer."""
     # Start Prometheus Server
     start_http_server(8000)
+
+    restart_on_config_change()
 
     consumer: PullConsumer
     consumer_name = os.getenv("NATS_CONSUMER")

--- a/src/nv_config_manager/temporal/api/main.py
+++ b/src/nv_config_manager/temporal/api/main.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 
 from nv_config_manager.common.auth import install_identity_probe
 from nv_config_manager.common.config import load_config
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import LogCategory, configure_logging, get_logger
 from nv_config_manager.common.telemetry import (
     group_fastapi_status_codes,
@@ -151,6 +152,7 @@ def rbac_config_status() -> RBACConfigResponse:
 
 def main() -> None:
     """CLI entrypoint for Temporal API."""
+    restart_on_config_change()
 
     uvicorn.run(
         "nv_config_manager.temporal.api.main:app",

--- a/src/nv_config_manager/temporal/archive/main.py
+++ b/src/nv_config_manager/temporal/archive/main.py
@@ -23,16 +23,20 @@ from typing import Any
 from nats.aio.msg import Msg
 
 from nv_config_manager.common.config import load_config, nats_archive_config
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import configure_logging
 from nv_config_manager.temporal.api.workflow_v1 import WorkflowDetailResponse, get_client
 from nv_config_manager.temporal.client.nats import NatsConsumer
 from nv_config_manager.temporal.telemetry import setup_telemetry
 
-config = load_config()
+# Backend selection gates the imports below, so unlike the settings read per
+# message it can only be decided once, at import.
+_startup_config = load_config()
 
 ARCHIVE_BACKEND = (
     "nvdataflow"
-    if "temporal.nvdataflow" in config and config["temporal.nvdataflow"].get("project")
+    if "temporal.nvdataflow" in _startup_config
+    and _startup_config["temporal.nvdataflow"].get("project")
     else "elasticsearch"
 )
 if ARCHIVE_BACKEND == "nvdataflow":
@@ -86,6 +90,7 @@ async def handle_archive_msg(msg: Msg) -> None:
 
 async def _archive_nvdataflow(workflow_details: Any) -> None:
     """Archive workflow details to nvdataflow."""
+    config = load_config()
     compressed = gzip.compress(json.dumps(workflow_details).encode("utf-8"))
     encoded = base64.b64encode(compressed).decode("utf-8")
 
@@ -131,6 +136,7 @@ async def _archive_nvdataflow(workflow_details: Any) -> None:
 
 def _archive_elasticsearch(workflow_details: Any) -> None:
     """Archive workflow details to Elasticsearch."""
+    config = load_config()
     # Add temporal server so we can track which environment sourced the workflow
     workflow_details["config_manager_temporal_server"] = config["temporal"]["api_url"]
 
@@ -206,6 +212,7 @@ def main() -> None:
     )
     configure_logging(service="temporal-archive")
     setup_telemetry("nv-config-manager-temporal-archive")
+    restart_on_config_change()
 
     stream, subject = nats_archive_config()
     consumer = NatsConsumer(

--- a/src/nv_config_manager/temporal/common/mixins/archive.py
+++ b/src/nv_config_manager/temporal/common/mixins/archive.py
@@ -49,16 +49,28 @@ class WorkflowResultLog(BaseModel):
         )
 
 
+_PUBLISH_RETRY_POLICY = RetryPolicy(maximum_attempts=3)
+
+
 class ArchiveMixin(BaseMixin):
-    """Mixin to send a workflow result to NATS for archival."""
+    """Mixin to publish a workflow result to NATS."""
 
     async def archive_results(self) -> None:
-        """Log the worklflow results."""
-        await workflow.execute_activity(
-            publish_nats,
-            PublishNatsInput(
-                message=WorkflowResultLog.from_workflow_info(workflow.info()).model_dump_json(),
-            ),
-            schedule_to_close_timeout=timedelta(minutes=1),
-            retry_policy=RetryPolicy(maximum_attempts=1),
-        )
+        """Publish the workflow result; never mask the run's own outcome."""
+        try:
+            await workflow.execute_activity(
+                publish_nats,
+                PublishNatsInput(
+                    message=WorkflowResultLog.from_workflow_info(workflow.info()).model_dump_json(),
+                ),
+                schedule_to_close_timeout=timedelta(minutes=1),
+                retry_policy=_PUBLISH_RETRY_POLICY,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            # The run has already finished its work by the time results are
+            # published, so a broker problem must not turn it into a failure.
+            # Consumers treat these events as an optimisation over polling.
+            workflow.logger.warning(
+                "Failed to publish the result for %s; consumers will not see this run",
+                workflow.info().workflow_id,
+            )

--- a/src/nv_config_manager/temporal/ngc/schedulers/backup.py
+++ b/src/nv_config_manager/temporal/ngc/schedulers/backup.py
@@ -36,6 +36,7 @@ from temporalio.common import (
 from temporalio.contrib.opentelemetry import TracingInterceptor
 
 from nv_config_manager.common.config import load_config
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import LogCategory, get_logger
 from nv_config_manager.temporal.client.connection import client_connect_options, temporal_address
 from nv_config_manager.temporal.client.nautobot import NautobotClient, NautobotException
@@ -229,6 +230,7 @@ def main() -> None:
     """Entry point for nv-config-manager-temporal-scheduler command."""
     logging.basicConfig(level=logging.INFO)
     setup_telemetry("nv-config-manager-temporal-scheduler")
+    restart_on_config_change()
     asyncio.run(BackupScheduler().run())
 
 

--- a/src/nv_config_manager/temporal/worker/main.py
+++ b/src/nv_config_manager/temporal/worker/main.py
@@ -23,6 +23,7 @@ from temporalio.client import Client
 from temporalio.contrib.opentelemetry import TracingInterceptor
 from temporalio.worker import Worker
 
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import configure_logging
 from nv_config_manager.temporal.client.connection import client_connect_options, temporal_address
 from nv_config_manager.temporal.common.activities import REGISTERED_COMMON_ACTIVITIES
@@ -54,6 +55,7 @@ def _enabled_env_flag(name: str) -> bool:
 
 async def main() -> None:
     """Run the temporal worker."""
+    restart_on_config_change()
     runtime = setup_telemetry("nv-config-manager-temporal-worker")
 
     client = await Client.connect(

--- a/src/nv_config_manager/ztp/api/main.py
+++ b/src/nv_config_manager/ztp/api/main.py
@@ -23,6 +23,7 @@ from fastapi import FastAPI
 from prometheus_fastapi_instrumentator import Instrumentator, metrics
 
 from nv_config_manager.common.auth import install_identity_probe
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import configure_logging
 from nv_config_manager.common.telemetry import (
     group_fastapi_status_codes,
@@ -45,6 +46,7 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=9000, help="Port to listen on (default: 9000)")
     args = parser.parse_args()
 
+    restart_on_config_change()
     uvicorn.run(
         "nv_config_manager.ztp.api.main:app",
         host=args.host,

--- a/src/nv_config_manager/ztp/sftp/main.py
+++ b/src/nv_config_manager/ztp/sftp/main.py
@@ -51,6 +51,7 @@ from paramiko.transport import Transport
 from prometheus_client import start_http_server
 
 from nv_config_manager.common.config import get_storage_client
+from nv_config_manager.common.config_watch import restart_on_config_change
 from nv_config_manager.common.log import (
     EscapingLoggerAdapter,
     LogCategory,
@@ -846,6 +847,7 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+    restart_on_config_change()
     start_server(host=args.host, port=args.port, level=args.level)
 
 

--- a/src/tests/common/test_config_watch.py
+++ b/src/tests/common/test_config_watch.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 import pytest
 
+from nv_config_manager.common import config_watch
 from nv_config_manager.common.config_watch import _watch, changed_keys
 from nv_config_manager.common.ini import file_digest
 
@@ -77,10 +78,21 @@ def _watch_while(
     """
     signals: list[tuple[int, int]] = []
     stop = threading.Event()
+    baseline_taken = threading.Event()
+    read_file = config_watch._read
 
-    with patch(
-        "nv_config_manager.common.config_watch.os.kill",
-        side_effect=lambda pid, sig: signals.append((pid, sig)),
+    def record_baseline(target: str) -> str:
+        """Report that the watch has finished reading the file it starts from."""
+        contents = read_file(target)
+        baseline_taken.set()
+        return contents
+
+    with (
+        patch(
+            "nv_config_manager.common.config_watch.os.kill",
+            side_effect=lambda pid, sig: signals.append((pid, sig)),
+        ),
+        patch("nv_config_manager.common.config_watch._read", side_effect=record_baseline),
     ):
         watcher = threading.Thread(
             target=_watch,
@@ -88,7 +100,10 @@ def _watch_while(
             daemon=True,
         )
         watcher.start()
-        time.sleep(POLL_INTERVAL * 2)
+
+        # Changing the file before the watch has read it would make the new
+        # contents its baseline, and the change would go unnoticed.
+        assert baseline_taken.wait(timeout=5.0)
         if change is not None:
             change()
 

--- a/src/tests/common/test_config_watch.py
+++ b/src/tests/common/test_config_watch.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for restarting a service when its configuration file changes."""
+
+import os
+import signal
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nv_config_manager.common.config_watch import _watch, changed_keys
+from nv_config_manager.common.ini import file_digest
+
+ORIGINAL = """[nats]
+server = nats://nats:4222
+queue = nv-config-manager
+password = original
+"""
+
+ROTATED = """[nats]
+server = nats://nats:4222
+queue = nv-config-manager
+password = rotated
+"""
+
+RENAMED_STREAM = """[nats]
+server = nats://nats:4222
+queue = nv-config-manager
+password = original
+config_manager_stream = renamed
+"""
+
+POLL_INTERVAL = 0.01
+
+
+@pytest.fixture
+def ini(tmp_path: Path) -> Path:
+    """Write a starting INI file and return its path."""
+    path = tmp_path / "nv-config-manager.ini"
+    path.write_text(ORIGINAL)
+    return path
+
+
+def _watch_while(
+    path: Path,
+    change: Callable[[], None] | None = None,
+    max_jitter: float = 0.0,
+) -> list[tuple[int, int]]:
+    """Start a watch, apply a change to the file, and report any signal sent.
+
+    The watch reads its baseline as it starts, the way a service does, so the
+    change has to land after it is already running.
+
+    Args:
+        path: INI file being watched
+        change: Applied once the watch has taken its baseline
+        max_jitter: Upper bound on the delay before signalling
+
+    Returns:
+        The (pid, signal) pairs the watch sent
+    """
+    signals: list[tuple[int, int]] = []
+    stop = threading.Event()
+
+    with patch(
+        "nv_config_manager.common.config_watch.os.kill",
+        side_effect=lambda pid, sig: signals.append((pid, sig)),
+    ):
+        watcher = threading.Thread(
+            target=_watch,
+            args=(str(path), POLL_INTERVAL, max_jitter, stop),
+            daemon=True,
+        )
+        watcher.start()
+        time.sleep(POLL_INTERVAL * 2)
+        if change is not None:
+            change()
+
+        # A watch with nothing to act on never returns, so give it a bounded
+        # chance to react and then take it down.
+        deadline = time.monotonic() + 1.0
+        while not signals and time.monotonic() < deadline:
+            time.sleep(POLL_INTERVAL)
+        stop.set()
+        watcher.join(timeout=5.0)
+
+    return signals
+
+
+def test_a_rotated_password_stops_the_process(ini: Path) -> None:
+    """A new credential only reaches an open connection by way of a restart."""
+    signals = _watch_while(ini, change=lambda: ini.write_text(ROTATED))
+
+    assert signals == [(os.getpid(), signal.SIGTERM)]
+
+
+def test_a_renamed_stream_stops_the_process(ini: Path) -> None:
+    """Consumers bind their stream at startup, so a rename needs a restart too."""
+    signals = _watch_while(ini, change=lambda: ini.write_text(RENAMED_STREAM))
+
+    assert signals == [(os.getpid(), signal.SIGTERM)]
+
+
+def test_an_unchanged_file_leaves_the_process_alone(ini: Path) -> None:
+    """Nothing changed, so nothing should be disturbed."""
+    assert _watch_while(ini) == []
+
+
+def test_an_identical_rewrite_is_not_a_change(ini: Path, tmp_path: Path) -> None:
+    """Kubernetes and Vault Agent rewrite these files on their own schedules.
+
+    The replacement arrives with a new inode and new timestamps, so watching
+    file metadata would restart a service that has nothing new to read.
+    """
+
+    def rewrite_with_the_same_contents() -> None:
+        replacement = tmp_path / "replacement.ini"
+        replacement.write_text(ORIGINAL)
+        os.replace(replacement, ini)
+
+    before = file_digest(str(ini))
+    signals = _watch_while(ini, change=rewrite_with_the_same_contents)
+
+    assert file_digest(str(ini)) == before
+    assert signals == []
+
+
+def test_an_unreadable_file_is_not_a_change(ini: Path) -> None:
+    """Losing sight of the file is a mount problem, not a reason to restart."""
+    assert _watch_while(ini, change=ini.unlink) == []
+
+
+def test_the_restart_is_spread_across_replicas(ini: Path) -> None:
+    """Every replica sees the change at once, so they must not all exit at once."""
+    with patch("nv_config_manager.common.config_watch.random.uniform", return_value=0.0) as uniform:
+        _watch_while(ini, change=lambda: ini.write_text(ROTATED), max_jitter=20.0)
+
+    uniform.assert_called_once_with(0, 20.0)
+
+
+def test_changed_keys_names_the_settings_that_moved() -> None:
+    """An operator needs to know why a service restarted."""
+    assert changed_keys(ORIGINAL, RENAMED_STREAM) == ["nats.config_manager_stream"]
+    assert changed_keys(ORIGINAL, ROTATED) == ["nats.password"]
+    assert changed_keys(ORIGINAL, ORIGINAL) == []
+
+
+def test_changed_keys_does_not_leak_the_values() -> None:
+    """The file holds credentials, so only names may be logged."""
+    reported = " ".join(changed_keys(ORIGINAL, ROTATED))
+
+    assert "rotated" not in reported
+    assert "original" not in reported

--- a/src/tests/temporal/test_archive_nats_prefix.py
+++ b/src/tests/temporal/test_archive_nats_prefix.py
@@ -12,14 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests that the archive consumer follows its stream's JetStream API prefix."""
+"""Tests for workflow-result routing and the resilience of the publish."""
 
-from unittest.mock import AsyncMock, patch
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import nats.errors
 import pytest
 
 from nv_config_manager.temporal.archive.main import main
 from nv_config_manager.temporal.client.nats import NatsConsumer
+from nv_config_manager.temporal.common.mixins.archive import ArchiveMixin
 from nv_config_manager.temporal.ngc.activities.nats import PublishNatsInput, publish_nats
 
 BASE_NATS_CONFIG = """
@@ -105,3 +108,59 @@ async def test_workflow_result_publish_subject_is_unchanged(custom_ini):
         '{"workflow_id":"workflow-1"}',
         stream="nv-config-manager",
     )
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_so_temporal_can_retry(custom_ini):
+    """The activity must surface broker errors; the mixin decides they are not fatal."""
+    custom_ini(BASE_NATS_CONFIG)
+    producer = AsyncMock()
+    producer.publish.side_effect = nats.errors.NoServersError()
+
+    with (
+        patch(
+            "nv_config_manager.temporal.ngc.activities.nats.NatsProducer",
+            return_value=producer,
+        ),
+        pytest.raises(nats.errors.NoServersError),
+    ):
+        await publish_nats(PublishNatsInput(message='{"workflow_id":"workflow-1"}'))
+
+
+def _workflow_info() -> MagicMock:
+    info = MagicMock()
+    info.workflow_id = "workflow-1"
+    info.workflow_type = "SomeWorkflow"
+    info.start_time = datetime(2026, 1, 1, tzinfo=UTC)
+    info.search_attributes = {}
+    return info
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.common.mixins.archive.workflow.logger")
+@patch("nv_config_manager.temporal.common.mixins.archive.workflow.now")
+@patch("nv_config_manager.temporal.common.mixins.archive.workflow.info", new=_workflow_info)
+@patch("nv_config_manager.temporal.common.mixins.archive.workflow.execute_activity")
+async def test_a_failed_publish_does_not_fail_the_workflow(execute_activity, now, logger):
+    """The run has already done its work, so a broker outage must not fail it."""
+    now.return_value = datetime(2026, 1, 1, tzinfo=UTC)
+    execute_activity.side_effect = RuntimeError("nats unreachable")
+
+    await ArchiveMixin().archive_results()
+
+    logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.common.mixins.archive.workflow.logger")
+@patch("nv_config_manager.temporal.common.mixins.archive.workflow.now")
+@patch("nv_config_manager.temporal.common.mixins.archive.workflow.info", new=_workflow_info)
+@patch("nv_config_manager.temporal.common.mixins.archive.workflow.execute_activity")
+async def test_publish_is_retried_before_being_given_up_on(execute_activity, now, logger):
+    """Consumers rely on these events, so a transient failure should be retried."""
+    now.return_value = datetime(2026, 1, 1, tzinfo=UTC)
+
+    await ArchiveMixin().archive_results()
+
+    assert execute_activity.call_args.kwargs["retry_policy"].maximum_attempts > 1
+    logger.warning.assert_not_called()


### PR DESCRIPTION
## Why

Kubernetes propagates a Secret update into a running pod, so a rotated NATS password or a renamed stream reaches `nv-config-manager.ini` without the pod being replaced. Nothing acts on it.

A service reads the INI as it starts and keeps whatever it built from it. A NATS or Nautobot connection carries the credentials it was opened with, even across its own automatic reconnects. That is what left the Temporal worker publishing to `kiwi.workflow.result` after the Cerebro v2 cutover until Ryan restarted it by hand, and what stranded the render consumers on a stream name that no longer existed.

## What this does

Adds a shared watcher that hashes the INI, polls it, and asks the process to stop when the contents change. Every long-lived service starts one. Kubernetes then replaces the pod, and the new process reads everything fresh.

Restarting rather than reloading in place is deliberate. Reloading would mean tracking every object derived from the file, in every service, forever: connections, JetStream contexts, subscription bindings, metrics label values, cached Nautobot and Redis clients. Miss one and it fails silently. A restart replaces all of it at once, and it is the remedy we already reach for by hand.

The watch covers all twelve long-lived services, not only the NATS ones. The same INI carries auth, OIDC, Nautobot, config store, DHCP and Temporal settings, and `NautobotConnectionManager` has the identical staleness problem as the NATS singleton beside it.

Two details this depends on:

- **The trigger is a hash of the contents, not the file metadata.** Kubernetes and Vault Agent both rewrite these files on their own schedules, and the replacement arrives with a new inode and new timestamps. Watching metadata would restart services that have nothing new to read.
- **The shutdown is delayed by a random interval, up to 20s.** Every replica reads the same file and notices within the same window, so without it all of them would exit together. A Deployment rollout gets that ordering from `maxUnavailable`; a self-exit has to arrange it.

It reuses `SIGTERM` rather than introducing a second kind of exit, so each service takes the shutdown path it already takes when Kubernetes replaces a pod. The log line names the settings that moved, never their values, so an operator can tell why a pod restarted without credentials reaching the logs.

## Verified in a cluster

The whole design rests on the mounted Secret actually being updated in place, so I measured it rather than assuming it.

In qa01 the INI is an ESO-owned Secret (`refreshInterval: 300s`, content-hash annotated) mounted as a whole directory, so it uses the Kubernetes atomic writer with a `..data` symlink and no `subPath`, which is the precondition for kubelet propagation.

Then in a kind cluster, patching the Secret behind a mounted INI put the new contents in front of a running process **33 seconds later**: the inode moved, the parse cache invalidated itself, and the process read the new value including a newly added `password` key.

Worst case end to end under `eso` is roughly six minutes, ESO's 300s refresh plus propagation plus jitter. Fine for a credential rotation; a stream rename you need immediately is still faster to fix by restarting the pods.

## Also here

**`fix(temporal)`** — every workflow with `ArchiveMixin` publishes its result to NATS as its last act, and the activity re-raised broker errors with no retries, so a NATS problem turned a run that had already done its work into a failed workflow. That is how an authorization error during the cutover took out every workflow QA was running. Publishing stays unconditional, since downstream systems consume these events instead of polling; it is now retried, and exhausting the retries is treated as a lost notification rather than a failed run.

## What this replaces

An earlier revision added a `checksum/nats-ini` annotation to roll pods when NATS values changed, along with a Helm refactor that shared one `[nats]` block across the three secrets renderers. Both were dropped, and the chart is untouched here.

The checksum could not cover the password, which never reaches the chart, and the cluster measurement above showed the rollout was not needed for the values either, since those changes reach a running pod through the same Secret. The dedup was sound on its own but is unrelated to the watcher, so it does not belong in the same review.

## Testing

- 1532 tests pass; ruff and mypy clean
- 8 new watcher tests: rotated password, renamed stream, identical rewrite, unreadable file, the jitter draw, and that changed-key logging never contains a value

## Not addressed

The watch notices a change and restarts; it does not drain first beyond the existing SIGTERM handling. In-flight NATS messages rely on redelivery and in-flight activities on Temporal retries, both of which already happen on any pod replacement.