### PR TITLE
fix(workflows): suppress redundant tenant backup drift notification

### DIFF
--- a/bindings/go/internal/clienttest/generated_models_test.go
+++ b/bindings/go/internal/clienttest/generated_models_test.go
@@ -33,10 +33,11 @@ func TestGeneratedDeviceCableValidationInputDocumentsDevice(t *testing.T) {
 
 func TestGeneratedBackupInputDocumentsOptionalMetadata(t *testing.T) {
 	expected := map[string]string{
-		"IntendedConfigCommitId": "Config Store commit containing the intended configuration.",
-		"User":                   "User that requested the backup.",
-		"UserDomain":             "Domain of the user requesting the backup.",
-		"WorkflowId":             "Identifier of the parent workflow, if any.",
+		"IntendedConfigCommitId":    "Config Store commit containing the intended configuration.",
+		"SuppressDriftNotification": "Suppress the Slack notification when configuration drift is detected.",
+		"User":                      "User that requested the backup.",
+		"UserDomain":                "Domain of the user requesting the backup.",
+		"WorkflowId":                "Identifier of the parent workflow, if any.",
 	}
 	comments := generatedStructFieldComments(t, "model_backup_input.go")
 	for field, expectedComment := range expected {

--- a/bindings/go/temporal/model_backup_input.go
+++ b/bindings/go/temporal/model_backup_input.go
@@ -25,6 +25,8 @@ type BackupInput struct {
 	DeviceId string `json:"device_id"`
 	// Config Store commit containing the intended configuration.
 	IntendedConfigCommitId NullableString `json:"intended_config_commit_id,omitempty"`
+	// Suppress the Slack notification when configuration drift is detected.
+	SuppressDriftNotification *bool `json:"suppress_drift_notification,omitempty"`
 	// Terminate the workflow instead of waiting to retry a failed stage.
 	TerminateOnFailure *bool `json:"terminate_on_failure,omitempty"`
 	// Reason the backup workflow was started.
@@ -46,6 +48,8 @@ type _BackupInput BackupInput
 func NewBackupInput(deviceId string, trigger TriggerEnum) *BackupInput {
 	this := BackupInput{}
 	this.DeviceId = deviceId
+	var suppressDriftNotification bool = false
+	this.SuppressDriftNotification = &suppressDriftNotification
 	var terminateOnFailure bool = false
 	this.TerminateOnFailure = &terminateOnFailure
 	this.Trigger = trigger
@@ -57,6 +61,8 @@ func NewBackupInput(deviceId string, trigger TriggerEnum) *BackupInput {
 // but it doesn't guarantee that properties required by API are set
 func NewBackupInputWithDefaults() *BackupInput {
 	this := BackupInput{}
+	var suppressDriftNotification bool = false
+	this.SuppressDriftNotification = &suppressDriftNotification
 	var terminateOnFailure bool = false
 	this.TerminateOnFailure = &terminateOnFailure
 	return &this
@@ -129,6 +135,39 @@ func (o *BackupInput) SetIntendedConfigCommitIdNil() {
 // UnsetIntendedConfigCommitId ensures that no value is present for IntendedConfigCommitId, not even an explicit nil
 func (o *BackupInput) UnsetIntendedConfigCommitId() {
 	o.IntendedConfigCommitId.Unset()
+}
+
+// GetSuppressDriftNotification returns the SuppressDriftNotification field value if set, zero value otherwise.
+func (o *BackupInput) GetSuppressDriftNotification() bool {
+	if o == nil || IsNil(o.SuppressDriftNotification) {
+		var ret bool
+		return ret
+	}
+	return *o.SuppressDriftNotification
+}
+
+// GetSuppressDriftNotificationOk returns a tuple with the SuppressDriftNotification field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+
+func (o *BackupInput) GetSuppressDriftNotificationOk() (*bool, bool) {
+	if o == nil || IsNil(o.SuppressDriftNotification) {
+		return nil, false
+	}
+	return o.SuppressDriftNotification, true
+}
+
+// HasSuppressDriftNotification returns a boolean if a field has been set.
+func (o *BackupInput) HasSuppressDriftNotification() bool {
+	if o != nil && !IsNil(o.SuppressDriftNotification) {
+		return true
+	}
+
+	return false
+}
+
+// SetSuppressDriftNotification gets a reference to the given bool and assigns it to the SuppressDriftNotification field.
+func (o *BackupInput) SetSuppressDriftNotification(v bool) {
+	o.SuppressDriftNotification = &v
 }
 
 // GetTerminateOnFailure returns the TerminateOnFailure field value if set, zero value otherwise.
@@ -336,6 +375,9 @@ func (o BackupInput) ToMap() (map[string]interface{}, error) {
 	toSerialize["device_id"] = o.DeviceId
 	if o.IntendedConfigCommitId.IsSet() {
 		toSerialize["intended_config_commit_id"] = o.IntendedConfigCommitId.Get()
+	}
+	if !IsNil(o.SuppressDriftNotification) {
+		toSerialize["suppress_drift_notification"] = o.SuppressDriftNotification
 	}
 	if !IsNil(o.TerminateOnFailure) {
 		toSerialize["terminate_on_failure"] = o.TerminateOnFailure

--- a/docs/api-specs/temporal.openapi.json
+++ b/docs/api-specs/temporal.openapi.json
@@ -21,6 +21,12 @@
             "description": "Config Store commit containing the intended configuration.",
             "title": "Intended Config Commit Id"
           },
+          "suppress_drift_notification": {
+            "default": false,
+            "description": "Suppress the Slack notification when configuration drift is detected.",
+            "title": "Suppress Drift Notification",
+            "type": "boolean"
+          },
           "terminate_on_failure": {
             "default": false,
             "description": "Terminate the workflow instead of waiting to retry a failed stage.",

--- a/src/nv_config_manager/temporal/ngc/workflows/backup.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/backup.py
@@ -86,6 +86,10 @@ class BackupInput(StageWorkflowInput):
     intended_config_commit_id: str | None = Field(
         default=None, description="Config Store commit containing the intended configuration."
     )
+    suppress_drift_notification: bool = Field(
+        default=False,
+        description="Suppress the Slack notification when configuration drift is detected.",
+    )
 
 
 @workflow.defn
@@ -166,6 +170,7 @@ class BackupWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, ArchiveMixi
 
         device_id: str
         intended_config_commit_id: str | None
+        suppress_drift_notification: bool
 
     class CheckDriftStageOutput(StageOutput):
         """Check Drift Stage Output."""
@@ -214,16 +219,16 @@ class BackupWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, ArchiveMixi
             markdown = "No drift detected between running and intended configuration."
         else:
             markdown = f"Configuration Drift Detected:\n```\n{diff}\n```"
-            # Alert in slack while we're here!
-            await workflow.execute_activity(
-                send_slack_message,
-                SlackMessageInput(
-                    message=f"Configuration Drift Detected on {result.device.name}, see workflow link for details.",
-                    link_workflow=True,
-                ),
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-            )
+            if not stage_input.suppress_drift_notification:
+                await workflow.execute_activity(
+                    send_slack_message,
+                    SlackMessageInput(
+                        message=f"Configuration Drift Detected on {result.device.name}, see workflow link for details.",
+                        link_workflow=True,
+                    ),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+                )
         config_path = result.device.intended_config_path
         markdown = f"Loaded intended configuration from [{config_path}]({url}).\n{markdown}"
 
@@ -304,6 +309,7 @@ class BackupWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, ArchiveMixi
                 BackupWorkflow.CheckDriftStageInput(
                     device_id=workflow_input.device_id,
                     intended_config_commit_id=workflow_input.intended_config_commit_id,
+                    suppress_drift_notification=workflow_input.suppress_drift_notification,
                 )
             ),
         )

--- a/src/nv_config_manager/temporal/ngc/workflows/deploy.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/deploy.py
@@ -722,6 +722,7 @@ class TenantDeployWorkflow(WorkflowMetadataMixin, StageMixin, DeviceMixin, Archi
             user="nv-config-manager-temporal",
             user_domain=None,
             workflow_id=workflow.info().workflow_id,
+            suppress_drift_notification=True,
         )
 
         backup_handle = await workflow.start_child_workflow(

--- a/src/tests/temporal/ngc/workflows/test_backup_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_backup_workflow.py
@@ -17,7 +17,7 @@
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from temporalio import activity
@@ -53,6 +53,7 @@ def test_backup_input_optional_metadata_defaults_to_none() -> None:
     assert workflow_input.user_domain is None
     assert workflow_input.workflow_id is None
     assert workflow_input.intended_config_commit_id is None
+    assert workflow_input.suppress_drift_notification is False
     assert workflow_input.terminate_on_failure is False
     assert BackupInput.model_json_schema()["required"] == ["device_id", "trigger"]
 
@@ -138,6 +139,47 @@ async def mock_publish_nats(activity_input: PublishNatsInput) -> None:
 
 
 @pytest.mark.asyncio
+async def test_check_drift_suppresses_slack_notification() -> None:
+    device = await mock_get_network_device(GetNetworkDeviceInput(device_id="mock_device_uuid"))
+    with patch(
+        "nv_config_manager.temporal.common.mixins.stage.workflow.time",
+        return_value=0.0,
+    ):
+        workflow_instance = BackupWorkflow()
+    execute_activity = AsyncMock(
+        side_effect=[
+            device,
+            (
+                "mock intended config",
+                "mock_intended_commit_id",
+                "https://config-manager.example.com/device/mock_device_uuid/startup.yaml",
+            ),
+            "mock_diff",
+        ]
+    )
+
+    with patch(
+        "nv_config_manager.temporal.ngc.workflows.backup.workflow.execute_activity",
+        new=execute_activity,
+    ):
+        output = await BackupWorkflow.check_drift.__wrapped__(  # type: ignore[attr-defined]
+            workflow_instance,
+            BackupWorkflow.CheckDriftStageInput(
+                device_id="mock_device_uuid",
+                intended_config_commit_id=None,
+                suppress_drift_notification=True,
+            ),
+        )
+
+    assert output.has_drift is True
+    assert [call.args[0].__name__ for call in execute_activity.await_args_list] == [
+        "get_network_device",
+        "load_intended_configuration",
+        "perform_candidate_diff",
+    ]
+
+
+@pytest.mark.asyncio
 @patch("nv_config_manager.temporal.common.mixins.stage.workflow.time", return_value=float(0))
 @patch(
     "nv_config_manager.temporal.ngc.workflows.backup.DEFAULT_ACTIVITY_RETRY_POLICY",
@@ -187,6 +229,13 @@ async def test_execute_workflow(
         result = await handle.result()
 
         assert result
+        history = await handle.fetch_history()
+        scheduled_activity_types = {
+            event.activity_task_scheduled_event_attributes.activity_type.name
+            for event in history.events
+            if event.HasField("activity_task_scheduled_event_attributes")
+        }
+        assert "send_slack_message" in scheduled_activity_types
         assert await handle.query("stages") == [
             {
                 "approval_threshold": 0,
@@ -247,6 +296,7 @@ async def test_execute_workflow(
                 "input": {
                     "device_id": "mock_device_uuid",
                     "intended_config_commit_id": None,
+                    "suppress_drift_notification": False,
                 },
                 "name": "check_drift",
                 "output": {

--- a/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_deploy_workflow.py
@@ -504,6 +504,13 @@ async def test_execute_workflow(
 
         backup_workflow_id = stages[-1]["child_workflows"][0]
         backup_handle = client.get_workflow_handle(backup_workflow_id)
+        backup_history = await backup_handle.fetch_history()
+        scheduled_activity_types = {
+            event.activity_task_scheduled_event_attributes.activity_type.name
+            for event in backup_history.events
+            if event.HasField("activity_task_scheduled_event_attributes")
+        }
+        assert "send_slack_message" not in scheduled_activity_types
 
         expected_backup_stages = [
             {
@@ -565,6 +572,7 @@ async def test_execute_workflow(
                 "input": {
                     "device_id": "mock_device_uuid",
                     "intended_config_commit_id": "mock_commit_id",
+                    "suppress_drift_notification": False,
                 },
                 "name": "check_drift",
                 "output": {
@@ -652,6 +660,7 @@ async def test_execute_workflow(
         expected_backup_input = {
             "device_id": "mock_device_uuid",
             "intended_config_commit_id": "mock_commit_id",
+            "suppress_drift_notification": False,
             "terminate_on_failure": False,
             "trigger": "WORKFLOW",
             "user": "nv-config-manager-temporal",
@@ -1213,6 +1222,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
                 "input": {
                     "device_id": "mock_device_uuid",
                     "intended_config_commit_id": None,
+                    "suppress_drift_notification": True,
                 },
                 "name": "check_drift",
                 "output": {
@@ -1302,6 +1312,7 @@ nv set vrf test-ryan-2 router bgp router-id 172.28.0.2
         expected_backup_input = {
             "device_id": "mock_device_uuid",
             "intended_config_commit_id": None,
+            "suppress_drift_notification": True,
             "terminate_on_failure": False,
             "trigger": "WORKFLOW",
             "user": "nv-config-manager-temporal",
@@ -1576,6 +1587,7 @@ nv set interface swp2 ip vrf test-vrf
         backup_handle = client.get_workflow_handle(backup_workflow_id)
         backup_input = await backup_handle.query("input")
         assert backup_input["intended_config_commit_id"] is None
+        assert backup_input["suppress_drift_notification"] is True
 
     # Reset state for other tests
     _newer_commit_mock_state["use_newer_commit"] = False


### PR DESCRIPTION
## Description

Add an optional backup-workflow flag and set it for tenant-deploy child backups so expected partial-deployment drift does not resend the Slack notification. Other backup triggers keep the existing notification behavior.

## Validation
- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Deployed to sim, confirmed in the temporal UI event history for the workflow that `send_slack_message` doesn't execute when drift occurs during the tenant deploy workflow, but does execute for a direct backup workflow invocation.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`53d8308`](https://github.com/NVIDIA/nv-config-manager/commit/53d8308e6512a2814a66213cfe8365ff6a43faba) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/31819336180).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to suppress Slack notifications for configuration drift during backups.
  * Tenant deployment backups now suppress drift notifications by default.
  * The option is available through backup inputs and API specifications.

* **Bug Fixes**
  * Drift detection continues to run even when notifications are suppressed.

* **Tests**
  * Added coverage verifying notification behavior and option propagation across backup and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->