### PR TITLE
fix(build): bump Temporal builders to Go 1.26.6

### DIFF
--- a/build/temporal.Dockerfile
+++ b/build/temporal.Dockerfile
@@ -17,7 +17,7 @@ FROM temporalio/server:${TEMPORAL_SERVER_VERSION} AS server-upstream
 FROM temporalio/admin-tools:${TEMPORAL_ADMIN_TOOLS_VERSION} AS admin-tools-upstream
 FROM temporalio/ui:${TEMPORAL_UI_VERSION} AS ui-upstream
 
-FROM golang:1.26.5-alpine AS bootstrap-builder
+FROM golang:1.26.6-alpine AS bootstrap-builder
 WORKDIR /src
 COPY components/temporal/go.mod ./
 COPY components/temporal/cmd/ ./cmd/
@@ -26,14 +26,14 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/temporal-bootstrap
 # Rebuild the version-matched UI server until an upstream release includes the
 # patched Go toolchain and dependency versions. The released module contains
 # the same embedded frontend assets as the upstream image.
-FROM golang:1.26.5-alpine AS ui-server-builder
+FROM golang:1.26.6-alpine AS ui-server-builder
 ARG TEMPORAL_UI_VERSION
 WORKDIR /src
 RUN go mod download github.com/temporalio/ui-server/v2@v${TEMPORAL_UI_VERSION} && \
     cp -R /go/pkg/mod/github.com/temporalio/ui-server/v2@v${TEMPORAL_UI_VERSION}/. . && \
     chmod -R u+w . && \
-    go get golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+    go get golang.org/x/crypto@v0.53.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/ui-server ./cmd/server/main.go


### PR DESCRIPTION
## Description

Resolve remaining pulse scan vulnerabilities.

- Update both project-owned Temporal builder stages from Go 1.26.5 to Go 1.26.6.
- Update golang.org/x/net from v0.55.0 to v0.56.0
- Updategolang.org/x/crypto from v0.52.0 to v0.53.0.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run because this change only updates compile-time Go
and module versions. The complete set of Temporal images was built locally,
including the rebuilt bootstrap and UI binaries.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.

There are no user-facing behavior, documentation, or generated-artifact changes.
