### PR TITLE
fix(build): Bump UI Nano ID to 3.3.18

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8267,9 +8267,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Description

Bump the UI's Nano ID lockfile resolution from 3.3.16 to 3.3.18, resolves `GHSA-2v37-7h3g-55p8+nanoid` in the production UI image. 

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`f15cde8`](https://github.com/NVIDIA/nv-config-manager/commit/f15cde834b84f37da22f9a7bc8791d7dcdd4f952) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/32046219781).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. No user-facing behavior changed.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs. No generated artifacts are affected.
