### PR TITLE
fix(scripts): Shell script sonar nits

### DIFF
--- a/.gitlab/ci/scripts/pr_ref_guard.sh
+++ b/.gitlab/ci/scripts/pr_ref_guard.sh
@@ -31,11 +31,11 @@ mirror_head="$(
     timeout 30s git ls-remote "$CI_REPOSITORY_URL" "refs/heads/${ref}" |
         cut -f1
 )"
-if [ -z "$mirror_head" ]; then
+if [[ -z "$mirror_head" ]]; then
     echo "ERROR: ${ref} no longer exists on the mirror (PR closed or merged?)"
     exit 1
 fi
-if [ "$mirror_head" != "$expected" ]; then
+if [[ "$mirror_head" != "$expected" ]]; then
     echo "ERROR: stale SHA - mirror ${ref} is at ${mirror_head}, expected ${expected}."
     echo "The PR gained commits since this run was scheduled; re-run against the new HEAD."
     exit 1

--- a/.gitlab/ci/scripts/promote_build_pipeline.sh
+++ b/.gitlab/ci/scripts/promote_build_pipeline.sh
@@ -72,7 +72,7 @@ api_get() {
 # live HEAD - the GitHub PR-HEAD comparison below surfaces any divergence.
 # -----------------------------------------------------------------------------
 PR_SHA="$(git ls-remote "$CI_REPOSITORY_URL" "refs/heads/${PR_REF}" | cut -f1)"
-if [ -z "$PR_SHA" ]; then
+if [[ -z "$PR_SHA" ]]; then
     echo "ERROR: ${PR_REF} does not exist on the mirror."
     echo "Either the PR is closed/merged, copy-pr-bot has not vetted it, or"
     echo "pull-mirroring has not replicated the branch yet."
@@ -88,9 +88,9 @@ echo "Promote version: ${PROMOTE_VERSION}"
 # pull-request/<n> branch (PR_SHA above), which is a VETTED SNAPSHOT that may
 # lag the PR (untrusted authors only re-copy on /ok to test).
 pr_json="$(curl -fsS --max-time 10 "https://api.github.com/repos/${github_repo}/pulls/${PR_NUM}" || true)"
-if [ -n "$pr_json" ]; then
+if [[ -n "$pr_json" ]]; then
     pr_state="$(printf '%s' "$pr_json" | jq -r '.state // empty')"
-    if [ "$pr_state" != "open" ]; then
+    if [[ "$pr_state" != "open" ]]; then
         echo "ERROR: upstream PR #${PR_NUM} is '${pr_state:-unknown}', not open. Refusing to promote."
         exit 1
     fi
@@ -99,16 +99,16 @@ if [ -n "$pr_json" ]; then
     # commits are unvetted and must not run - but the operator must know when
     # what deploys is not their latest push.
     pr_head_sha="$(printf '%s' "$pr_json" | jq -r '.head.sha // empty')"
-    if [ -n "$pr_head_sha" ] && [ "$pr_head_sha" != "$PR_SHA" ]; then
+    if [[ -n "$pr_head_sha" && "$pr_head_sha" != "$PR_SHA" ]]; then
         echo "WARN: PR #${PR_NUM} HEAD is ${pr_head_sha}, but the vetted copy-pr-bot"
         echo "      snapshot (pull-request/${PR_NUM}) is ${PR_SHA}. Promoting the VETTED"
         echo "      snapshot; to deploy newer commits, have them re-vetted (/ok to test)."
-        if [ "${NVCM_PROMOTE_REQUIRE_PR_HEAD:-false}" = "true" ]; then
+        if [[ "${NVCM_PROMOTE_REQUIRE_PR_HEAD:-false}" = "true" ]]; then
             echo "ERROR: NVCM_PROMOTE_REQUIRE_PR_HEAD=true and the snapshot lags PR HEAD."
             exit 1
         fi
     fi
-elif [ "${NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE:-false}" = "true" ]; then
+elif [[ "${NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE:-false}" = "true" ]]; then
     echo "WARN: could not query GitHub PR state; NVCM_PROMOTE_ALLOW_UNVERIFIED_PR_STATE=true set, continuing."
 else
     # Fail closed: don't promote a possibly-closed PR just because GitHub was
@@ -123,14 +123,14 @@ bash "$(dirname "$0")/pr_ref_guard.sh" "$PR_REF" "$PR_SHA"
 # Reuse an existing successful build for this exact ref+SHA, if allowed.
 # -----------------------------------------------------------------------------
 BUILD_PIPELINE_ID=""
-if [ "${NVCM_PROMOTE_REUSE_BUILD:-true}" != "false" ]; then
+if [[ "${NVCM_PROMOTE_REUSE_BUILD:-true}" != "false" ]]; then
     # Consider several recent successes, not just the newest: a pipeline with a
     # disallowed source would be rejected by the provenance gate below, which
     # would dead-end the promote instead of falling through to a fresh trigger.
     BUILD_PIPELINE_ID="$(api_get "${api}/pipelines?ref=$(printf '%s' "$PR_REF" | sed 's|/|%2F|g')&sha=${PR_SHA}&status=success&order_by=id&sort=desc&per_page=20" \
         | jq -r --argjson allowed "$allowed_build_sources" \
             '[.[] | select(.source as $s | $allowed | index($s))] | sort_by(.id) | last | .id // empty')"
-    if [ -n "$BUILD_PIPELINE_ID" ]; then
+    if [[ -n "$BUILD_PIPELINE_ID" ]]; then
         echo "Found existing successful build pipeline ${BUILD_PIPELINE_ID} for ${PR_SHA}; will verify its artifacts."
     fi
 fi
@@ -140,7 +140,7 @@ fi
 # Uses a pipeline trigger token (NVCM_BUILD_TRIGGER_TOKEN): GitLab returns 422
 # for a job token triggering its own project. NO variables are passed.
 # -----------------------------------------------------------------------------
-if [ -z "$BUILD_PIPELINE_ID" ]; then
+if [[ -z "$BUILD_PIPELINE_ID" ]]; then
     : "${NVCM_BUILD_TRIGGER_TOKEN:?NVCM_BUILD_TRIGGER_TOKEN required to trigger a build (Settings > CI/CD > Pipeline triggers)}"
     echo "Triggering build pipeline on ${PR_REF}..."
     # No `-f`: it suppresses the response body on an HTTP error and, under
@@ -158,7 +158,7 @@ if [ -z "$BUILD_PIPELINE_ID" ]; then
     trigger_http="$(printf '%s' "$trigger_raw" | tail -n 1)"
     trigger_response="$(printf '%s' "$trigger_raw" | sed '$d')"
     BUILD_PIPELINE_ID="$(printf '%s' "$trigger_response" | jq -r '.id // empty' 2>/dev/null || true)"
-    if [ -z "$BUILD_PIPELINE_ID" ]; then
+    if [[ -z "$BUILD_PIPELINE_ID" ]]; then
         echo "ERROR: failed to trigger build pipeline (HTTP ${trigger_http:-000}):"
         printf '%s\n' "$trigger_response"
         echo ""
@@ -188,7 +188,7 @@ if [ -z "$BUILD_PIPELINE_ID" ]; then
                 exit 1
                 ;;
             *)
-                if [ "$elapsed" -ge "$poll_timeout" ]; then
+                if [[ "$elapsed" -ge "$poll_timeout" ]]; then
                     echo "ERROR: timed out after ${poll_timeout}s waiting for build pipeline ${BUILD_PIPELINE_ID} (status: ${status})."
                     exit 1
                 fi
@@ -211,7 +211,7 @@ build_sha="$(printf '%s' "$build_pipeline_json" | jq -r '.sha')"
 build_ref="$(printf '%s' "$build_pipeline_json" | jq -r '.ref')"
 build_status="$(printf '%s' "$build_pipeline_json" | jq -r '.status')"
 build_source="$(printf '%s' "$build_pipeline_json" | jq -r '.source')"
-if [ "$build_sha" != "$PR_SHA" ] || [ "$build_ref" != "$PR_REF" ] || [ "$build_status" != "success" ]; then
+if [[ "$build_sha" != "$PR_SHA" || "$build_ref" != "$PR_REF" || "$build_status" != "success" ]]; then
     echo "ERROR: build pipeline ${BUILD_PIPELINE_ID} provenance mismatch."
     echo "  got ref=${build_ref} sha=${build_sha} status=${build_status}"
     echo "  expected ref=${PR_REF} sha=${PR_SHA} status=success"
@@ -244,15 +244,15 @@ now_epoch="$(date -u +%s)"
 while IFS='|' read -r target image; do
     job_name="pr-build-image: [${target}, ${image}]"
     job_json="$(printf '%s' "$jobs_json" | jq -c --arg name "$job_name" '[.[] | select(.name == $name and .status == "success")] | sort_by(.id) | last // empty')"
-    if [ -z "$job_json" ] || [ "$job_json" = "null" ]; then
+    if [[ -z "$job_json" || "$job_json" = "null" ]]; then
         echo "ERROR: no successful '${job_name}' job in pipeline ${BUILD_PIPELINE_ID}."
         exit 1
     fi
     job_id="$(printf '%s' "$job_json" | jq -r '.id')"
     expires_at="$(printf '%s' "$job_json" | jq -r '.artifacts_expire_at // empty')"
-    if [ -n "$expires_at" ]; then
+    if [[ -n "$expires_at" ]]; then
         expire_epoch="$(date -u -d "$expires_at" +%s 2>/dev/null || date -u -D "%Y-%m-%dT%H:%M:%S" -d "${expires_at%%.*}" +%s 2>/dev/null || echo 0)"
-        if [ "$expire_epoch" != "0" ] && [ "$expire_epoch" -le "$now_epoch" ]; then
+        if [[ "$expire_epoch" != "0" && "$expire_epoch" -le "$now_epoch" ]]; then
             echo "ERROR: artifacts of job ${job_id} (${job_name}) have expired."
             echo "Re-run with NVCM_PROMOTE_REUSE_BUILD=false to force a fresh build."
             exit 1
@@ -269,7 +269,7 @@ EOF
 # so the promote pipeline can download the .tgz and publish it without ever
 # rebuilding from PR source.
 chart_job_id="$(printf '%s' "$jobs_json" | jq -r '[.[] | select(.name == "pr-build-chart" and .status == "success")] | sort_by(.id) | last | .id // empty')"
-if [ -z "$chart_job_id" ]; then
+if [[ -z "$chart_job_id" ]]; then
     echo "ERROR: no successful 'pr-build-chart' job in pipeline ${BUILD_PIPELINE_ID}."
     exit 1
 fi

--- a/.gitlab/ci/scripts/promote_push_images.sh
+++ b/.gitlab/ci/scripts/promote_push_images.sh
@@ -30,11 +30,11 @@ api="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}"
 # same-named variable could otherwise redirect which job's artifacts are
 # downloaded (BUILD_JOB_ID_*) or change the tag images are pushed under.
 promote_attest="${CI_PROJECT_DIR}/promote.env"
-[ -f "$promote_attest" ] || { echo "ERROR: missing attestation artifact ${promote_attest}"; exit 1; }
+[[ -f "$promote_attest" ]] || { echo "ERROR: missing attestation artifact ${promote_attest}"; exit 1; }
 attest() {
     local key="$1" val
     val="$(grep -m1 "^${key}=" "$promote_attest" | cut -d= -f2- || true)"
-    [ -n "$val" ] || { echo "ERROR: ${key} missing from promote.env"; exit 1; }
+    [[ -n "$val" ]] || { echo "ERROR: ${key} missing from promote.env"; exit 1; }
     printf '%s' "$val"
 }
 
@@ -74,7 +74,7 @@ for image in $images; do
     # source or eval anything under $workdir here: this job holds registry
     # credentials, so executing untrusted build output would leak them.
     tar_file="${workdir}/images/${image}.tar.gz"
-    if [ ! -f "$tar_file" ]; then
+    if [[ ! -f "$tar_file" ]]; then
         echo "ERROR: job ${job_id} artifacts do not contain ${image}.tar.gz"
         ls -laR "$workdir" || true
         exit 1
@@ -95,7 +95,7 @@ for image in $images; do
     # a non-matching grep would abort the script here, making the fallback (and
     # the validation below) unreachable.
     digest="$(docker buildx imagetools inspect "$dst" --format '{{json .Manifest}}' 2>/dev/null | grep -o '"digest": *"sha256:[0-9a-f]*"' | head -n 1 | cut -d'"' -f4 || true)"
-    if [ -z "$digest" ]; then
+    if [[ -z "$digest" ]]; then
         echo "  imagetools inspect yielded no digest; falling back to docker inspect"
         digest="$(docker inspect --format '{{index .RepoDigests 0}}' "$dst" 2>/dev/null | cut -d@ -f2 || true)"
     fi

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -41,13 +41,13 @@ promote_attest="${CI_PROJECT_DIR}/promote.env"
 chart_attest="${CI_PROJECT_DIR}/chart.env"
 digest_attest="${CI_PROJECT_DIR}/digests.env"
 for f in "$promote_attest" "$chart_attest" "$digest_attest"; do
-    [ -f "$f" ] || { echo "ERROR: missing attestation artifact ${f}"; exit 1; }
+    [[ -f "$f" ]] || { echo "ERROR: missing attestation artifact ${f}"; exit 1; }
 done
 
 attest() {
     local key="$1" file="$2" val
     val="$(grep -m1 "^${key}=" "$file" | cut -d= -f2- || true)"
-    [ -n "$val" ] || { echo "ERROR: ${key} missing from $(basename "$file")"; exit 1; }
+    [[ -n "$val" ]] || { echo "ERROR: ${key} missing from $(basename "$file")"; exit 1; }
     printf '%s' "$val"
 }
 
@@ -66,7 +66,7 @@ DIGEST_NV_CONFIG_MANAGER_TEMPORAL="$(attest DIGEST_NV_CONFIG_MANAGER_TEMPORAL "$
 DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP="$(attest DIGEST_NV_CONFIG_MANAGER_TEMPORAL_BOOTSTRAP "$digest_attest")"
 DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI="$(attest DIGEST_NV_CONFIG_MANAGER_TEMPORAL_UI "$digest_attest")"
 
-if [ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]; then
+if [[ -n "${NV_CONFIG_MANAGER_VALUES_REPO_URL:-}" ]]; then
     # A full URL override is used as-is (provide any auth it needs in the URL).
     values_repo_url="$NV_CONFIG_MANAGER_VALUES_REPO_URL"
     # Credential-free label for logs: strip any "userinfo@" (e.g. oauth2:token@)
@@ -98,7 +98,7 @@ else
     exit 1
 fi
 
-if [ ! -f "$state_file" ]; then
+if [[ ! -f "$state_file" ]]; then
     echo "ERROR: ${state_file} not found on ${NVCM_ENV_BRANCH}; the env is not seeded."
     exit 1
 fi
@@ -109,7 +109,7 @@ fi
 # change in between. Refuse to write deploy-state against overrides that were
 # never validated - fail closed and let the operator re-run.
 current_env_rev="$(git rev-parse HEAD)"
-if [ "$current_env_rev" != "$ENV_BRANCH_REVISION" ]; then
+if [[ "$current_env_rev" != "$ENV_BRANCH_REVISION" ]]; then
     echo "ERROR: ${NVCM_ENV_BRANCH} moved since the render gate validated it."
     echo "  validated: ${ENV_BRANCH_REVISION}"
     echo "  current:   ${current_env_rev}"
@@ -121,7 +121,7 @@ fi
 # Honor a manual hold: an occupant who set hold: true is protecting the slot.
 current_hold=$(yq -r '.hold // false' "$state_file")
 current_occupant=$(yq -r '.occupant // "none"' "$state_file")
-if [ "$current_hold" = "true" ] && [ "$current_occupant" != "$occupant" ]; then
+if [[ "$current_hold" = "true" && "$current_occupant" != "$occupant" ]]; then
     echo "ERROR: ${NVCM_ENV} is on hold by '${current_occupant}' (deploy-state hold: true)."
     echo "Coordinate with them or have them release the hold before promoting."
     exit 1
@@ -202,6 +202,6 @@ echo ""
 echo "Deploy-state committed. ArgoCD will sync ${NVCM_ENV} to chart ${PROMOTE_VERSION} with digest-pinned images."
 # Only build the web view URL from a known project path - a full-URL override
 # has no clean path and could otherwise produce a malformed/credential URL.
-if [ -n "$values_repo_path" ]; then
+if [[ -n "$values_repo_path" ]]; then
     echo "View: https://${CI_SERVER_HOST}/${values_repo_path}/-/commits/${NVCM_ENV_BRANCH}"
 fi

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -91,6 +91,9 @@ if [[ "$SIGNING_ENABLED" == "true" || -n "$SIGNING_KEY" || -n "$SIGNING_FORMAT" 
                     SIGNING_READY="true"
                 fi
                 ;;
+            *)
+                echo "Unsupported cryptographic commit signing format: $SIGNING_FORMAT."
+                ;;
         esac
     fi
 


### PR DESCRIPTION
## Description

Address sonar maintainability nits for shell scripts.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of build promotion, image publishing, deployment-state validation, and reference checks.
  * Unsupported cryptographic signing formats now produce a clear error and do not indicate signing readiness.

* **Chores**
  * Standardized validation behavior across automation scripts without changing existing workflows or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->