### PR TITLE
fix(cnpg): use valid 6-field cron in default backup schedules

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -2371,7 +2371,7 @@ cnpg:
       topologyKey: kubernetes.io/hostname
     backup:
       enabled: false
-      schedule: "0 0 * * *" # Daily at midnight
+      schedule: "0 0 0 * * *" # Daily at midnight; CNPG cron takes 6 fields (leading seconds)
       retentionPolicy: "30d"
       target: preferStandby # preferStandby or primary
   # Temporal visibility database cluster
@@ -2402,7 +2402,7 @@ cnpg:
       topologyKey: kubernetes.io/hostname
     backup:
       enabled: false
-      schedule: "0 0 * * *"
+      schedule: "0 0 0 * * *"
       retentionPolicy: "30d"
       target: preferStandby
   # Config Store Service database cluster
@@ -2433,7 +2433,7 @@ cnpg:
       topologyKey: kubernetes.io/hostname
     backup:
       enabled: false
-      schedule: "0 0 * * *"
+      schedule: "0 0 0 * * *"
       retentionPolicy: "30d" # Config store may need longer retention
       target: preferStandby
   # DHCP database cluster
@@ -2464,7 +2464,7 @@ cnpg:
       topologyKey: kubernetes.io/hostname
     backup:
       enabled: false
-      schedule: "0 0 * * *"
+      schedule: "0 0 0 * * *"
       retentionPolicy: "30d"
       target: preferStandby
   # Nautobot PostgreSQL cluster (when nautobot.enabled=true)
@@ -2496,7 +2496,7 @@ cnpg:
       topologyKey: kubernetes.io/hostname
     backup:
       enabled: false
-      schedule: "0 0 * * *"
+      schedule: "0 0 0 * * *"
       retentionPolicy: "30d"
       target: preferStandby
 # =============================================================================


### PR DESCRIPTION
## Description

CNPG parses `ScheduledBackup.spec.schedule` as a **six-field** cron with a leading seconds
field. The chart shipped all five CNPG backup defaults as:

```yaml
schedule: "0 0 * * *" # Daily at midnight
```

That is a five-field expression, so the comment is wrong on two counts: CNPG will not accept
it, and it reads as a plausible standard-cron example. An operator who pads it to six fields
by *appending* rather than prepending gets `"0 <N> * * * *"`, which fires **hourly** at minute
`N`, not daily at hour `N`.

This change makes all five defaults (`temporal`, `temporalVisibility`, `configStore`, `dhcp`,
`nautobot`) `"0 0 0 * * *"`, and the comment now names the seconds field. All five remain
`enabled: false`, so **no rendered output changes** — this only stops the chart from handing
operators a broken example.

### Why it matters

This is not hypothetical: it is what happened across the CFA cells. Of the 16 cells that have
CNPG backups enabled, **11 carried a padded five-field expression** and had been taking hourly
backups — 24x the intended rate. The resulting `Backup` CR pileup (~17k objects across the
`kiwi-*` namespaces) grew the `cnpg-system` operator's informer cache until it OOMKilled at its
memory limit, paging out `ngcops-eks` with a CrashLoopBackOff.

For accuracy, the remaining cells were not part of that. `pdx04`, `sjc4`, `ytl-jhb01` and
`pdx01` were already corrected in June (`3b48732`). `sjc11` had been set hourly *deliberately*
in `41a6ef8` to shorten its RPO window, and was moved to daily later as a separate judgement
call, once it was established that WAL archiving already provides an RPO under five minutes
regardless of base backup cadence. `test01` has no backup schedules at all.

The per-cell fixes have all landed:

| change | scope | state |
|---|---|---|
| kiwi-argocd !354 | 8 `main`-tracked CFA overlays | merged |
| kiwi-argocd !356 | `kiwi-test`, which deploys from `nvcm-kiwi-platform-test` | merged |
| kiwi-argocd !358 | `hfa01`, `demo01`, `kiwi-qa01`, `sjc11` | merged |
| cerebro !1664 | operator memory limit 500Mi -> 2Gi | merged |
| kiwi-argocd !361 | CI check rejecting sub-daily CNPG schedules | open |

It took four passes to clear because each one started from whichever cluster was paging and
worked inward to the files, rather than auditing the repo. A repo-wide audit of all 17 cells,
each on the branch it actually deploys from, now shows every schedule daily. This PR fixes the
upstream source so the mistake stops being re-introduced, and !361 adds the gate that would
have caught it in a single pass.

### Upstream reference

CloudNativePG **v1.23** docs — [Backup → Scheduled backups](https://cloudnative-pg.io/documentation/1.23/backup/).
Pinned to 1.23 because that matches the operator actually deployed
(`ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2`).

> The `schedule` field allows you to define a six-term cron schedule specification, which
> includes seconds, as expressed in the [Go `cron` package format](https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format).

> **Warning:** Beware that this format accepts also the `seconds` field, and it is different
> from the `crontab` format in Unix/Linux systems.

Upstream uses `"0 0 0 * * *"` as its canonical daily-at-midnight example — the exact value this
PR moves to — and then names the trap directly:

> In Kubernetes CronJobs, the equivalent expression is `0 0 * * *` because seconds are not
> included.

That is precisely the string the chart was shipping, under a `# Daily at midnight` comment: the
Kubernetes CronJob spelling, in a field that is not a Kubernetes CronJob. Upstream also notes it
is *"extremely rare to schedule backups more frequently than once a day"*, and that WAL archiving
alone provides *"an RPO <= 5 minutes"* — so base backup frequency drives RTO, not RPO.

### Note for reviewers

The defaults deliberately all sit at midnight rather than being staggered, to keep this a pure
syntax fix. Cells that enable more than one backup should stagger by hour as the CFA overlays
do, to avoid concurrent base backups.

## Validation

Rendered the chart against a real cell overlay and confirmed the four `ScheduledBackup` objects
come out daily and staggered:

```
cluster-dhcp-backup                  schedule: "0 0 0 * * *"
cluster-config-store-backup          schedule: "0 0 1 * * *"
cluster-temporal-backup              schedule: "0 0 2 * * *"
cluster-temporal-visibility-backup   schedule: "0 0 3 * * *"
```

Confirmed the change is inert for existing consumers by rendering the same overlay against
`origin/main` and against this branch — the two outputs are byte-identical, since every cell
supplies its own schedule and all five defaults are `enabled: false`.

Also confirmed on-cluster that the equivalent fix behaves as intended: after !358 reached
`ngcops-eks-test`, `kiwi-demo01` produced 5 backups on 2026-08-19 across its staggered hours,
against 120/day while the bug was live.

- [x] Standard CI passes.
- [x] Kind integration passes.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`cd15567`](https://github.com/NVIDIA/nv-config-manager/commit/cd1556779ae93dcd526bf2a286485f23f78c0005) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/32291337464).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] Tests are not added because all five defaults remain `enabled: false`, so there is no
      rendered output to assert against. The equivalent regression guard lives where the bug
      actually occurred: kiwi-argocd !361 fails CI on any CNPG schedule with `*` in the hour
      field, verified to flag the exact overlays !358 fixed and nothing else.
- [x] Documentation is updated: the inline comment now names the seconds field, which is the
      only user-facing surface this value has.
- [x] Generated artifacts are not affected, because the defaults are disabled and
      `helm template` output is byte-identical before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup schedules for Temporal, Temporal Visibility, Config Store, DHCP, and Nautobot clusters to use six-field cron expressions with explicit seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
