### PR TITLE
fix(build): Bump nats-ready to Go 1.26.6

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -237,11 +237,13 @@ jobs:
         uses: *setup_proxy_cache
       - uses: &actions_setup_go actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version-file: components/nats-ready/go.mod
+          go-version: "1.26.6"
           cache-dependency-path: components/nats-ready/go.sum
       - name: Verify go.mod is tidy
         working-directory: components/nats-ready
         run: |
+          go_version="$(go env GOVERSION)"
+          test "${go_version}" = "go1.26.6"
           go mod tidy
           git diff --exit-code -- go.mod go.sum
 

--- a/build/nats-ready.Dockerfile
+++ b/build/nats-ready.Dockerfile
@@ -12,9 +12,9 @@ ARG APT_MIRROR=""
 ARG APT_MIRROR_GPG_KEY_URL=""
 
 # Official SHA256 checksums from https://go.dev/dl/
-ARG GO_VERSION=1.26.4
-ARG GO_SHA256_AMD64=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f
-ARG GO_SHA256_ARM64=ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768
+ARG GO_VERSION=1.26.6
+ARG GO_SHA256_AMD64=708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89
+ARG GO_SHA256_ARM64=d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e
 
 # Install Go with checksum verification
 COPY --from=scripts configure-apt-mirror.sh /tmp/configure-apt-mirror.sh

--- a/components/nats-ready/go.mod
+++ b/components/nats-ready/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nv-config-manager/components/nats-ready
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.6
 
 require (
 	github.com/nats-io/nats.go v1.47.0


### PR DESCRIPTION
## Description

Bump the Go toolchain used to build `nv-config-manager-nats-ready` from Go 1.26.4 to Go 1.26.6. Resolves CVE-2026-39822 and CVE-2026-42505


## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`17ec855`](https://github.com/NVIDIA/nv-config-manager/commit/17ec855f031f1769110c5df062ec997691e95311) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/31763393905).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain used to build and validate the application to version 1.26.6.
  * Refreshed platform-specific build verification checks for the updated toolchain.
  * Added explicit version validation to help ensure consistent builds across development and continuous integration environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->