### PR TITLE
fix(ztp): pool object-storage and Config Store clients

### DIFF
--- a/src/nv_config_manager/ztp/api/device_v1.py
+++ b/src/nv_config_manager/ztp/api/device_v1.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """V1 Device API Endpoints."""
 
+import aiohttp
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
@@ -23,6 +24,11 @@ from nv_config_manager.common.client import ConfigStoreException, ConfigStoreFil
 from nv_config_manager.common.config import get_storage_client, temporal_client
 from nv_config_manager.common.log import LogCategory, get_logger
 from nv_config_manager.ztp.api.schemas import ChecksumResponse
+from nv_config_manager.ztp.api.storage_clients import (
+    StorageUnavailableError,
+    get_object_storage_client,
+    guarded_storage,
+)
 from nv_config_manager.ztp.api.streaming import create_object_storage_streaming_response
 from nv_config_manager.ztp.nautobot import NautobotClient, NotFoundError
 from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
@@ -30,6 +36,24 @@ from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
 logger = get_logger(__name__, category=LogCategory.ZTP_API)
 
 router = APIRouter(prefix="/device", tags=["device"], responses={404: {"description": "Not found"}})
+
+# HTTP statuses the Config Store client itself retries; if one still surfaces it
+# means the backend is transiently unhealthy, so treat it as retryable (503).
+_CONFIG_STORE_RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
+
+
+def _config_store_error_is_transient(exc: ConfigStoreException) -> bool:
+    """Return True if a ConfigStoreException stems from a transient backend blip.
+
+    The Config Store client wraps the underlying failure as the ``__cause__``:
+    a raw ``aiohttp.ClientError`` (connection reset/disconnect/timeout) is always
+    transient, while a ``ClientResponseError`` is transient only for retryable
+    5xx/429 statuses (a 4xx is a genuine client error and stays a 500).
+    """
+    cause = exc.__cause__
+    if isinstance(cause, aiohttp.ClientResponseError):
+        return cause.status in _CONFIG_STORE_RETRYABLE_STATUSES
+    return isinstance(cause, aiohttp.ClientError)
 
 
 async def _authorize_request(request: Request, device_uuid: str) -> None:
@@ -97,6 +121,12 @@ async def load_configuration(
     except (NotFoundError, ConfigStoreFileNotFound) as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ConfigStoreException as exc:
+        # A transient Config Store blip (connection reset/disconnect, or a 5xx/429
+        # that outlived the client's own retries) should shed as a retryable 503
+        # so the device retries, not masquerade as a hard 500. Genuine errors
+        # (e.g. a 4xx) stay 500.
+        if _config_store_error_is_transient(exc):
+            raise StorageUnavailableError(str(exc)) from exc
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
@@ -144,12 +174,11 @@ async def load_firmware_checksum(device_uuid: str, request: Request) -> Checksum
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-    storage_client = get_storage_client()
+    storage_client = await get_object_storage_client()
     try:
-        async with storage_client:
-            checksum = await storage_client.get_firmware_checksum(
-                device_data.platform, device_data.version
-            )
+        checksum = await guarded_storage(
+            lambda: storage_client.get_firmware_checksum(device_data.platform, device_data.version)
+        )
         return ChecksumResponse(checksum=checksum)
     except ObjectStorageNotFoundException as exc:
         raise HTTPException(status_code=404, detail="Firmware image not found in S3.") from exc

--- a/src/nv_config_manager/ztp/api/firmware_v1.py
+++ b/src/nv_config_manager/ztp/api/firmware_v1.py
@@ -20,6 +20,7 @@ from fastapi.responses import StreamingResponse
 from nv_config_manager.common.config import get_storage_client
 from nv_config_manager.common.log import LogCategory, get_logger
 from nv_config_manager.ztp.api.schemas import ChecksumResponse
+from nv_config_manager.ztp.api.storage_clients import get_object_storage_client, guarded_storage
 from nv_config_manager.ztp.api.streaming import create_object_storage_streaming_response
 from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
 
@@ -53,10 +54,11 @@ async def load_firmware(platform: str, version: str, request: Request) -> Stream
 @router.get("/{platform}/{version}/checksum")
 async def load_firmware_checksum(platform: str, version: str) -> ChecksumResponse:
     """Load the firmware checksum by platform and version."""
-    storage_client = get_storage_client()
+    storage_client = await get_object_storage_client()
     try:
-        async with storage_client:
-            checksum = await storage_client.get_firmware_checksum(platform, version)
+        checksum = await guarded_storage(
+            lambda: storage_client.get_firmware_checksum(platform, version)
+        )
         return ChecksumResponse(checksum=checksum)
     except ObjectStorageNotFoundException as exc:
         raise HTTPException(status_code=404, detail="Firmware image not found in S3.") from exc

--- a/src/nv_config_manager/ztp/api/main.py
+++ b/src/nv_config_manager/ztp/api/main.py
@@ -17,9 +17,12 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import PlainTextResponse
 from prometheus_fastapi_instrumentator import Instrumentator, metrics
 
 from nv_config_manager.common.auth import install_identity_probe
@@ -31,6 +34,11 @@ from nv_config_manager.common.telemetry import (
 )
 from nv_config_manager.ztp.api import device_v1, files_v1, firmware_v1
 from nv_config_manager.ztp.api.metrics import device_http_requests
+from nv_config_manager.ztp.api.storage_clients import (
+    StorageUnavailableError,
+    close_storage_clients,
+    warm_storage_clients,
+)
 
 configure_logging(service="ztp")
 setup_tracing("ztp")
@@ -58,8 +66,35 @@ def main() -> None:
     )
 
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Pre-connect the shared object-storage client; close pooled clients on shutdown."""
+    await warm_storage_clients()
+    try:
+        yield
+    finally:
+        await close_storage_clients()
+
+
+app = FastAPI(lifespan=lifespan)
 instrument_fastapi_app(app)
+
+
+@app.exception_handler(StorageUnavailableError)
+async def _storage_unavailable_handler(
+    _request: Request, exc: StorageUnavailableError
+) -> PlainTextResponse:
+    """Surface object-storage / Config Store backpressure as a retryable 503.
+
+    Sheds load fast (rather than letting per-request S3/Config Store I/O pile up
+    on the event loop) so a device/ONIE backs off and retries its boot.
+    """
+    return PlainTextResponse(
+        str(exc) or "Storage temporarily unavailable.",
+        status_code=503,
+        headers={"Retry-After": "5"},
+    )
+
 
 # Include routers
 app.include_router(device_v1.router, prefix="/v1")

--- a/src/nv_config_manager/ztp/api/storage_clients.py
+++ b/src/nv_config_manager/ztp/api/storage_clients.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared, process-wide storage + Config Store clients for the ZTP API.
+
+Why this exists
+---------------
+Device-facing handlers used to build a fresh client *per request*:
+
+* ``get_storage_client()`` created a new :class:`S3Client` each call — a new
+  ``aioboto3.Session`` plus a ``connect()`` that resolves credentials (IRSA →
+  STS on first use) and opens a brand-new connection pool. Measured at ~139ms
+  of event-loop CPU per request on an idle pod.
+* ``DeviceData.config_store_client()`` created a new
+  :class:`ConfigStoreClient` each call — and its ``__init__`` builds a new
+  ``aiohttp.TCPConnector`` + SSL context every time, so nothing is reused.
+
+That setup work runs on ZTP's single asyncio event loop. Under a boot storm
+it is a large fraction of each lap, which is what made ``/healthcheck`` miss
+its probe timeout even when S3 and Config Store themselves were fine.
+
+Streaming firmware/ONIE/files still use the per-request ``get_storage_client()``
+path: the streaming helper takes ownership of the client and closes it when
+the response finishes, so pointing those endpoints at the shared client
+without a lifecycle change would close the pool mid-flight.
+
+What this provides
+------------------
+* A single, pre-connected object-storage client reused across requests
+  (keepalive + a real pool cap instead of one pool per request).
+* Config Store clients cached per endpoint (connector/pool reuse).
+* A bounded concurrency semaphore + short per-op timeout so a saturated or
+  stuck storage/Config Store call sheds load fast as a retryable
+  :class:`StorageUnavailableError` (surfaced as HTTP 503 ``Retry-After``)
+  instead of accumulating on the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from nv_config_manager.common.client import ConfigStoreClient
+from nv_config_manager.common.config import get_storage_client as _build_storage_client
+from nv_config_manager.common.config import load_config
+from nv_config_manager.common.log import LogCategory, get_logger
+
+if TYPE_CHECKING:
+    from nv_config_manager.ztp.device import DeviceData
+    from nv_config_manager.ztp.storage import ObjectStorageClient
+
+logger = get_logger(__name__, category=LogCategory.ZTP_API)
+
+# Bound the number of in-flight storage/Config Store operations so ZTP applies
+# backpressure instead of opening unbounded I/O during a boot storm. Callers
+# that cannot get a slot within the acquire timeout, or whose op exceeds the op
+# timeout, get a fast StorageUnavailableError (HTTP 503) rather than piling up.
+_MAX_CONCURRENCY = 40
+_ACQUIRE_TIMEOUT = 3.0
+_OP_TIMEOUT = 8.0
+
+_semaphore = asyncio.Semaphore(_MAX_CONCURRENCY)
+
+_object_storage_client: ObjectStorageClient | None = None
+_object_storage_lock = asyncio.Lock()
+_config_store_clients: dict[str, ConfigStoreClient] = {}
+
+
+class StorageUnavailableError(Exception):
+    """Object storage / Config Store is saturated or too slow; retry shortly."""
+
+
+async def guarded_storage[T](
+    factory: Callable[[], Awaitable[T]],
+    *,
+    op_timeout: float = _OP_TIMEOUT,
+) -> T:
+    """Run a storage/Config Store coroutine under backpressure + a short timeout.
+
+    Takes a factory (not a coroutine) so the underlying request is only created
+    once a slot is admitted. Semaphore saturation or a timeout is translated
+    into a retryable :class:`StorageUnavailableError` (HTTP 503); every other
+    exception (e.g. NotFound) propagates unchanged so real 404s stay 404s.
+    """
+    try:
+        await asyncio.wait_for(_semaphore.acquire(), timeout=_ACQUIRE_TIMEOUT)
+    except TimeoutError as exc:
+        raise StorageUnavailableError(
+            "Storage backend busy (backpressure); retry shortly."
+        ) from exc
+    try:
+        async with asyncio.timeout(op_timeout):
+            return await factory()
+    except TimeoutError as exc:
+        raise StorageUnavailableError(
+            "Storage backend slow or unavailable; retry shortly."
+        ) from exc
+    finally:
+        _semaphore.release()
+
+
+async def get_object_storage_client() -> ObjectStorageClient:
+    """Return the process-wide, pre-connected object storage client.
+
+    Created and connected lazily behind a lock so concurrent first requests
+    don't each build (and leak) their own client. Safe to share: the underlying
+    aiobotocore client multiplexes concurrent calls over its connection pool.
+    """
+    global _object_storage_client
+    if _object_storage_client is not None:
+        return _object_storage_client
+    async with _object_storage_lock:
+        if _object_storage_client is None:
+            client = _build_storage_client()
+            await client.connect()
+            _object_storage_client = client
+    return _object_storage_client
+
+
+def _config_store_key(device_data: DeviceData) -> str:
+    """Cache key for a device's Config Store client.
+
+    Internal-endpoint deployments (all devices share one service URL) collapse
+    to a single client; external mTLS deployments key by per-device endpoint so
+    each distinct Config Store instance gets its own pooled client.
+    """
+    cfg = load_config()
+    if cfg.getboolean("config_store.client", "use_internal_endpoint", fallback=False):
+        return "internal"
+    return device_data.config_store_instance or "default"
+
+
+def get_config_store_client(device_data: DeviceData) -> ConfigStoreClient:
+    """Return a shared Config Store client for this device's endpoint.
+
+    Reuses one client (and its connection pool) per distinct endpoint instead
+    of building a new connector + SSL context on every ``load_file`` call.
+    """
+    key = _config_store_key(device_data)
+    client = _config_store_clients.get(key)
+    if client is None:
+        client = device_data.config_store_client()
+        _config_store_clients[key] = client
+    return client
+
+
+async def warm_storage_clients() -> None:
+    """Best-effort pre-connect of the object storage client on app startup.
+
+    Failures are logged and swallowed so the app still starts (e.g. in envs
+    without S3 credentials); the client will be built lazily on first request.
+    """
+    try:
+        await get_object_storage_client()
+    except Exception as exc:  # noqa: BLE001 - startup warming must never crash boot
+        logger.warning("Could not pre-connect object storage client at startup: %s", exc)
+
+
+async def close_storage_clients() -> None:
+    """Close all shared storage + Config Store clients (called on app shutdown)."""
+    global _object_storage_client
+    if _object_storage_client is not None:
+        try:
+            await _object_storage_client.close()
+        finally:
+            _object_storage_client = None
+    for client in _config_store_clients.values():
+        try:
+            await client.close()
+        except Exception as exc:  # noqa: BLE001 - shutdown cleanup is best-effort
+            logger.warning("Error closing Config Store client: %s", exc)
+    _config_store_clients.clear()
+
+
+def reset_storage_clients() -> None:
+    """Drop shared clients without awaiting (test isolation helper)."""
+    global _object_storage_client
+    _object_storage_client = None
+    _config_store_clients.clear()

--- a/src/nv_config_manager/ztp/device.py
+++ b/src/nv_config_manager/ztp/device.py
@@ -25,6 +25,7 @@ from nv_config_manager.common.client import (
     ConfigStoreFileNotFound,
 )
 from nv_config_manager.common.config import get_internal_auth_headers, load_config
+from nv_config_manager.ztp.api.storage_clients import get_config_store_client, guarded_storage
 
 
 @dataclass
@@ -98,9 +99,11 @@ class DeviceData:  # pylint: disable=too-many-instance-attributes
         if self.config_store_instance is None:
             raise ConfigStoreFileNotFound(f"No config store file found for device {self.name}")
 
-        client = self.config_store_client()
-        async with client:
-            config_file = await client.load_file(self.id, filename)
+        # Shared Config Store client (pooled connector + backpressure) rather
+        # than building/closing a fresh client per call, which under load piles
+        # TCP+TLS handshakes and coroutines onto the event loop.
+        client = get_config_store_client(self)
+        config_file = await guarded_storage(lambda: client.load_file(self.id, filename))
         return config_file.content
 
     @staticmethod

--- a/src/tests/ztp/api/test_main.py
+++ b/src/tests/ztp/api/test_main.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import aiohttp
 import pytest
 from fastapi.testclient import TestClient
 
@@ -26,6 +27,7 @@ from nv_config_manager.common.client import (
     ConfigStoreFileNotFound,
 )
 from nv_config_manager.ztp.api.main import app
+from nv_config_manager.ztp.api.storage_clients import StorageUnavailableError
 from nv_config_manager.ztp.s3 import (
     S3ExistsException,
     S3NotFoundException,
@@ -285,7 +287,8 @@ def test_device_v1_firmware_checksum(mock_device_data, mock_not_found_data, clie
         mock_s3_class.return_value = mock_s3_instance
 
         with patch(
-            "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
+            "nv_config_manager.ztp.api.device_v1.get_object_storage_client",
+            new=AsyncMock(return_value=mock_s3_instance),
         ):
             rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
             assert rsp.status_code == 200
@@ -295,7 +298,8 @@ def test_device_v1_firmware_checksum(mock_device_data, mock_not_found_data, clie
         mock_s3_instance.get_firmware_checksum = AsyncMock(side_effect=S3NotFoundException())
 
         with patch(
-            "nv_config_manager.ztp.api.device_v1.get_storage_client", return_value=mock_s3_instance
+            "nv_config_manager.ztp.api.device_v1.get_object_storage_client",
+            new=AsyncMock(return_value=mock_s3_instance),
         ):
             rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
             assert rsp.status_code == 404
@@ -306,6 +310,25 @@ def test_device_v1_firmware_checksum(mock_device_data, mock_not_found_data, clie
     ):
         rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 404
+
+
+def test_device_v1_firmware_checksum_returns_503_when_storage_unavailable(mock_device_data, client):
+    """Storage backpressure/timeout surfaces to devices as a retryable 503."""
+    mock_s3_instance = MagicMock()
+    mock_s3_instance.get_firmware_checksum = AsyncMock(
+        side_effect=StorageUnavailableError("storage busy")
+    )
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        return_value=mock_device_data,
+    ):
+        with patch(
+            "nv_config_manager.ztp.api.device_v1.get_object_storage_client",
+            new=AsyncMock(return_value=mock_s3_instance),
+        ):
+            rsp = client.get(f"/v1/device/{uuid4()}/firmware/checksum", headers=SSO_HEADERS)
+            assert rsp.status_code == 503
+            assert rsp.headers["retry-after"] == "5"
 
 
 @patch("nv_config_manager.ztp.api.device_v1.Request.client")
@@ -334,6 +357,52 @@ def test_device_v1_config_store_exceptions(mock_request_client, mock_device_data
             rsp = client.get(f"/v1/device/{uuid4()}/boot-script")
             assert rsp.json() == {"detail": "config store query error"}
             assert rsp.status_code == 500
+
+
+@patch("nv_config_manager.ztp.api.device_v1.Request.client")
+def test_device_v1_config_store_transient_error_returns_503(
+    mock_request_client, mock_device_data, client
+):
+    """A transient Config Store blip sheds as a retryable 503, not a hard 500."""
+    mock_request_client.host = "testclient"
+    mock_device_data["data"]["config_manager_device"]["device"]["interfaces"] = [
+        {"ip_addresses": [{"host": "testclient"}]}
+    ]
+
+    def _wrapped(cause: Exception | None) -> ConfigStoreException:
+        exc = ConfigStoreException("transient config store failure")
+        exc.__cause__ = cause
+        return exc
+
+    transient_causes = [
+        aiohttp.ClientConnectionError("connection reset"),
+        aiohttp.ClientResponseError(MagicMock(), (), status=503),
+    ]
+    permanent_causes: list[Exception | None] = [
+        aiohttp.ClientResponseError(MagicMock(), (), status=400),
+        None,
+    ]
+
+    with patch(
+        "nv_config_manager.ztp.nautobot.NautobotClient.graphql_query",
+        return_value=mock_device_data,
+    ):
+        for cause in transient_causes:
+            with patch(
+                "nv_config_manager.ztp.device.DeviceData.load_file",
+                side_effect=_wrapped(cause),
+            ):
+                rsp = client.get(f"/v1/device/{uuid4()}/config/startup.yaml")
+                assert rsp.status_code == 503
+                assert rsp.headers["retry-after"] == "5"
+
+        for cause in permanent_causes:
+            with patch(
+                "nv_config_manager.ztp.device.DeviceData.load_file",
+                side_effect=_wrapped(cause),
+            ):
+                rsp = client.get(f"/v1/device/{uuid4()}/config/startup.yaml")
+                assert rsp.status_code == 500
 
 
 @patch("nv_config_manager.ztp.api.device_v1.Request.client")
@@ -511,7 +580,8 @@ def test_v1_firmware_checksum(client):
     mock_s3_class.return_value = mock_s3_instance
 
     with patch(
-        "nv_config_manager.ztp.api.firmware_v1.get_storage_client", return_value=mock_s3_instance
+        "nv_config_manager.ztp.api.firmware_v1.get_object_storage_client",
+        new=AsyncMock(return_value=mock_s3_instance),
     ):
         rsp = client.get("/v1/firmware/arista_eos/4.29.3M/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 200
@@ -521,7 +591,8 @@ def test_v1_firmware_checksum(client):
     mock_s3_instance.get_firmware_checksum = AsyncMock(side_effect=S3NotFoundException())
 
     with patch(
-        "nv_config_manager.ztp.api.firmware_v1.get_storage_client", return_value=mock_s3_instance
+        "nv_config_manager.ztp.api.firmware_v1.get_object_storage_client",
+        new=AsyncMock(return_value=mock_s3_instance),
     ):
         rsp = client.get("/v1/firmware/arista_eos/4.29.3M/checksum", headers=SSO_HEADERS)
         assert rsp.status_code == 404

--- a/src/tests/ztp/api/test_storage_clients.py
+++ b/src/tests/ztp/api/test_storage_clients.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the shared ZTP storage / Config Store clients + backpressure."""
+
+import asyncio
+
+import pytest
+
+from nv_config_manager.ztp.api import storage_clients
+from nv_config_manager.ztp.api.storage_clients import (
+    StorageUnavailableError,
+    guarded_storage,
+)
+from nv_config_manager.ztp.s3 import S3NotFoundException
+
+
+async def test_guarded_storage_returns_value():
+    """A fast op returns its value unchanged through the guard."""
+
+    async def factory() -> str:
+        return "ok"
+
+    assert await guarded_storage(factory) == "ok"
+
+
+async def test_guarded_storage_timeout_raises_unavailable():
+    """An op that exceeds the op timeout is shed as a retryable 503-mapped error."""
+
+    async def slow() -> str:
+        await asyncio.sleep(0.2)
+        return "never"
+
+    with pytest.raises(StorageUnavailableError):
+        await guarded_storage(slow, op_timeout=0.01)
+
+
+async def test_guarded_storage_propagates_logical_errors():
+    """NotFound (a real answer) propagates unchanged — it must stay a 404, not 503."""
+
+    async def missing() -> str:
+        raise S3NotFoundException("nope")
+
+    with pytest.raises(S3NotFoundException):
+        await guarded_storage(missing)
+
+
+async def test_guarded_storage_backpressure_sheds_when_saturated(monkeypatch):
+    """When all concurrency slots are held, a new op fails fast as unavailable."""
+    # Drain the semaphore to 0 permits and use a tiny acquire timeout so the
+    # test is fast and deterministic.
+    monkeypatch.setattr(storage_clients, "_ACQUIRE_TIMEOUT", 0.01)
+    sem = asyncio.Semaphore(1)
+    await sem.acquire()  # now 0 permits available
+    monkeypatch.setattr(storage_clients, "_semaphore", sem)
+
+    async def factory() -> str:
+        return "ok"
+
+    with pytest.raises(StorageUnavailableError):
+        await guarded_storage(factory)

--- a/src/tests/ztp/conftest.py
+++ b/src/tests/ztp/conftest.py
@@ -19,8 +19,18 @@ import os
 
 import pytest
 
+from nv_config_manager.ztp.api import storage_clients
+
 # Get the directory containing this conftest.py
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_storage_clients():
+    """Drop process-wide storage/Config Store clients between tests."""
+    storage_clients.reset_storage_clients()
+    yield
+    storage_clients.reset_storage_clients()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Split out of #125. Independent of #228 (probe timings).

ZTP was building a new S3 client on every checksum/config request (~139ms of event-loop CPU to construct an aiobotocore session and connect) and a new Config Store client on every `load_file` (new `aiohttp` connector + SSL context). That setup runs on the same asyncio loop that answers `/healthcheck`. Pooling it is the measured way to take work off that loop; Nautobot was never the bottleneck those tests were hitting.

This PR:

- Adds a process-wide object-storage client (lazy connect, warmed at startup) and Config Store clients cached per endpoint.
- Bounds in-flight storage/Config Store ops (`max` 40, 3s acquire, 8s op) and maps saturation/timeouts to `StorageUnavailableError`.
- Surfaces that as HTTP **503 `Retry-After: 5`** so devices retry.
- Maps transient Config Store failures (connection errors, 429/5xx that outlived the client's own retries) to the same 503. Genuine 4xx stay 500.

**Not in this PR:** streaming firmware/ONIE/files still call `get_storage_client()` per request. The streaming helper takes ownership and closes the client when the response finishes; pointing those endpoints at the shared client without a lifecycle change would close the pool mid-flight. Follow-up after this lands.

Also not here: Nautobot cache/limiter/breaker (#125), probe timings (#228).

## Validation

- [x] Standard CI passes.
- [ ] Kind integration passes, or this PR explains why it was not run.

`uv run ruff check` on the touched files. `uv run pytest src/tests/ztp/` — 119 passed. Kind is not needed for this: unit tests cover pooling backpressure, 404-vs-503, and Config Store transient vs permanent errors.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [ ] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared, managed storage connections for improved reliability and performance.
  * Added startup and shutdown handling for storage services.
  * Added bounded concurrency and timeout protection for storage operations.

* **Bug Fixes**
  * Transient storage and Config Store failures now return HTTP 503 responses with retry guidance.
  * Permanent and logical storage errors continue to return appropriate error responses.
  * Firmware checksum retrieval now handles temporary storage unavailability consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->