### PR TITLE
fix(build): preserve tracked build files during clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ clean:
 	find . -type d -name ".ruff_cache" -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name "dist" -exec rm -rf {} + 2>/dev/null || true
-	find . -type d -name "build" -exec rm -rf {} + 2>/dev/null || true
+	find . -mindepth 2 -type d -name "build" -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name ".cache" -exec rm -rf {} + 2>/dev/null || true
 
 # UI targets


### PR DESCRIPTION
## Description

Update `make clean` to avoid deleting the `build/` directory.

## Validation

```
➜  nv-config-manager git:(rheffernan/preserve-root-build-on-clean) ls build
configure-apt-mirror.sh      kea-admin                    kea.Dockerfile               nautobot-test.Dockerfile     nv-config-manager.Dockerfile temporal.Dockerfile
kea                          kea-admin.Dockerfile         nats-ready.Dockerfile        nautobot.Dockerfile          setup.stork.deb.sh           ui.Dockerfile
➜  nv-config-manager git:(rheffernan/preserve-root-build-on-clean) make clean
find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
find . -type d -name ".mypy_cache" -exec rm -rf {} + 2>/dev/null || true
find . -type d -name ".ruff_cache" -exec rm -rf {} + 2>/dev/null || true
find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
find . -type d -name "dist" -exec rm -rf {} + 2>/dev/null || true
find . -mindepth 2 -type d -name "build" -exec rm -rf {} + 2>/dev/null || true
find . -type d -name ".cache" -exec rm -rf {} + 2>/dev/null || true
➜  nv-config-manager git:(rheffernan/preserve-root-build-on-clean) ls build
configure-apt-mirror.sh      kea-admin                    kea.Dockerfile               nautobot-test.Dockerfile     nv-config-manager.Dockerfile temporal.Dockerfile
kea                          kea-admin.Dockerfile         nats-ready.Dockerfile        nautobot.Dockerfile          setup.stork.deb.sh           ui.Dockerfile
```

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Makefile change, no need to run kind

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup behavior to remove only nested build directories, helping preserve top-level build directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->