### PR TITLE
Junos Cable Validation

### DIFF
--- a/docs/temporal/index.mdx
+++ b/docs/temporal/index.mdx
@@ -44,6 +44,7 @@ Streamline data center operations:
 - **Arista EOS**: Complete support for Arista network devices
 - **Cumulus Linux**: Full integration with Cumulus networking
 - **Mellanox/NVIDIA**: Infiniband and Ethernet switch support
+- **Juniper Junos**: Cable validation, configuration backup, and diagnostics
 - **Generic BMC**: Redfish-compatible baseboard management controllers
 
 ## Quick Start

--- a/docs/user-guides/cable-validation/index.mdx
+++ b/docs/user-guides/cable-validation/index.mdx
@@ -84,7 +84,7 @@ Before running cable validation, confirm the following are in place:
 
 - **Devices have completed ZTP** and reached the `Provisioned` (or `Active`) status in Nautobot. Running validation against devices that are still provisioning or unreachable produces noisy failures. See [New Site Bringup](../new-site-deployment/index.mdx) for the bringup sequence.
 - **Intended cabling is captured in Nautobot.** The workflow compares observed state against enabled interfaces and connected endpoints in Nautobot, so the Nautobot data must reflect the design. Use `cable-validation-link-state-only` temporarily when an intended connection should be checked for link state but its far-end identity data is not available. Use `cable-validation-ignore` only for interfaces that are deliberately outside validation scope.
-- **Devices are running a supported platform** — Cumulus Linux, NVOS, or Arista EOS. Devices on other platforms are filtered out automatically.
+- **Devices are running a supported platform** — Cumulus Linux, NVOS, Arista EOS, or Juniper Junos. Devices on other platforms are filtered out automatically.
 - **Network reachability from Config Manager** to every in-scope device's management address, so the workflow can query LLDP neighbors and the MAC/ARP tables.
 
 ## Running site cable validation
@@ -143,7 +143,7 @@ The site workflow runs three stages. None require manual approval.
 
 1. **`get_devices_to_validate` — Resolve the device list from Nautobot.**
 
-   Calls Nautobot for all devices matching the site, role, status, tenant, and device-type filters, then drops anything not on a supported platform (Cumulus Linux, NVOS, Arista EOS). The resolved device list is rendered as a Markdown table on the stage page. If no devices match the filters, the remaining stages are marked Unreachable and the workflow returns immediately with an explanatory message.
+   Calls Nautobot for all devices matching the site, role, status, tenant, and device-type filters, then drops anything not on a supported platform (Cumulus Linux, NVOS, Arista EOS, Juniper Junos). The resolved device list is rendered as a Markdown table on the stage page. If no devices match the filters, the remaining stages are marked Unreachable and the workflow returns immediately with an explanatory message.
 
 1. **`validate_devices` — Run a device cable validation child per device.**
 

--- a/src/nv_config_manager/temporal/client/device.py
+++ b/src/nv_config_manager/temporal/client/device.py
@@ -113,7 +113,7 @@ def _junos_list(container: dict[str, Any], key: str) -> list[dict[str, Any]]:
     if isinstance(value, dict):
         return [value]
     if isinstance(value, list):
-        return list(value)
+        return cast(list[dict[str, Any]], list(value))
     return []
 
 

--- a/src/nv_config_manager/temporal/client/device.py
+++ b/src/nv_config_manager/temporal/client/device.py
@@ -240,8 +240,17 @@ class DeviceMacEntry(BaseModel):
         if not (mac and interface):
             return None
         vlan = _junos_string(data, "mac-vlan")
+        try:
+            mac_std = str(netaddr.EUI(mac))
+        except netaddr.core.AddrFormatError:
+            logger.warning("Invalid MAC %r in Junos MAC table entry, skipping: %s", mac, data)
+            return None
+        # get-ethernet-switching-table-information has no per-entry last-seen time,
+        # unlike Arista/Cumulus. sys.maxsize as a shared age means a duplicate MAC
+        # always loses the tie-break in get_mac_table, so the later entry in
+        # response order wins rather than either side being picked at random.
         return DeviceMacEntry(
-            mac=str(netaddr.EUI(mac)),
+            mac=mac_std,
             interface=interface.split(".")[0],
             vlan=int(vlan) if vlan and vlan.isdigit() else None,
             age=sys.maxsize,
@@ -332,8 +341,12 @@ class DeviceArpTable(BaseModel):
             if not (ip and mac and interface):
                 logger.warning("ARP entry missing data, skipping: %s", entry)
                 continue
-            ip_std = str(ipaddress.ip_address(ip))
-            mac_std = str(netaddr.EUI(mac))
+            try:
+                ip_std = str(ipaddress.ip_address(ip))
+                mac_std = str(netaddr.EUI(mac))
+            except (ValueError, netaddr.core.AddrFormatError):
+                logger.warning("Invalid IP/MAC in Junos ARP entry, skipping: %s", entry)
+                continue
             result._add_ip_mac_mapping(ip_std, mac_std)
             result._add_interface_mac_mapping(interface.split(".")[0], mac_std)
         return result

--- a/src/nv_config_manager/temporal/client/device.py
+++ b/src/nv_config_manager/temporal/client/device.py
@@ -97,6 +97,24 @@ def format_mac(mac: str) -> str:
     return mac.replace("-", ":").lower()
 
 
+def _junos_string(container: dict[str, Any], key: str) -> str | None:
+    """Return a string value (or None) from a Junos JSON response."""
+    value = container.get(key)
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if isinstance(value, dict):
+        value = value.get("data")
+    return str(value) if value is not None else None
+
+
+def _junos_list(container: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    """Return a repeatable Junos JSON element as a list, however it was wrapped."""
+    value = container.get(key, [])
+    if isinstance(value, dict):
+        return [value]
+    return list(value) if value else []
+
+
 class NetworkDeviceException(ApplicationError):
     """Exception when interacting with a network device."""
 
@@ -210,6 +228,23 @@ class DeviceMacEntry(BaseModel):
             ),
         )
 
+    @staticmethod
+    def from_junos(data: dict[str, Any]) -> DeviceMacEntry | None:
+        """Return a MAC address from a Junos response."""
+        mac = _junos_string(data, "mac-address")
+        interface = _junos_string(data, "mac-interfaces-list") or _junos_string(
+            data, "mac-interface"
+        )
+        if not (mac and interface):
+            return None
+        vlan = _junos_string(data, "mac-vlan")
+        return DeviceMacEntry(
+            mac=str(netaddr.EUI(mac)),
+            interface=interface.split(".")[0],
+            vlan=int(vlan) if vlan and vlan.isdigit() else None,
+            age=sys.maxsize,
+        )
+
 
 class DeviceArpTable(BaseModel):
     """Device ARP Table."""
@@ -282,6 +317,23 @@ class DeviceArpTable(BaseModel):
                 else:
                     logger.warning("ARP entry missing data, skipping: %s %s", ipaddr, ip_data)
 
+        return result
+
+    @staticmethod
+    def from_junos(entries: list[dict[str, Any]]) -> DeviceArpTable:
+        """ARP table from a Junos get-arp-table-information reply."""
+        result = DeviceArpTable()
+        for entry in entries:
+            ip = _junos_string(entry, "ip-address")
+            mac = _junos_string(entry, "mac-address")
+            interface = _junos_string(entry, "interface-name")
+            if not (ip and mac and interface):
+                logger.warning("ARP entry missing data, skipping: %s", entry)
+                continue
+            ip_std = str(ipaddress.ip_address(ip))
+            mac_std = str(netaddr.EUI(mac))
+            result._add_ip_mac_mapping(ip_std, mac_std)
+            result._add_interface_mac_mapping(interface.split(".")[0], mac_std)
         return result
 
 
@@ -357,6 +409,15 @@ class InterfaceNeighborData(BaseModel):
                 if is_mac_address(data[device]["port"]["name"])
                 else data[device]["port"]["name"]
             ),
+        )
+
+    @staticmethod
+    def from_junos(entry: dict[str, Any]) -> InterfaceNeighborData:
+        """Produce InterfaceNeighborData from a Junos LLDP neighbor entry."""
+        name = _junos_string(entry, "lldp-remote-port-id")
+        return InterfaceNeighborData(
+            device_name=_junos_string(entry, "lldp-remote-system-name"),
+            name=str(netaddr.EUI(name)) if name and is_mac_address(name) else name,
         )
 
 
@@ -2629,6 +2690,91 @@ class JuniperConnection(NetworkConnection):
             return int(uptime["attributes"]["junos:seconds"])
         except (KeyError, IndexError, TypeError, ValueError) as error:
             raise NetworkDeviceException(f"Unable to determine uptime on {self._host}.") from error
+
+    def _get_lldp_neighbor_entries(self) -> list[dict[str, Any]]:
+        """Return raw lldp-neighbor-information entries from the device."""
+        data = self._rpc("get-lldp-neighbors-information")
+        root = _junos_list(data, "lldp-neighbors-information")
+        return _junos_list(root[0], "lldp-neighbor-information") if root else []
+
+    def get_lldp_data(self, interface_name: str) -> InterfaceNeighborData | None:
+        """Get the raw LLDP data for a given interface."""
+        entries = [
+            entry
+            for entry in self._get_lldp_neighbor_entries()
+            if _junos_string(entry, "lldp-local-port-id") == interface_name
+        ]
+        if len(entries) > 1:
+            raise NetworkDeviceException(
+                f"Received multiple LLDP neighbors on interface {interface_name} from {self._host}"
+            )
+        return InterfaceNeighborData.from_junos(entries[0]) if entries else None
+
+    def _get_interface_link_states(self) -> dict[str, bool]:
+        """Return physical interface oper-status keyed by interface name."""
+        data = self._rpc("get-interface-information", {"terse": True})
+        root = _junos_list(data, "interface-information")
+        if not root:
+            return {}
+        link_states = {}
+        for physical in _junos_list(root[0], "physical-interface"):
+            name = _junos_string(physical, "name")
+            oper_status = _junos_string(physical, "oper-status")
+            if name and oper_status:
+                link_states[name] = oper_status == "up"
+        return link_states
+
+    def get_interface_connections(self) -> DeviceNeighborData:
+        """Get all interface connections from LLDP."""
+        neighbors = {}
+        for entry in self._get_lldp_neighbor_entries():
+            interface = _junos_string(entry, "lldp-local-port-id")
+            if interface:
+                neighbors[interface] = InterfaceNeighborData.from_junos(entry)
+
+        return DeviceNeighborData(
+            neighbors=neighbors, link_states=self._get_interface_link_states()
+        )
+
+    def get_mac_table(self) -> DeviceMacTable:
+        """Get the device MAC table."""
+        try:
+            data = self._rpc("get-ethernet-switching-table-information")
+        except NetworkDeviceException:
+            logger.debug(
+                "No Ethernet switching table on %s; treating the MAC table as empty.",
+                self._host,
+            )
+            return DeviceMacTable()
+
+        result = DeviceMacTable()
+        root = _junos_list(data, "ethernet-switching-table-information")
+        table = _junos_list(root[0], "ethernet-switching-table") if root else []
+        entries = _junos_list(table[0], "mac-table-entry") if table else []
+        for raw_entry in entries:
+            mac_entry = DeviceMacEntry.from_junos(raw_entry)
+            if mac_entry is None:
+                continue
+            if mac_entry.mac in result.by_mac:
+                logger.warning(
+                    "Duplicate MAC address %s on device %s: using newest entry",
+                    mac_entry.mac,
+                    self._host,
+                )
+                if mac_entry.age > result.by_mac[mac_entry.mac].age:
+                    continue
+            result.by_mac[mac_entry.mac] = mac_entry
+            result.by_interface.setdefault(mac_entry.interface, [])
+            if mac_entry.mac not in result.by_interface[mac_entry.interface]:
+                result.by_interface[mac_entry.interface].append(mac_entry.mac)
+        return result
+
+    def get_arp_table(self) -> DeviceArpTable:
+        """Get the device ARP table."""
+        data = self._rpc("get-arp-table-information")
+        root = _junos_list(data, "arp-table-information")
+        entries = _junos_list(root[0], "arp-table-entry") if root else []
+        return DeviceArpTable.from_junos(entries)
 
     # ------------------------------------------------------------------
     # Configuration operations.

--- a/src/nv_config_manager/temporal/client/device.py
+++ b/src/nv_config_manager/temporal/client/device.py
@@ -112,7 +112,9 @@ def _junos_list(container: dict[str, Any], key: str) -> list[dict[str, Any]]:
     value = container.get(key, [])
     if isinstance(value, dict):
         return [value]
-    return list(value) if value else []
+    if isinstance(value, list):
+        return list(value)
+    return []
 
 
 class NetworkDeviceException(ApplicationError):
@@ -2433,6 +2435,11 @@ class JuniperConnection(NetworkConnection):
     # TCP/NETCONF open deadline separate from per-RPC timeout.
     _CONN_OPEN_TIMEOUT_SECONDS = 30
 
+    # Substring of the RpcError Junos raises for get-ethernet-switching-table-information
+    # on a device with no bridging (e.g. a pure backbone router). Any other RPC failure
+    # (auth, connection, timeout) must propagate rather than read as an empty MAC table.
+    _MAC_TABLE_UNSUPPORTED_MESSAGE = "l2-learning subsystem is not running"
+
     def __init__(
         self,
         host: str,
@@ -2726,11 +2733,16 @@ class JuniperConnection(NetworkConnection):
 
     def get_interface_connections(self) -> DeviceNeighborData:
         """Get all interface connections from LLDP."""
-        neighbors = {}
+        neighbors: dict[str, InterfaceNeighborData] = {}
         for entry in self._get_lldp_neighbor_entries():
             interface = _junos_string(entry, "lldp-local-port-id")
-            if interface:
-                neighbors[interface] = InterfaceNeighborData.from_junos(entry)
+            if not interface:
+                continue
+            if interface in neighbors:
+                raise NetworkDeviceException(
+                    f"Received multiple LLDP neighbors on interface {interface} from {self._host}"
+                )
+            neighbors[interface] = InterfaceNeighborData.from_junos(entry)
 
         return DeviceNeighborData(
             neighbors=neighbors, link_states=self._get_interface_link_states()
@@ -2740,7 +2752,10 @@ class JuniperConnection(NetworkConnection):
         """Get the device MAC table."""
         try:
             data = self._rpc("get-ethernet-switching-table-information")
-        except NetworkDeviceException:
+        except NetworkDeviceException as error:
+            cause_message = getattr(error.__cause__, "message", None) or str(error)
+            if self._MAC_TABLE_UNSUPPORTED_MESSAGE not in cause_message:
+                raise
             logger.debug(
                 "No Ethernet switching table on %s; treating the MAC table as empty.",
                 self._host,

--- a/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/cable_validation.py
@@ -100,7 +100,12 @@ CLONE_SEARCH_ATTRS = [
     EXECUTE_ROLES_SEARCH_ATTRIBUTE,
 ]
 
-SUPPORTED_PLATFORMS = [Platform.CUMULUS_LINUX, Platform.ARISTA_EOS, Platform.NV_OS]
+SUPPORTED_PLATFORMS = [
+    Platform.CUMULUS_LINUX,
+    Platform.ARISTA_EOS,
+    Platform.NV_OS,
+    Platform.JUNIPER_JUNOS,
+]
 DEVICE_CABLE_VALIDATION_DEVICE_DESCRIPTION = (
     "Preloaded data for the target network device, if available."
 )
@@ -234,10 +239,12 @@ class SiteCableValidationWorkflow(WorkflowMetadataMixin, StageMixin, ArchiveMixi
             retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
         )
         if not result.devices:
+            platform_names = [p.dcim_name for p in SUPPORTED_PLATFORMS]
             display = (
                 "No devices found matching the specified filters "
                 f"(location={stage_input.site}, roles={stage_input.roles}, "
-                f"status={stage_input.status}, tenant={stage_input.tenant})."
+                f"status={stage_input.status}, tenant={stage_input.tenant}, "
+                f"platforms={platform_names})."
             )
         else:
             display = self.markdown_table(result.devices)

--- a/src/tests/temporal/clients/test_device.py
+++ b/src/tests/temporal/clients/test_device.py
@@ -1127,6 +1127,34 @@ def test_get_mac_table_parses_switching_table_entries(juniper_conn):
     assert result.by_interface["ge-0/0/0"] == [mac]
 
 
+def test_get_mac_table_skips_entry_with_invalid_mac(juniper_conn):
+    """A malformed MAC in one entry is skipped rather than aborting the whole table."""
+    data = {
+        "ethernet-switching-table-information": [
+            {
+                "ethernet-switching-table": [
+                    {
+                        "mac-table-entry": [
+                            {
+                                "mac-address": [{"data": "not-a-mac"}],
+                                "mac-interfaces-list": [{"data": "ge-0/0/0.0"}],
+                            },
+                            {
+                                "mac-address": [{"data": "00:11:22:33:44:55"}],
+                                "mac-interfaces-list": [{"data": "ge-0/0/1.0"}],
+                            },
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", return_value=data):
+        result = juniper_conn.get_mac_table()
+    assert list(result.by_mac.keys()) == ["00-11-22-33-44-55"]
+    assert result.by_interface == {"ge-0/0/1": ["00-11-22-33-44-55"]}
+
+
 def _raise_unsupported_switching_table(*_args: object, **_kwargs: object) -> None:
     """Raise the RpcError Junos actually returns for a backbone router with no bridging."""
     cause = Exception()
@@ -1180,6 +1208,37 @@ def test_get_arp_table_skips_incomplete_entries(juniper_conn):
         result = juniper_conn.get_arp_table()
     assert result.ip_to_mac == {}
     assert result.mac_to_ip == {}
+
+
+def test_get_arp_table_skips_entries_with_invalid_ip_or_mac(juniper_conn):
+    """A malformed IP or MAC in one entry is skipped rather than aborting the whole table."""
+    data = {
+        "arp-table-information": [
+            {
+                "arp-table-entry": [
+                    {
+                        "ip-address": [{"data": "not-an-ip"}],
+                        "mac-address": [{"data": "00:11:22:33:44:55"}],
+                        "interface-name": [{"data": "ge-0/0/0.0"}],
+                    },
+                    {
+                        "ip-address": [{"data": "10.0.0.1"}],
+                        "mac-address": [{"data": "not-a-mac"}],
+                        "interface-name": [{"data": "ge-0/0/0.0"}],
+                    },
+                    {
+                        "ip-address": [{"data": "10.0.0.2"}],
+                        "mac-address": [{"data": "00:11:22:33:44:66"}],
+                        "interface-name": [{"data": "ge-0/0/0.0"}],
+                    },
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", return_value=data):
+        result = juniper_conn.get_arp_table()
+    assert result.ip_to_mac == {"10.0.0.2": ["00-11-22-33-44-66"]}
+    assert result.mac_to_ip == {"00-11-22-33-44-66": ["10.0.0.2"]}
 
 
 def test_get_arp_table_returns_empty_for_empty_reply(juniper_conn):

--- a/src/tests/temporal/clients/test_device.py
+++ b/src/tests/temporal/clients/test_device.py
@@ -962,3 +962,180 @@ def test_run_diagnostic_command_unsupported_junos_raises_network_exception(junip
     a raw NotImplementedError from the base stub."""
     with pytest.raises(NetworkDeviceException, match="not implemented for JuniperConnection"):
         juniper_conn.run_diagnostic_command("show_bgp_summary")
+
+
+def _lldp_neighbor_entry(local_port: str, remote_port: str, remote_system: str) -> dict:
+    """Build one lldp-neighbor-information entry as PyEZ returns it in JSON."""
+    return {
+        "lldp-local-port-id": [{"data": local_port}],
+        "lldp-remote-port-id": [{"data": remote_port}],
+        "lldp-remote-system-name": [{"data": remote_system}],
+    }
+
+
+def test_get_lldp_data_returns_neighbor_for_matching_interface(juniper_conn):
+    """get_lldp_data finds the single neighbor entry for the requested local port."""
+    data = {
+        "lldp-neighbors-information": [
+            {
+                "lldp-neighbor-information": [
+                    _lldp_neighbor_entry("ge-0/0/0", "et-0/0/1", "junos-backbone-vjunos02"),
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", return_value=data):
+        result = juniper_conn.get_lldp_data("ge-0/0/0")
+    assert result.device_name == "junos-backbone-vjunos02"
+    assert result.name == "et-0/0/1"
+
+
+def test_get_lldp_data_returns_none_when_no_match(juniper_conn):
+    """get_lldp_data returns None when the interface has no LLDP neighbor."""
+    data = {"lldp-neighbors-information": [{"lldp-neighbor-information": []}]}
+    with patch.object(juniper_conn, "_rpc", return_value=data):
+        assert juniper_conn.get_lldp_data("ge-0/0/5") is None
+
+
+def test_get_lldp_data_raises_on_multiple_neighbors_for_one_interface(juniper_conn):
+    """Multiple neighbors on the same local port is treated as ambiguous, like Arista."""
+    data = {
+        "lldp-neighbors-information": [
+            {
+                "lldp-neighbor-information": [
+                    _lldp_neighbor_entry("ge-0/0/0", "et-0/0/1", "device-a"),
+                    _lldp_neighbor_entry("ge-0/0/0", "et-0/0/2", "device-b"),
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", return_value=data):
+        with pytest.raises(NetworkDeviceException, match="multiple LLDP neighbors"):
+            juniper_conn.get_lldp_data("ge-0/0/0")
+
+
+def test_get_interface_connections_combines_lldp_and_link_state(juniper_conn):
+    """get_interface_connections merges LLDP neighbors with per-interface link state."""
+    lldp_data = {
+        "lldp-neighbors-information": [
+            {
+                "lldp-neighbor-information": [
+                    _lldp_neighbor_entry("ge-0/0/0", "et-0/0/1", "junos-backbone-vjunos02"),
+                ]
+            }
+        ]
+    }
+    link_state_data = {
+        "interface-information": [
+            {
+                "physical-interface": [
+                    {"name": [{"data": "ge-0/0/0"}], "oper-status": [{"data": "up"}]},
+                    {"name": [{"data": "ge-0/0/1"}], "oper-status": [{"data": "down"}]},
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", side_effect=[lldp_data, link_state_data]):
+        result = juniper_conn.get_interface_connections()
+    assert result.neighbors["ge-0/0/0"].device_name == "junos-backbone-vjunos02"
+    assert result.link_states == {"ge-0/0/0": True, "ge-0/0/1": False}
+
+
+def test_get_interface_connections_handles_no_neighbors(juniper_conn):
+    """An empty LLDP table still returns link states with no neighbors."""
+    empty_lldp = {"lldp-neighbors-information": [{"lldp-neighbor-information": []}]}
+    link_state_data = {
+        "interface-information": [
+            {
+                "physical-interface": [
+                    {"name": [{"data": "ge-0/0/0"}], "oper-status": [{"data": "up"}]}
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", side_effect=[empty_lldp, link_state_data]):
+        result = juniper_conn.get_interface_connections()
+    assert result.neighbors == {}
+    assert result.link_states == {"ge-0/0/0": True}
+
+
+def test_get_mac_table_parses_switching_table_entries(juniper_conn):
+    """get_mac_table parses mac-table-entry rows, keyed by physical interface."""
+    data = {
+        "ethernet-switching-table-information": [
+            {
+                "ethernet-switching-table": [
+                    {
+                        "mac-table-entry": [
+                            {
+                                "mac-address": [{"data": "00:11:22:33:44:55"}],
+                                "mac-interfaces-list": [{"data": "ge-0/0/0.0"}],
+                                "mac-vlan": [{"data": "100"}],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", return_value=data):
+        result = juniper_conn.get_mac_table()
+    mac = "00-11-22-33-44-55"
+    assert result.by_mac[mac].interface == "ge-0/0/0"
+    assert result.by_mac[mac].vlan == 100
+    assert result.by_interface["ge-0/0/0"] == [mac]
+
+
+def test_get_mac_table_returns_empty_when_switching_unsupported(juniper_conn):
+    """A backbone router without bridging rejects the RPC; treat that as an empty table."""
+    with patch.object(juniper_conn, "_rpc", side_effect=NetworkDeviceException("unsupported RPC")):
+        result = juniper_conn.get_mac_table()
+    assert result.by_mac == {}
+    assert result.by_interface == {}
+
+
+def test_get_arp_table_parses_entries_and_strips_logical_unit(juniper_conn):
+    """get_arp_table maps IP/MAC/interface, keying interfaces by physical name."""
+    data = {
+        "arp-table-information": [
+            {
+                "arp-table-entry": [
+                    {
+                        "mac-address": [{"data": "00:11:22:33:44:55"}],
+                        "ip-address": [{"data": "192.0.2.1"}],
+                        "interface-name": [{"data": "ge-0/0/0.0"}],
+                    }
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", return_value=data):
+        result = juniper_conn.get_arp_table()
+    mac = "00-11-22-33-44-55"
+    assert result.ip_to_mac["192.0.2.1"] == [mac]
+    assert result.mac_to_ip[mac] == ["192.0.2.1"]
+    assert result.interface_to_mac["ge-0/0/0"] == [mac]
+
+
+def test_get_arp_table_skips_incomplete_entries(juniper_conn):
+    """Entries missing a mac, ip, or interface are skipped rather than raising."""
+    data = {
+        "arp-table-information": [
+            {
+                "arp-table-entry": [
+                    {"mac-address": [{"data": "00:11:22:33:44:55"}], "ip-address": []},
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", return_value=data):
+        result = juniper_conn.get_arp_table()
+    assert result.ip_to_mac == {}
+    assert result.mac_to_ip == {}
+
+
+def test_get_arp_table_returns_empty_for_empty_reply(juniper_conn):
+    """An empty arp-table-information reply produces an empty table, not an error."""
+    with patch.object(juniper_conn, "_rpc", return_value={"arp-table-information": []}):
+        result = juniper_conn.get_arp_table()
+    assert result.ip_to_mac == {}

--- a/src/tests/temporal/clients/test_device.py
+++ b/src/tests/temporal/clients/test_device.py
@@ -39,6 +39,7 @@ from nv_config_manager.temporal.client.device import (
     MockNetworkConnection,
     NetworkConnection,
     NetworkDeviceException,
+    _junos_list,
 )
 from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData
 from nv_config_manager.temporal.common.secrets import clear_secrets_cache
@@ -964,6 +965,29 @@ def test_run_diagnostic_command_unsupported_junos_raises_network_exception(junip
         juniper_conn.run_diagnostic_command("show_bgp_summary")
 
 
+class TestJunosList:
+    """Tests for the _junos_list Junos-JSON normalization helper."""
+
+    def test_missing_key_returns_empty_list(self):
+        """A key absent from the container returns an empty list, not an error."""
+        assert _junos_list({}, "mac-table-entry") == []
+
+    def test_wraps_a_bare_dict_as_a_single_item_list(self):
+        """Junos omits the list wrapper entirely when there is exactly one element."""
+        entry = {"mac-address": [{"data": "00:11:22:33:44:55"}]}
+        assert _junos_list({"mac-table-entry": entry}, "mac-table-entry") == [entry]
+
+    def test_preserves_an_actual_list(self):
+        """A real list of entries is returned as-is."""
+        entries = [{"a": 1}, {"b": 2}]
+        assert _junos_list({"mac-table-entry": entries}, "mac-table-entry") == entries
+
+    @pytest.mark.parametrize("scalar", ["some-string", 5, 1.5, True])
+    def test_scalar_value_returns_empty_list_instead_of_iterating_it(self, scalar):
+        """A stray string/number under a repeatable key must not be iterated character-by-character."""
+        assert _junos_list({"mac-table-entry": scalar}, "mac-table-entry") == []
+
+
 def _lldp_neighbor_entry(local_port: str, remote_port: str, remote_system: str) -> dict:
     """Build one lldp-neighbor-information entry as PyEZ returns it in JSON."""
     return {
@@ -1059,6 +1083,23 @@ def test_get_interface_connections_handles_no_neighbors(juniper_conn):
     assert result.link_states == {"ge-0/0/0": True}
 
 
+def test_get_interface_connections_raises_on_multiple_neighbors_for_one_interface(juniper_conn):
+    """A hub/fan-in on one port must raise here too, not silently keep the last neighbor."""
+    lldp_data = {
+        "lldp-neighbors-information": [
+            {
+                "lldp-neighbor-information": [
+                    _lldp_neighbor_entry("ge-0/0/0", "et-0/0/1", "device-a"),
+                    _lldp_neighbor_entry("ge-0/0/0", "et-0/0/2", "device-b"),
+                ]
+            }
+        ]
+    }
+    with patch.object(juniper_conn, "_rpc", return_value=lldp_data):
+        with pytest.raises(NetworkDeviceException, match="multiple LLDP neighbors"):
+            juniper_conn.get_interface_connections()
+
+
 def test_get_mac_table_parses_switching_table_entries(juniper_conn):
     """get_mac_table parses mac-table-entry rows, keyed by physical interface."""
     data = {
@@ -1086,9 +1127,16 @@ def test_get_mac_table_parses_switching_table_entries(juniper_conn):
     assert result.by_interface["ge-0/0/0"] == [mac]
 
 
+def _raise_unsupported_switching_table(*_args: object, **_kwargs: object) -> None:
+    """Raise the RpcError Junos actually returns for a backbone router with no bridging."""
+    cause = Exception()
+    cause.message = "the l2-learning subsystem is not running"  # matches jnpr RpcError.message
+    raise NetworkDeviceException("RPC get-ethernet-switching-table-information failed") from cause
+
+
 def test_get_mac_table_returns_empty_when_switching_unsupported(juniper_conn):
     """A backbone router without bridging rejects the RPC; treat that as an empty table."""
-    with patch.object(juniper_conn, "_rpc", side_effect=NetworkDeviceException("unsupported RPC")):
+    with patch.object(juniper_conn, "_rpc", side_effect=_raise_unsupported_switching_table):
         result = juniper_conn.get_mac_table()
     assert result.by_mac == {}
     assert result.by_interface == {}


### PR DESCRIPTION
## Description

Add support for cable validation for Junos 

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`632bf7c`](https://github.com/NVIDIA/nv-config-manager/commit/632bf7cac68376d84e0d446585628e37dfcef846) in [this workflow run](https://github.com/NVIDIA/nv-config-manager/actions/runs/32410154623).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Juniper Junos support for cable validation.
  * Added collection of LLDP neighbors, interface status, MAC tables, and ARP tables from Junos devices.
  * Improved handling of varied, incomplete, duplicate, and empty network data.

* **Documentation**
  * Updated platform prerequisites and validation-stage documentation to include Juniper Junos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->