### PR TITLE
fix(ci): update test/test01 ci files to maintain baseline snapshot

### DIFF
--- a/.gitlab/ci/README.md
+++ b/.gitlab/ci/README.md
@@ -234,11 +234,32 @@ Runbooks (run pipeline on the default branch):
     to override during a GitHub outage.
 - **Rollback**: set only `NVCM_PROMOTE_ENV`, start `test-rollback-env`. Without
   `NVCM_ROLLBACK_TO` it lists recent deploy-states and fails; re-run with
-  `NVCM_ROLLBACK_TO=<env-branch commit sha>` to restore that exact snapshot
-  (chart version + digests + pinned baseline revision).
+  `NVCM_ROLLBACK_TO=<env-branch commit sha>` to restore that exact snapshot -
+  chart version, digests, and the baseline values that state was rendered
+  against. Both the deploy-state and the baseline snapshot are taken from that
+  one commit, so the restore does not depend on the values repo's `main`.
 - **Free a slot**: set only `NVCM_PROMOTE_ENV`, start `test-release-env`. It
-  resets the env's deploy-state and overrides to the canonicals on the values
-  repo's `main`.
+  resets the env's deploy-state, overrides and baseline snapshot to the
+  canonicals on the values repo's `main`.
+
+### Where the baseline lives
+
+ArgoCD refuses a multi-source Application that references one repository at two
+revisions, so the appset cannot read baseline values from the values repo's
+`main` while reading overrides from the env branch. Everything it renders comes
+from a single revision - the env branch.
+
+The promote pipeline therefore **snapshots** the baseline onto the env branch,
+in the same commit as `deploy-state.yaml`. `main` stays the source of truth
+(humans edit it via MR); the snapshot is what deploys, and it refreshes on every
+promote or release.
+
+Two consequences worth knowing:
+
+- A baseline change merged to the values repo's `main` does not reach an
+  environment until the next promote or release copies it across.
+- `deploy-state.yaml`'s `baselineRevision` is **provenance only** - it records
+  which `main` SHA the snapshot came from. Nothing renders from it.
 
 Project settings required (GitLab UI):
 

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -525,7 +525,8 @@ test-release-env:
   # concurrent runs can't race on the same nvcm-<env> branch.
   resource_group: nvcm-env-$NVCM_PROMOTE_ENV
   before_script:
-    - apk add --no-cache bash git coreutils
+    # yq: the baselineRevision restamp below rewrites the restored deploy-state.
+    - apk add --no-cache bash git yq coreutils
     - git config --global user.email "${CI_PUSH_EMAIL:-ci@nv-config-manager}"
     - git config --global user.name "NVIDIA Config Manager CI"
   script:

--- a/.gitlab/ci/promote-test-envs.yml
+++ b/.gitlab/ci/promote-test-envs.yml
@@ -454,14 +454,24 @@ test-rollback-env:
         echo "       (re-run without NVCM_ROLLBACK_TO to list valid candidates)."
         exit 1
       fi
-      # And it must actually carry this env's deploy-state.
-      if ! git cat-file -e "${NVCM_ROLLBACK_TO}:${state_file}" 2>/dev/null; then
-        echo "ERROR: ${NVCM_ROLLBACK_TO} does not contain ${state_file}."
-        exit 1
-      fi
+      # And it must actually carry this env's deploy-state AND the baseline
+      # snapshot that state was rendered against - both are restored together.
+      baseline_file="${NVCM_ENV_BASELINE_VALUES}"
+      for f in "$state_file" "$baseline_file"; do
+        if ! git cat-file -e "${NVCM_ROLLBACK_TO}:${f}" 2>/dev/null; then
+          echo "ERROR: ${NVCM_ROLLBACK_TO} does not contain ${f}."
+          exit 1
+        fi
+      done
 
       echo "Rolling ${NVCM_PROMOTE_ENV} back to deploy-state @ ${NVCM_ROLLBACK_TO}"
-      git show "${NVCM_ROLLBACK_TO}:${state_file}" > "$state_file"
+      # Restore BOTH files. ArgoCD renders the baseline from this branch (it
+      # rejects a multi-source app referencing one repo at two revisions), so
+      # restoring only deploy-state would pin the old chart and digests against
+      # whatever baseline happens to be on the branch now - a mixed state, not a
+      # rollback. Taking both from the same commit is what makes it exact.
+      git show "${NVCM_ROLLBACK_TO}:${state_file}"    > "$state_file"
+      git show "${NVCM_ROLLBACK_TO}:${baseline_file}" > "$baseline_file"
 
       # Idempotency guard, matching test-release-env and write_deploy_state.sh:
       # if the branch already carries these exact deployment pins, stop rather
@@ -474,8 +484,9 @@ test-rollback-env:
       yq "$strip_audit" "$state_file" > "${CI_PROJECT_DIR}/rollback-new.yaml"
       git show "HEAD:${state_file}" 2>/dev/null \
         | yq "$strip_audit" > "${CI_PROJECT_DIR}/rollback-current.yaml" || true
-      if cmp -s "${CI_PROJECT_DIR}/rollback-current.yaml" "${CI_PROJECT_DIR}/rollback-new.yaml"; then
-        echo "✓ ${NVCM_ENV_BRANCH} already carries the deploy-state from ${NVCM_ROLLBACK_TO}; nothing to roll back."
+      if cmp -s "${CI_PROJECT_DIR}/rollback-current.yaml" "${CI_PROJECT_DIR}/rollback-new.yaml" \
+         && git diff --quiet "$baseline_file"; then
+        echo "✓ ${NVCM_ENV_BRANCH} already carries the deploy-state and baseline from ${NVCM_ROLLBACK_TO}; nothing to roll back."
         exit 0
       fi
 
@@ -486,7 +497,11 @@ test-rollback-env:
       yq -i '.occupant = strenv(occupant) | .updatedAt = strenv(updated_at)' "$state_file"
 
       git diff "$state_file"
-      git add "$state_file"
+      if ! git diff --quiet "$baseline_file"; then
+        echo "Baseline snapshot also restored:"
+        git diff --stat "$baseline_file"
+      fi
+      git add "$state_file" "$baseline_file"
       git commit -m "[nvcm CI] Rollback ${NVCM_PROMOTE_ENV} to deploy-state @ ${NVCM_ROLLBACK_TO}
 
       Triggered by: ${occupant}
@@ -535,13 +550,25 @@ test-release-env:
       git rm -r --quiet --ignore-unmatch "${NVCM_ENV_STATE_DIR}/"
       git checkout origin/main -- "${NVCM_ENV_STATE_DIR}/"
 
+      # Refresh the baseline snapshot too. ArgoCD renders the baseline from this
+      # branch, so leaving a stale snapshot would hand the next occupant a slot
+      # running old baseline config while the deploy-state claims it is clean.
+      baseline_file="${NVCM_ENV_BASELINE_VALUES}"
+      baseline_rev="$(git rev-parse origin/main)"
+      git checkout origin/main -- "$baseline_file"
+      # Keep the restored canonical's provenance honest: it ships a
+      # baselineRevision from whenever it was last edited on main, but the
+      # snapshot beside it now comes from main's current HEAD.
+      export baseline_rev
+      yq -i '.baselineRevision = strenv(baseline_rev)' "${NVCM_ENV_STATE_DIR}/deploy-state.yaml"
+
       if git diff --cached --quiet && git diff --quiet; then
         echo "✓ ${NVCM_PROMOTE_ENV} already matches the canonicals; nothing to release."
         exit 0
       fi
 
-      git add "${NVCM_ENV_STATE_DIR}/"
-      git commit -m "[nvcm CI] Release ${NVCM_PROMOTE_ENV}: reset deploy-state and overrides to canonicals
+      git add "${NVCM_ENV_STATE_DIR}/" "$baseline_file"
+      git commit -m "[nvcm CI] Release ${NVCM_PROMOTE_ENV}: reset deploy-state, overrides and baseline to canonicals
 
       Triggered by: ${GITLAB_USER_LOGIN:-${GITLAB_USER_NAME:-ci}}
       Pipeline: ${CI_PIPELINE_URL}"

--- a/.gitlab/ci/scripts/write_deploy_state.sh
+++ b/.gitlab/ci/scripts/write_deploy_state.sh
@@ -182,15 +182,39 @@ yq -n '
 mv "${state_file}.merged" "$state_file"
 rm -f "${state_file}.new"
 
-if git diff --quiet "$state_file"; then
-    echo "No deploy-state changes; ${NVCM_ENV} is already at ${PROMOTE_VERSION}."
+# Snapshot the blessed baseline onto the env branch, in this same commit.
+#
+# ArgoCD renders every value file for this env from ONE revision of the values
+# repository - it rejects a multi-source Application referencing one repo at two
+# revisions, so the appset cannot read the baseline from main while reading the
+# overrides from the env branch. The baseline therefore has to BE on the branch.
+#
+# Committing it here, alongside deploy-state.yaml, is what keeps rollback exact:
+# re-committing a prior deploy-state also restores the baseline it was rendered
+# against, with no dependency on main's history. baseline_rev stays in
+# deploy-state as provenance recording where this snapshot came from.
+baseline_file="${NVCM_ENV_BASELINE_VALUES}"
+if ! git cat-file -e "${baseline_rev}:${baseline_file}" 2>/dev/null; then
+    echo "ERROR: ${baseline_rev} does not contain ${baseline_file}." >&2
+    echo "The render gate validated against a baseline this commit lacks - refusing"
+    echo "to deploy a baseline that was never validated."
+    exit 1
+fi
+git show "${baseline_rev}:${baseline_file}" > "$baseline_file"
+
+if git diff --quiet "$state_file" "$baseline_file"; then
+    echo "No deploy-state or baseline changes; ${NVCM_ENV} is already at ${PROMOTE_VERSION}."
     exit 0
 fi
 
 echo "Deploy-state diff:"
 git diff "$state_file"
+if ! git diff --quiet "$baseline_file"; then
+    echo "Baseline snapshot diff (from main @ ${baseline_rev}):"
+    git diff --stat "$baseline_file"
+fi
 
-git add "$state_file"
+git add "$state_file" "$baseline_file"
 git commit -m "[nvcm CI] Promote PR #${PR_NUM} (${PROMOTE_VERSION}) to ${NVCM_ENV}
 
 Source commit: ${PR_SHA}


### PR DESCRIPTION
## Description

The non-prod deployment ApplicationSet can no longer read baseline values from the
downstream values repository's `main` while reading overrides from the
environment branch: ArgoCD rejects a multi-source Application that references
one repository at two revisions. Everything it renders now comes from a single
revision — the environment branch — so the baseline has to live there.

That was fixed on the ArgoCD side by pointing the render at a baseline snapshot
on the environment branch. This PR makes the promote pipeline maintain that
snapshot, which it previously knew nothing about.

- **`write_deploy_state.sh`** — copies the baseline from the exact revision the
  render gate validated (`BASELINE_REVISION`, attested in `chart.env`) onto the
  environment branch, in the same commit as `deploy-state.yaml`. Fails closed if
  that revision doesn't carry the file.
- **`test-rollback-env`** — restores the deploy-state *and* the baseline
  snapshot from the target commit. Without this, a rollback pins the old chart
  and digests against whatever baseline happens to be on the branch — a mixed
  state, not a rollback.
- **`test-release-env`** — resets the snapshot to the canonical on the values
  repository's `main` alongside the deploy-state and overrides, and restamps
  `baselineRevision` to the revision it copied from.
- **`.gitlab/ci/README.md`** — rollback/release runbook corrected, plus a short
  section on where the baseline lives and why.

Committing the snapshot beside the deploy-state is what keeps rollback exact:
both come from the same commit, so re-committing a prior state restores the
baseline it was rendered against with no dependency on `main`'s history.
`baselineRevision` stays in the schema as provenance recording where the
snapshot came from; nothing renders from it.

## Validation

- `promote-test-envs.yml` parses; the `test-rollback-env` and `test-release-env`
  script blocks and `write_deploy_state.sh` all pass `bash -n`.
- Confirmed the render gate needs no change: `test-promote-chart` records the
  values-repo `main` revision it validated against, and `write_deploy_state.sh`
  snapshots that same revision — so what is validated is what is deployed.
- Grepped the promote path for other assumptions that the baseline is read from
  `main`; the three above were the only ones, plus a CI validator in the values
  repository fixed separately.

Not exercised end to end yet: promoting or rolling back the shared test
environment before this lands would produce exactly the mixed state this fixes,
so the runtime test comes immediately after merge — promote, promote again,
roll back, and confirm the chart version and the baseline revert together.

- [ ] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.
      GitLab CI only — no application code, chart, or manifest changes, so the
      kind suite exercises nothing this PR touches.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests
      are not needed. These paths only run against the downstream values
      repository from the internal mirror; there is no local harness for them.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rollbacks now reliably restore the complete deployment configuration, including matching chart versions, image digests, and baseline settings.
  * Release operations now reset environments to the approved canonical configuration and refresh associated baseline metadata.
  * Deployment changes validate both configuration and baseline snapshots, avoiding unnecessary updates and ensuring consistent recovery.

* **Documentation**
  * Added guidance explaining configuration snapshots, refresh timing, rollback behavior, and how baseline information is maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->