### PR TITLE
fix(build): Bump distroless Python runtime images

### DIFF
--- a/build/nautobot.Dockerfile
+++ b/build/nautobot.Dockerfile
@@ -78,7 +78,7 @@ RUN mkdir -p /opt/nautobot/static \
 # =============================================================================
 # Runtime stage - NVIDIA distroless Python
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/python:3.11-v4.0.8
+FROM nvcr.io/nvidia/distroless/python:3.11-v4.0.9
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/build/nv-config-manager.Dockerfile
+++ b/build/nv-config-manager.Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=type=cache,id=nvcm-uv-cache,target=/root/.cache/uv \
 # =============================================================================
 # Runtime stage - NVIDIA distroless Python
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.8
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.9
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Description

Update the NVIDIA distroless Python runtime images used by the NVIDIA Config Manager and Nautobot containers from v4.0.8 to v4.0.9.

The v4.0.9 images include Expat 2.8.2, resolving CVE-2026-45186, CVE-2025-59375, and CVE-2026-25210 inherited from the prior runtime images.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`95ab8df`](https://github.com/NVIDIA/nv-config-manager/commit/95ab8df2f0224c91b957370358fada3a1beb8e3b) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/31755097986).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application runtime environment to a newer NVIDIA-supported Python base image.
  - Updated the configuration manager runtime environment to a newer NVIDIA-supported Python base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->