### PR TITLE
fix(build): refresh local Nautobot packages

### DIFF
--- a/build/nautobot.Dockerfile
+++ b/build/nautobot.Dockerfile
@@ -49,7 +49,8 @@ COPY nautobot_config.py /opt/nautobot/nautobot_config.py
 COPY nv_config_manager_jobs /opt/nautobot/jobs/nv_config_manager_jobs
 COPY nv_config_manager_auth /opt/nautobot/nv_config_manager_auth
 
-# Create venv and install dependencies (--no-editable ensures packages are in site-packages)
+# Create venv and install dependencies (--no-editable ensures packages are in site-packages).
+# Refresh local path packages so the shared BuildKit cache cannot reuse wheels built from older source.
 RUN uv venv /opt/nautobot/.venv
 RUN --mount=type=cache,id=nvcm-uv-cache,target=/root/.cache/uv \
     set -eux; \
@@ -61,7 +62,9 @@ RUN --mount=type=cache,id=nvcm-uv-cache,target=/root/.cache/uv \
         export SETUPTOOLS_SCM_PRETEND_VERSION="$NAUTOBOT_NV_CONFIG_MANAGER_VERSION"; \
         export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NAUTOBOT_NV_CONFIG_MANAGER="$NAUTOBOT_NV_CONFIG_MANAGER_VERSION"; \
     fi; \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --frozen --no-dev --no-editable \
+        --refresh-package nautobot-app-overlays \
+        --refresh-package nautobot-nv-config-manager
 
 RUN mkdir -p /opt/nautobot/static \
     /opt/nautobot/media \


### PR DESCRIPTION
## Description

Ensure to refresh the local Nautobot image builds so they can't install stale `nautobot-app-overlays` or
`nautobot-nv-config-manager` code after those path dependencies change.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run because this change is isolated to Nautobot image construction. The
Nautobot builder target was built using the same shared `nvcm-uv-cache`; its output showed both
local packages being rebuilt. SHA-256 checks confirmed that the installed `tables.py` and
`nv_config_manager/__init__.py` files exactly matched the current source files.

```text
docker build --provenance=false --progress=plain \
  --build-context scripts=build/ --target builder \
  -t nv-config-manager-nautobot:uv-cache-fix-builder \
  -f build/nautobot.Dockerfile components/nautobot
```

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
      The focused Docker builder validation exercises the affected cache and package-install path.
- [x] Documentation is updated for user-facing behavior changes.
      No documentation change is needed for this build-only correction.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.
      No generated artifacts are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build reliability by refreshing local packages during dependency synchronization.
  * Updated build documentation comments to clarify local package path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->