### PR TITLE
Require MCP 1.29.0 minimum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dependencies = [
     # Documentation
     "mkdocs>=1.6.1",
     # Model Context Protocol
-    "mcp>=1.28.1,<2",
+    "mcp>=1.29.0,<2",
     # Network Templates (render service)
     "nv-config-manager-templates",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2365,7 +2365,7 @@ requires-dist = [
     { name = "junos-eznc", specifier = ">=2.8.2" },
     { name = "macaddress", specifier = ">=2.0.2" },
     { name = "mako", specifier = ">=1.3.12" },
-    { name = "mcp", specifier = ">=1.28.1,<2" },
+    { name = "mcp", specifier = ">=1.29.0,<2" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "nats-py", extras = ["nkeys"], specifier = ">=2.8.0" },
     { name = "netaddr", specifier = ">=0.10.1" },


### PR DESCRIPTION
## Description

Raise the declared MCP Python SDK minimum from `mcp>=1.28.1,<2` to `mcp>=1.29.0,<2` and update the corresponding lockfile metadata.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] Existing MCP tests cover this metadata adjustment and pass.
- [x] Documentation is not required because there is no user-facing behavior change.
- [x] Generated artifacts are not affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MCP dependency to require version 1.29.0 or later, while remaining below version 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->