### PR TITLE
fix(gateway): retry requests that never reached a backend

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1046,6 +1046,27 @@ Result depends on configuration:
 {{- end }}
 
 {{/*
+Name of the method-matched rule on the browser HTTPRoutes. Shared so the rule
+and the BackendTrafficPolicy that targets it by sectionName cannot drift apart.
+*/}}
+{{- define "nv-config-manager.browserSafeMethodRuleName" -}}
+safe-methods
+{{- end }}
+
+{{/*
+True when the browser routes should carry a separate method-matched rule for
+the safe-method retry. Requires oauth2-proxy to actually be in the request
+path, and Envoy Gateway, since the retry rides on a BackendTrafficPolicy.
+*/}}
+{{- define "nv-config-manager.browserSafeMethodRetryEnabled" -}}
+{{- $r := .Values.gateway.retry | default dict -}}
+{{- $sm := $r.safeMethods | default dict -}}
+{{- if and .Values.oidc.enabled $r.enabled $sm.enabled (eq (include "nv-config-manager.gatewayControllerType" .) "envoyGateway") -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
 Address of the Prometheus this release deploys, for KEDA's render-autoscaling
 trigger -- empty unless that in-cluster Prometheus is actually what KEDA will
 query.

--- a/deploy/helm/templates/backend-traffic-policy.yaml
+++ b/deploy/helm/templates/backend-traffic-policy.yaml
@@ -50,6 +50,30 @@ retry:
       maxInterval: {{ dig "backOff" "maxInterval" "1s" $r | quote }}
 {{- end -}}
 {{- end }}
+{{- /* -----------------------------------------------------------------------
+  Passive health check (outlier detection), emitted into every policy below for
+  the same reason as the retry: a policy targeting a route or a route rule
+  replaces the Gateway-level one rather than merging with it, so anything set
+  only globally would be lost on the routes that have their own policy.
+  ----------------------------------------------------------------------- */}}
+{{- define "nv-config-manager.gatewayPassiveHealthCheck" -}}
+{{- $root := .root | default . -}}
+{{- $p := $root.Values.gateway.passiveHealthCheck | default dict -}}
+{{- if $p.enabled -}}
+healthCheck:
+  passive:
+    {{- /* dig rather than `default`, as with numRetries: 0 is a meaningful
+         value for a threshold and `default` would silently rewrite it. */}}
+    consecutiveLocalOriginFailures: {{ dig "consecutiveLocalOriginFailures" 1 $p | int }}
+    consecutive5XxErrors: {{ dig "consecutive5XxErrors" 5 $p | int }}
+    interval: {{ dig "interval" "3s" $p | quote }}
+    baseEjectionTime: {{ dig "baseEjectionTime" "30s" $p | quote }}
+    maxEjectionPercent: {{ dig "maxEjectionPercent" 50 $p | int }}
+    {{- /* Envoy ignores consecutiveLocalOriginFailures unless this is true, so
+         it is defaulted on rather than left to the CRD default of false. */}}
+    splitExternalLocalOriginErrors: {{ dig "splitExternalLocalOriginErrors" true $p }}
+{{- end -}}
+{{- end }}
 {{- if and .Values.gateway.enabled (eq (include "nv-config-manager.gatewayControllerType" .) "envoyGateway") }}
 {{- if .Values.gateway.create }}
 {{- $policyName := include "nv-config-manager.componentName" (dict "root" . "component" "global-traffic-policy") }}
@@ -76,6 +100,7 @@ spec:
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
   {{- include "nv-config-manager.gatewayRetry" . | nindent 2 }}
+  {{- include "nv-config-manager.gatewayPassiveHealthCheck" . | nindent 2 }}
   
   {{- if .Values.gateway.rateLimit.enabled }}
   rateLimit:
@@ -125,6 +150,7 @@ spec:
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
   {{- include "nv-config-manager.gatewayRetry" . | nindent 2 }}
+  {{- include "nv-config-manager.gatewayPassiveHealthCheck" . | nindent 2 }}
 {{- if and .Values.oidc.enabled (.Values.networkZtp.gateway.svcHostname | default "") }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -148,6 +174,7 @@ spec:
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
   {{- include "nv-config-manager.gatewayRetry" . | nindent 2 }}
+  {{- include "nv-config-manager.gatewayPassiveHealthCheck" . | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- /* -----------------------------------------------------------------------
@@ -217,6 +244,7 @@ spec:
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
   {{- include "nv-config-manager.gatewayRetry" (dict "root" . "statusCodes" true) | nindent 2 }}
+  {{- include "nv-config-manager.gatewayPassiveHealthCheck" . | nindent 2 }}
 {{- end }}
 {{- if .Values.networkZtp.enabled }}
 {{- $ztpName := include "nv-config-manager.componentName" (dict "root" . "component" "ztp") }}
@@ -242,6 +270,7 @@ spec:
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
   {{- include "nv-config-manager.gatewayRetry" (dict "root" . "statusCodes" true) | nindent 2 }}
+  {{- include "nv-config-manager.gatewayPassiveHealthCheck" . | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/backend-traffic-policy.yaml
+++ b/deploy/helm/templates/backend-traffic-policy.yaml
@@ -5,7 +5,10 @@
   routes would silently lose retries if this were only set globally.
   ----------------------------------------------------------------------- */}}
 {{- define "nv-config-manager.gatewayRetry" -}}
-{{- $r := .Values.gateway.retry | default dict -}}
+{{- /* Accepts either the root context or a dict of `root` plus `statusCodes`.
+     `.root | default .` keeps the plain-root call sites below unchanged. */ -}}
+{{- $root := .root | default . -}}
+{{- $r := $root.Values.gateway.retry | default dict -}}
 {{- if $r.enabled -}}
 retry:
   {{- /* dig, not `default`: 0 is falsy in Go templates, so `default 2` would
@@ -14,16 +17,33 @@ retry:
        only when the key is genuinely absent, which is what makes a partial
        gateway.retry override work. */}}
   numRetries: {{ dig "numRetries" 2 $r | int }}
+  {{- /* `default` is deliberate here, unlike numRetries above. An empty
+       triggers list would render `triggers:` as null, and Envoy would fall
+       back to its own retryOn default, which retries 5xx - exactly what the
+       narrow list below exists to avoid. Falling back to the safe pair beats
+       silently widening what gets replayed. Set enabled: false to opt out. */}}
+  {{- $triggers := ($r.triggers | default (list "connect-failure" "refused-stream")) }}
+  {{- if .statusCodes }}
+  {{- /* Not optional. Envoy ignores retriable_status_codes unless retry_on
+       contains retriable-status-codes, and Envoy Gateway builds retry_on from
+       these triggers verbatim rather than inferring it from httpStatusCodes.
+       Without this the status codes below would render, validate, and do
+       nothing. */}}
+  {{- $triggers = append $triggers "retriable-status-codes" | uniq }}
+  {{- end }}
   retryOn:
-    {{- /* `default` is deliberate here, unlike numRetries above. An empty
-         triggers list would render `triggers:` as null, and Envoy would fall
-         back to its own retryOn default, which retries 5xx - exactly what the
-         narrow list below exists to avoid. Falling back to the safe pair beats
-         silently widening what gets replayed. Set enabled: false to opt out. */}}
     triggers:
-      {{- range ($r.triggers | default (list "connect-failure" "refused-stream")) }}
+      {{- range $triggers }}
       - {{ . | quote }}
       {{- end }}
+    {{- if .statusCodes }}
+    {{- /* Only reached from the method-matched rule below, never from a policy
+         that covers every method. */}}
+    httpStatusCodes:
+      {{- range (dig "safeMethods" "httpStatusCodes" (list 502) $r) }}
+      - {{ . | int }}
+      {{- end }}
+    {{- end }}
   perRetry:
     backOff:
       baseInterval: {{ dig "backOff" "baseInterval" "100ms" $r | quote }}
@@ -128,6 +148,100 @@ spec:
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
   {{- include "nv-config-manager.gatewayRetry" . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- /* -----------------------------------------------------------------------
+  Safe-method retry for the browser routes. With oidc.enabled, oauth2-proxy
+  proxies to the component Service, so a pod that stops accepting mid-rollout
+  makes the proxy answer 502 rather than the connection failing at the gateway.
+  That is a real response, which the transport-only triggers cannot absorb, and
+  it cannot be told apart from a write that already committed -- so it is
+  retried only on the method-matched rule, reached here by sectionName.
+
+  The timeouts are restated rather than inherited: a policy targeting a route
+  rule is the most specific one, so it replaces the Gateway- and route-level
+  policies for that rule instead of merging with them. ZTP is separate because
+  its uploads run on far longer timeouts than the global default, and the rule
+  would otherwise be silently downgraded to that default.
+  ----------------------------------------------------------------------- */}}
+{{- if include "nv-config-manager.browserSafeMethodRetryEnabled" . }}
+{{- $ruleName := include "nv-config-manager.browserSafeMethodRuleName" . }}
+{{- $temporalName := include "nv-config-manager.componentName" (dict "root" . "component" "temporal") }}
+{{- $routes := list }}
+{{- if .Values.renderService.enabled }}
+{{- $routes = append $routes (include "nv-config-manager.componentName" (dict "root" . "component" "render")) }}
+{{- end }}
+{{- if .Values.networkDhcp.enabled }}
+{{- $routes = append $routes (include "nv-config-manager.componentName" (dict "root" . "component" "dhcp")) }}
+{{- end }}
+{{- if .Values.temporal.enabled }}
+{{- $routes = append $routes (printf "%s-api" $temporalName) }}
+{{- if .Values.temporal.server.enabled }}
+{{- $routes = append $routes (printf "%s-web" $temporalName) }}
+{{- end }}
+{{- end }}
+{{- if .Values.ui.enabled }}
+{{- $routes = append $routes (include "nv-config-manager.componentName" (dict "root" . "component" "ui")) }}
+{{- end }}
+{{- if and .Values.nautobot.enabled .Values.externalServices.nautobot.local }}
+{{- $routes = append $routes (include "nv-config-manager.componentName" (dict "root" . "component" "nautobot")) }}
+{{- end }}
+{{- if .Values.configStore.enabled }}
+{{- $routes = append $routes (printf "%s-api" (include "nv-config-manager.componentName" (dict "root" . "component" "config-store"))) }}
+{{- end }}
+{{- if .Values.mcp.enabled }}
+{{- $routes = append $routes (include "nv-config-manager.componentName" (dict "root" . "component" "mcp")) }}
+{{- end }}
+{{- if $routes }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ include "nv-config-manager.componentName" (dict "root" . "component" "browser-retry-policy") }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "nv-config-manager.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+  {{- range $routes }}
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: {{ . }}
+    sectionName: {{ $ruleName }}
+  {{- end }}
+  timeout:
+    http:
+      requestTimeout: {{ .Values.gateway.timeout.requestTimeout | default "300s" }}
+      connectionIdleTimeout: {{ .Values.gateway.timeout.connectionIdleTimeout | default "60s" }}
+      maxConnectionDuration: {{ .Values.gateway.timeout.maxConnectionDuration | default "0s" }}
+    tcp:
+      connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
+  {{- include "nv-config-manager.gatewayRetry" (dict "root" . "statusCodes" true) | nindent 2 }}
+{{- end }}
+{{- if .Values.networkZtp.enabled }}
+{{- $ztpName := include "nv-config-manager.componentName" (dict "root" . "component" "ztp") }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ $ztpName }}-upload-browser-retry-policy
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "nv-config-manager.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: {{ $ztpName }}
+    sectionName: {{ $ruleName }}
+  timeout:
+    http:
+      requestTimeout: {{ .Values.networkZtp.upload.timeout | default "3600s" }}
+      connectionIdleTimeout: {{ .Values.networkZtp.upload.idleTimeout | default "300s" }}
+      maxConnectionDuration: "0s"
+    tcp:
+      connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
+  {{- include "nv-config-manager.gatewayRetry" (dict "root" . "statusCodes" true) | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/backend-traffic-policy.yaml
+++ b/deploy/helm/templates/backend-traffic-policy.yaml
@@ -65,7 +65,10 @@ healthCheck:
     {{- /* dig rather than `default`, as with numRetries: 0 is a meaningful
          value for a threshold and `default` would silently rewrite it. */}}
     consecutiveLocalOriginFailures: {{ dig "consecutiveLocalOriginFailures" 1 $p | int }}
-    consecutive5XxErrors: {{ dig "consecutive5XxErrors" 5 $p | int }}
+    {{- /* Falls back to 0, i.e. off, matching values.yaml: dropping the key
+         should not quietly enable a detector that misattributes failures on
+         proxied routes. */}}
+    consecutive5XxErrors: {{ dig "consecutive5XxErrors" 0 $p | int }}
     interval: {{ dig "interval" "3s" $p | quote }}
     baseEjectionTime: {{ dig "baseEjectionTime" "30s" $p | quote }}
     maxEjectionPercent: {{ dig "maxEjectionPercent" 50 $p | int }}

--- a/deploy/helm/templates/backend-traffic-policy.yaml
+++ b/deploy/helm/templates/backend-traffic-policy.yaml
@@ -144,6 +144,12 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ $ztpName }}
+  {{- /* Without this, targeting a route replaces the Gateway policy above
+       outright instead of layering on it, so this route would serve with no
+       rateLimit at all whenever gateway.rateLimit.enabled is set. Merging keeps
+       the longer upload timeouts below winning, because the route policy is the
+       patch and the Gateway policy the base. */}}
+  mergeType: StrategicMerge
   timeout:
     http:
       # Allow up to 1 hour for 5GB uploads on slower connections
@@ -169,6 +175,9 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ $ztpName }}-svc
+  # Same reason as the policy above: without merging, this route loses the
+  # Gateway policy's rateLimit entirely.
+  mergeType: StrategicMerge
   timeout:
     http:
       requestTimeout: {{ $uploadTimeout }}
@@ -239,6 +248,10 @@ spec:
     name: {{ . }}
     sectionName: {{ $ruleName }}
   {{- end }}
+  # A rule-scoped policy displaces the Gateway policy for that rule just as a
+  # route-scoped one does, so without merging every safe-method request would
+  # bypass rateLimit - and safe methods are most of the browser traffic.
+  mergeType: StrategicMerge
   timeout:
     http:
       requestTimeout: {{ .Values.gateway.timeout.requestTimeout | default "300s" }}
@@ -265,6 +278,8 @@ spec:
     kind: HTTPRoute
     name: {{ $ztpName }}
     sectionName: {{ $ruleName }}
+  # As above: keep the Gateway policy's rateLimit on this rule.
+  mergeType: StrategicMerge
   timeout:
     http:
       requestTimeout: {{ .Values.networkZtp.upload.timeout | default "3600s" }}

--- a/deploy/helm/templates/backend-traffic-policy.yaml
+++ b/deploy/helm/templates/backend-traffic-policy.yaml
@@ -197,11 +197,12 @@ spec:
   it cannot be told apart from a write that already committed -- so it is
   retried only on the method-matched rule, reached here by sectionName.
 
-  The timeouts are restated rather than inherited: a policy targeting a route
-  rule is the most specific one, so it replaces the Gateway- and route-level
-  policies for that rule instead of merging with them. ZTP is separate because
-  its uploads run on far longer timeouts than the global default, and the rule
-  would otherwise be silently downgraded to that default.
+  The timeouts are restated rather than inherited, despite the mergeType below.
+  Merging is against the Gateway-level policy, which only exists with
+  gateway.create, so a BYO-gateway install has nothing to inherit from. And it
+  is the Gateway policy rather than a sibling route-level one, so the ZTP upload
+  route would inherit the global default instead of its own far longer timeouts.
+  That is why ZTP gets a second policy below rather than sharing this one.
   ----------------------------------------------------------------------- */}}
 {{- if include "nv-config-manager.browserSafeMethodRetryEnabled" . }}
 {{- $ruleName := include "nv-config-manager.browserSafeMethodRuleName" . }}
@@ -248,9 +249,8 @@ spec:
     name: {{ . }}
     sectionName: {{ $ruleName }}
   {{- end }}
-  # A rule-scoped policy displaces the Gateway policy for that rule just as a
-  # route-scoped one does, so without merging every safe-method request would
-  # bypass rateLimit - and safe methods are most of the browser traffic.
+  # Without this, this policy would replace the Gateway-level one for these
+  # rules and take its rateLimit with it, on most of the browser traffic.
   mergeType: StrategicMerge
   timeout:
     http:

--- a/deploy/helm/templates/backend-traffic-policy.yaml
+++ b/deploy/helm/templates/backend-traffic-policy.yaml
@@ -1,3 +1,25 @@
+{{- /* -----------------------------------------------------------------------
+  Shared retry policy, emitted into every BackendTrafficPolicy below rather
+  than set once on the Gateway. A policy targeting an HTTPRoute overrides the
+  Gateway-level policy for that route instead of merging with it, so the ZTP
+  routes would silently lose retries if this were only set globally.
+  ----------------------------------------------------------------------- */}}
+{{- define "nv-config-manager.gatewayRetry" -}}
+{{- $r := .Values.gateway.retry | default dict -}}
+{{- if $r.enabled -}}
+retry:
+  numRetries: {{ $r.numRetries | default 2 | int }}
+  retryOn:
+    triggers:
+      {{- range ($r.triggers | default (list "connect-failure" "refused-stream")) }}
+      - {{ . | quote }}
+      {{- end }}
+  perRetry:
+    backOff:
+      baseInterval: {{ dig "backOff" "baseInterval" "100ms" $r | quote }}
+      maxInterval: {{ dig "backOff" "maxInterval" "1s" $r | quote }}
+{{- end -}}
+{{- end }}
 {{- if and .Values.gateway.enabled (eq (include "nv-config-manager.gatewayControllerType" .) "envoyGateway") }}
 {{- if .Values.gateway.create }}
 {{- $policyName := include "nv-config-manager.componentName" (dict "root" . "component" "global-traffic-policy") }}
@@ -23,6 +45,7 @@ spec:
       maxConnectionDuration: {{ .Values.gateway.timeout.maxConnectionDuration | default "0s" }}
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
+  {{- include "nv-config-manager.gatewayRetry" . | nindent 2 }}
   
   {{- if .Values.gateway.rateLimit.enabled }}
   rateLimit:
@@ -71,6 +94,7 @@ spec:
       maxConnectionDuration: "0s"
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
+  {{- include "nv-config-manager.gatewayRetry" . | nindent 2 }}
 {{- if and .Values.oidc.enabled (.Values.networkZtp.gateway.svcHostname | default "") }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -93,6 +117,7 @@ spec:
       maxConnectionDuration: "0s"
     tcp:
       connectTimeout: {{ .Values.gateway.timeout.connectTimeout | default "10s" }}
+  {{- include "nv-config-manager.gatewayRetry" . | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/backend-traffic-policy.yaml
+++ b/deploy/helm/templates/backend-traffic-policy.yaml
@@ -8,8 +8,18 @@
 {{- $r := .Values.gateway.retry | default dict -}}
 {{- if $r.enabled -}}
 retry:
-  numRetries: {{ $r.numRetries | default 2 | int }}
+  {{- /* dig, not `default`: 0 is falsy in Go templates, so `default 2` would
+       quietly rewrite an explicit numRetries: 0 to 2 and leave an operator
+       unable to keep the policy while turning retries off. dig substitutes
+       only when the key is genuinely absent, which is what makes a partial
+       gateway.retry override work. */}}
+  numRetries: {{ dig "numRetries" 2 $r | int }}
   retryOn:
+    {{- /* `default` is deliberate here, unlike numRetries above. An empty
+         triggers list would render `triggers:` as null, and Envoy would fall
+         back to its own retryOn default, which retries 5xx - exactly what the
+         narrow list below exists to avoid. Falling back to the safe pair beats
+         silently widening what gets replayed. Set enabled: false to opt out. */}}
     triggers:
       {{- range ($r.triggers | default (list "connect-failure" "refused-stream")) }}
       - {{ . | quote }}

--- a/deploy/helm/templates/httproutes.yaml
+++ b/deploy/helm/templates/httproutes.yaml
@@ -109,6 +109,37 @@ backendRefs:
 {{- end }}
 {{- end }}
 
+{{/*
+An extra rule on a browser route, identical to the catch-all below it except
+that it matches only methods that are safe to replay. It exists so a
+BackendTrafficPolicy can attach a status-code retry to those methods alone: with
+oidc.enabled, oauth2-proxy proxies to the component Service, so a pod that stops
+accepting mid-rollout makes the proxy answer 502 rather than the connection
+failing at the gateway, and a 502 cannot be told apart from a write that already
+committed.
+
+Emitted before the catch-all for readability only. Gateway API resolves ties by
+match specificity, not list order, and ranks a method match above a bare path
+prefix, so this rule wins for the methods it lists and everything else falls
+through.
+*/}}
+{{- define "nv-config-manager.browserSafeMethodRule" }}
+{{- $root := $.root }}
+{{- if include "nv-config-manager.browserSafeMethodRetryEnabled" $root }}
+{{- $sm := $root.Values.gateway.retry.safeMethods }}
+- name: {{ include "nv-config-manager.browserSafeMethodRuleName" $root }}
+  matches:
+  {{- range ($sm.methods | default (list "GET" "HEAD")) }}
+  - path:
+      type: PathPrefix
+      value: /
+    method: {{ . | quote }}
+  {{- end }}
+  {{- include "nv-config-manager.protectedIdentityHeaders" (dict "redirectHostname" $.redirectHostname) | nindent 2 }}
+  {{- include "nv-config-manager.browserBackendRefs" (dict "root" $root "backendName" $.backendName "backendPort" $.backendPort "proxyPort" $.proxyPort) | nindent 2 }}
+{{- end }}
+{{- end }}
+
 # =============================================================================
 # Auth Bypass HTTPRoute Helper Template
 # =============================================================================
@@ -227,6 +258,7 @@ spec:
   hostnames:
   - {{ tpl .Values.renderService.gateway.hostname . | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" (tpl .Values.renderService.gateway.hostname .) "backendName" (printf "%s-api" $renderName) "backendPort" 9000 "proxyPort" 9101) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix
@@ -274,6 +306,7 @@ spec:
   hostnames:
   - {{ tpl .Values.networkZtp.gateway.hostname . | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" (tpl .Values.networkZtp.gateway.hostname .) "backendName" (printf "%s-api" $ztpName) "backendPort" 9000 "proxyPort" 9102) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix
@@ -319,6 +352,7 @@ spec:
   hostnames:
   - {{ tpl .Values.networkDhcp.gateway.hostname . | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" (tpl .Values.networkDhcp.gateway.hostname .) "backendName" (printf "%s-internal" $dhcpName) "backendPort" 9000 "proxyPort" 9103) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix
@@ -364,6 +398,7 @@ spec:
   hostnames:
   - {{ tpl .Values.temporal.gateway.api.hostname . | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" (tpl .Values.temporal.gateway.api.hostname .) "backendName" (printf "%s-api" $temporalName) "backendPort" 9000 "proxyPort" 9104) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix
@@ -385,6 +420,7 @@ spec:
   hostnames:
   - {{ tpl .Values.temporal.gateway.devUi.hostname . | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" (tpl .Values.temporal.gateway.devUi.hostname .) "backendName" (printf "%s-web-service" $temporalName) "backendPort" 8080 "proxyPort" 9105) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix
@@ -438,6 +474,7 @@ spec:
   hostnames:
   - {{ .Values.gateway.baseHostname | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" .Values.gateway.baseHostname "backendName" $uiName "backendPort" 3000 "proxyPort" 9100) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix
@@ -496,6 +533,7 @@ spec:
   hostnames:
   - {{ tpl .Values.nautobot.gateway.hostname . | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" (tpl .Values.nautobot.gateway.hostname .) "backendName" $nautobotName "backendPort" 80 "proxyPort" 9106) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix
@@ -541,6 +579,7 @@ spec:
   hostnames:
   - {{ tpl .Values.configStore.gateway.api.hostname . | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" (tpl .Values.configStore.gateway.api.hostname .) "backendName" (printf "%s-api" $configStoreName) "backendPort" 9000 "proxyPort" 9107) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix
@@ -586,6 +625,7 @@ spec:
   hostnames:
   - {{ tpl .Values.mcp.gateway.hostname . | quote }}
   rules:
+  {{- include "nv-config-manager.browserSafeMethodRule" (dict "root" . "redirectHostname" (tpl .Values.mcp.gateway.hostname .) "backendName" $mcpName "backendPort" 9000 "proxyPort" 9108) | nindent 2 }}
   - matches:
     - path:
         type: PathPrefix

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -842,6 +842,27 @@ gateway:
     maxConnectionDuration: 0s
     # TCP connect timeout - time to establish connection to backend
     connectTimeout: 10s
+  # Retry policy for requests the gateway never managed to hand to a backend.
+  # Envoy does not retry at all unless this is set, so a single refused
+  # connection reaches the client as a 503. That is most likely while endpoints
+  # are churning - a rollout, or an autoscaler scaling in - where a pod stops
+  # accepting connections a moment before the gateway stops routing to it.
+  # Envoy Gateway only; kgateway TrafficPolicy has a separate retry schema and
+  # is not covered here.
+  retry:
+    enabled: true
+    # Total attempts is numRetries + 1.
+    numRetries: 2
+    # Deliberately narrow. Both triggers mean the request never reached a
+    # backend, so replaying it cannot apply a write twice. Excluded on purpose:
+    # 5xx/retriable-status-codes, where the backend may have already committed,
+    # and reset, which can arrive after the request was sent.
+    triggers:
+      - connect-failure
+      - refused-stream
+    backOff:
+      baseInterval: 100ms
+      maxInterval: 1s
   # CORS configuration
   cors:
     enabled: true

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -920,8 +920,13 @@ gateway:
     baseEjectionTime: 30s
     # Envoy admits an ejection when (active_ejections + 1) / endpoints is <=
     # this, so the default of 10 cannot eject even one endpoint from a pool
-    # smaller than ten - it leaves everything above configured but inert. 50
-    # permits one of three or three of six, always keeping a majority serving.
+    # smaller than ten - it leaves everything above configured but inert.
+    #
+    # 50 keeps at least half the pool serving, which is not the same as a
+    # majority: an even pool can lose exactly half, so three of six may be
+    # ejected. Deliberately not 49, which reads safer but rounds the wrong way
+    # for the pool this most often applies to - the two-replica oidc proxy,
+    # where one ejection is 50% and nothing could ever be ejected at 49.
     maxEjectionPercent: 50
     # Required, not merely advisable: Envoy only counts local-origin failures
     # separately when this is set, and consecutiveLocalOriginFailures above is

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -874,6 +874,38 @@ gateway:
         - HEAD
       httpStatusCodes:
         - 502
+  # Passive health checking, i.e. Envoy outlier detection. Complements the
+  # retry above rather than duplicating it: a retry saves the request that
+  # failed, while ejection saves the requests behind it, by pulling a failing
+  # endpoint out of the pool instead of letting every later request rediscover
+  # it for itself.
+  #
+  # Off by default, unlike the retry. The thresholds below are only meaningful
+  # against a known replica count and a known churn pattern, and neither is
+  # knowable from inside this chart. Turning it on without that context risks
+  # either never ejecting or ejecting healthy endpoints.
+  passiveHealthCheck:
+    enabled: false
+    # Transport-level failures: connection refused, connect timeout, reset —
+    # cases where no response ever came back. Envoy's default is 5; 1 ejects on
+    # the first, which is what a terminating pod actually produces, because the
+    # retry is steered elsewhere and any success resets the counter. A
+    # threshold of 2 is rarely reached before the pod is gone.
+    consecutiveLocalOriginFailures: 1
+    # Real 5xx responses from the application, deliberately less sensitive: an
+    # app can return one 500 without being unhealthy.
+    consecutive5XxErrors: 5
+    interval: 3s
+    baseEjectionTime: 30s
+    # Envoy admits an ejection when (active_ejections + 1) / endpoints is <=
+    # this, so the default of 10 cannot eject even one endpoint from a pool
+    # smaller than ten - it leaves everything above configured but inert. 50
+    # permits one of three or three of six, always keeping a majority serving.
+    maxEjectionPercent: 50
+    # Required, not merely advisable: Envoy only counts local-origin failures
+    # separately when this is set, and consecutiveLocalOriginFailures above is
+    # ignored entirely when it is false.
+    splitExternalLocalOriginErrors: true
   # CORS configuration
   cors:
     enabled: true

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -884,6 +884,14 @@ gateway:
   # against a known replica count and a known churn pattern, and neither is
   # knowable from inside this chart. Turning it on without that context risks
   # either never ejecting or ejecting healthy endpoints.
+  #
+  # Worth knowing what it can see, because ejection judges whatever the gateway
+  # connects to, which is not always the component. With oidc.enabled the
+  # browser routes resolve to the shared oauth2-proxy Deployment, so on those
+  # routes this ejects an unreachable proxy replica and cannot reach the
+  # component's pods at all - they are behind the proxy, invisible here. The
+  # mTLS and auth-bypass routes, and every route when oidc is disabled, resolve
+  # to the component pods directly, which is where this does what it reads as.
   passiveHealthCheck:
     enabled: false
     # Transport-level failures: connection refused, connect timeout, reset —
@@ -892,9 +900,22 @@ gateway:
     # retry is steered elsewhere and any success resets the counter. A
     # threshold of 2 is rarely reached before the pod is gone.
     consecutiveLocalOriginFailures: 1
-    # Real 5xx responses from the application, deliberately less sensitive: an
-    # app can return one 500 without being unhealthy.
-    consecutive5XxErrors: 5
+    # Ejecting on real 5xx responses is off. Envoy tests this threshold with
+    # equality against a counter that has already been incremented, so 0 is
+    # never reached and the detector never fires.
+    #
+    # Deliberate, because a 5xx only indicts the endpoint that returned it if
+    # that endpoint is the application. Behind the oidc proxy it is not: every
+    # proxy replica forwards to the same component Service, so one failing
+    # component pod makes all of them answer 502 alike. Ejecting one would
+    # remove a healthy proxy, leave the failing pod in place, and hand the
+    # retry to a proxy that reaches it just the same - and with two proxy
+    # replicas, maxEjectionPercent below permits exactly that one ejection.
+    #
+    # Raise it, 5 is a reasonable start, where the gateway talks to component
+    # pods directly: oidc disabled, or an install whose traffic arrives on the
+    # mTLS or auth-bypass routes, which bypass the proxy regardless.
+    consecutive5XxErrors: 0
     interval: 3s
     baseEjectionTime: 30s
     # Envoy admits an ejection when (active_ejections + 1) / endpoints is <=

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -863,6 +863,17 @@ gateway:
     backOff:
       baseInterval: 100ms
       maxInterval: 1s
+    # Adds a status-code retry for the 502 the OIDC browser proxy returns when
+    # it cannot reach a backend. Restricted to methods that are safe to replay,
+    # because a 502 cannot be distinguished from a write that already committed.
+    # Only takes effect when oidc.enabled puts the proxy in the request path.
+    safeMethods:
+      enabled: true
+      methods:
+        - GET
+        - HEAD
+      httpStatusCodes:
+        - 502
   # CORS configuration
   cors:
     enabled: true


### PR DESCRIPTION
## Why

Envoy performs **no retries at all** unless a `BackendTrafficPolicy` asks for them, and none of the three policies in this chart do. So a single refused connection becomes a `503` at the client, even when healthy replicas were available to serve it.

That is most likely precisely when endpoints churn — a rollout, or KEDA scaling the render service in — because a pod stops accepting connections slightly before the gateway stops routing to it. The window is short, but every request that lands in it is lost rather than retried.

This came out of debugging the same gap in another Envoy Gateway deployment, where it produced intermittent single-request `503`s during autoscaler scale-in that were enough to trip endpoint monitoring. There, Envoy's own counters showed `upstream_cx_connect_fail` and `upstream_rq_xx{class="5"}` incrementing in lockstep while `upstream_rq_retry` stayed flat at zero — nothing absorbed the failure. The template gap here is identical, so I'm fixing it before it pages someone.

## What changed

**1. A `retry` block on all three `BackendTrafficPolicy` objects**, configurable under `gateway.retry` and defaulting on.

**Triggers are deliberately narrow.** `connect-failure` and `refused-stream` both mean the request was never delivered to a backend, so replaying it cannot apply a write twice. Excluded on purpose: `5xx`, where the backend may have already committed, and `reset`, which can arrive after the request was sent. Envoy's default for an empty `retryOn` *would* have included 503s, so `retryOn` is set explicitly rather than left to default.

**Why it's duplicated into all three policies** rather than set once on the Gateway: a policy targeting an HTTPRoute overrides the Gateway-level policy for that route instead of merging with it, so the ZTP upload routes would silently have had no retries. A shared named template keeps the three copies from drifting.

**That same override is also a pre-existing rate-limit bypass**, which item 3 fixes.

**2. A method-scoped retry for the `oidc-proxy` `502`** — see below. This was flagged as out of scope in the first revision of this PR; it now has a portable fix, so it's included.

**3. `mergeType: StrategicMerge` on every route- and rule-scoped policy.** Follows from the override behaviour above, but the consequence is worse than missing retries: with `gateway.rateLimit.enabled`, the `rateLimit` lives on the Gateway policy, so every route carrying its own policy was served with **no rate limit at all**. That predates this PR for the two ZTP upload policies, and the safe-method rules added here would have extended it to most browser traffic.

Merging fixes it without giving up the overrides. Envoy Gateway calls `utils.Merge(gatewayPolicy, routePolicy, mergeType)` — the route policy is the patch, the Gateway policy the base — so the 3600s upload timeouts and the retry still win where set, and `rateLimit` is inherited where they say nothing. It also handles "only the Gateway policy has rate limits" as an explicit case, which is ours. Safe where no Gateway policy exists: that branch falls back to applying the route policy unchanged.

The field is not set on the Gateway-level policy, where the CRD forbids it.

**Scope.** Envoy Gateway only. kgateway's `TrafficPolicy` expresses retries with a different schema, so `kgateway-traffic-policy.yaml` is untouched.

## The `oidc-proxy` 502

With `oidc.enabled`, browser routes are served by oauth2-proxy with the component's Service as its upstream, so a pod that stops accepting mid-rollout makes the proxy answer `502` rather than the connection failing at the gateway. That is a real HTTP response, so none of the transport triggers above can absorb it.

**oauth2-proxy cannot retry this itself.** At the pinned v7.15.3, its `Upstream` config exposes exactly twelve fields — `id`, `path`, `rewriteTarget`, `uri`, `insecureSkipTLSVerify`, `static`, `staticCode`, `flushInterval`, `passHostHeader`, `proxyWebSockets`, `timeout`, `disableKeepAlives` — and none of them is a retry. Proxying is Go's `httputil.ReverseProxy`, which has no retry mechanism to configure, and every upstream connection error lands in a single handler whose comment reads "It is expected to always render a bad gateway error". So the `502` is the only thing that layer can produce, and it has to be absorbed at the gateway.

**Retrying `502` for every method would be unsafe.** A proxy returns it both when the request never reached the app and when the app committed and then died before responding, and those are indistinguishable from the outside. A blanket status-code retry on the existing policies would therefore replay writes.

**So the retry is scoped to methods that can be replayed.** Each browser route gains a rule matching only those methods, named `safe-methods`, and a `BackendTrafficPolicy` targets that rule through `targetRefs[].sectionName`. Writes fall through to the catch-all rule and keep the narrow transport triggers, unchanged.

Three things make this work on the versions this product actually pins:

- **No experimental channel needed.** The obvious approach — `rules[].retry` on the route — exists only in the Gateway API *experimental* channel, and the installer ships `standard-install.yaml` at v1.4.1, where the field is absent. CRD pruning would drop it silently, so it would look correct and do nothing. The rule here uses only GA fields: `rules[].name` and `matches[].method` are both in the standard channel at v1.4.1, and I confirmed that against the manifest the installer downloads.
- **Rule-level policy attachment is supported at the pinned Envoy Gateway v1.6.5.** When a `targetRef` is not a Gateway and carries a `sectionName`, EG resolves it as a route rule. Verified in the v1.6.5 translator, and still present in later versions, so this is not relying on behaviour newer than what ships.
- **Precedence is by specificity, not list order.** Gateway API ranks a method match above a bare path prefix when the path matches are equal, so the `safe-methods` rule wins for the methods it lists and everything else falls through. Rendered first only for readability.

**`retriable-status-codes` is not optional here.** Envoy ignores `retriable_status_codes` unless `retry_on` names that trigger, and Envoy Gateway builds `retry_on` from the configured triggers verbatim rather than inferring it from `httpStatusCodes`. Without it these policies would render, validate, and never retry anything — a silent no-op. The CRD's own field description says the same thing. It is added only to the two method-scoped policies; the three that cover every method keep the narrow pair.

**The new policies restate the timeouts on purpose.** A policy targeting a route rule is the most specific one, so it replaces the Gateway- and route-level policies for that rule rather than merging with them, and any timeout left unset would fall back to Envoy's own default instead of the configured one. ZTP gets its own policy so its long upload timeouts are not silently downgraded to the global default.

## Notes for review

- **This defaults to `enabled: true`**, so it is a behaviour change for existing installs rather than opt-in. That felt right for a resilience fix whose triggers cannot replay a write, but say the word and I'll flip it to `false` by default. The method-scoped part is a separate switch, `gateway.retry.safeMethods.enabled`, also on by default, and it only renders when `oidc.enabled` actually puts the proxy in the request path.
- **New values surface:** `gateway.retry.safeMethods.{enabled,methods,httpStatusCodes}`, defaulting to `GET`/`HEAD` and `502`. Both lists are configurable, so adding `504` or dropping `HEAD` needs no template change.
- **Two new objects** when all components are enabled: one policy covering the browser routes on the global timeouts, and one for the ZTP browser route on the upload timeouts. With everything on, nine routes carry the `safe-methods` rule.
- Expect the pre-existing ZTP route policy to report an `Overridden` condition naming the `safe-methods` rule. That is EG recording that a more specific policy won for that rule, which is the intent, not a misconfiguration.
- Retrying the ZTP upload routes is safe: a `connect-failure` occurs before any body is sent. Envoy also will not retry once a request body exceeds its per-try buffer limit, so large uploads degrade to current behaviour rather than buffering 5GB.
- Included, but off by default: passive health checking (outlier detection), as `gateway.passiveHealthCheck`. **Correcting something I wrote here earlier:** I said this chart's default load balancer is what makes a retry land on a different host, and that outlier detection mainly matters for consistent hashing. That premise is wrong. Envoy Gateway injects `envoy.retry_host_predicates.previous_hosts` into every retry policy it generates, with `HostSelectionRetryMaxAttempts: 5`, so a retry avoids the endpoint that just failed regardless of the load balancer — consistent hash included, and confirmed present at the pinned v1.6.5. What ejection actually buys is the requests *after* the retried one: otherwise the failing endpoint stays in the pool until Kubernetes removes it, and each subsequent request pays its own failed connection and its own retry.

  It ships disabled, unlike the retry. The retry's triggers are safe on any topology; useful ejection thresholds are not, because they depend on the replica count and churn pattern of the install. Too sensitive pulls healthy endpoints, too lax never ejects. The values carry defaults that are reasonable to start from, with the reasoning for each, but the decision to switch it on is left to whoever can see the traffic.

  Emitted into all five policies, for the same reason the retry is: a policy attached to a route or a route rule replaces the Gateway-level one rather than merging with it, so anything set only globally would go missing precisely on the routes that have their own policy.

  Two of the defaults differ from the CRD's own, and neither is cosmetic. `splitExternalLocalOriginErrors` must be `true` or Envoy never consults `consecutiveLocalOriginFailures` — the constructor picks a different accounting path when it is false, and the local-origin counter is only incremented on the split path. And `maxEjectionPercent` must clear `100/endpoints`, because Envoy admits an ejection only while `(active_ejections + 1) / endpoints <= max`; the CRD default of 10 cannot eject even one endpoint from a pool smaller than ten, which would leave the whole block configured and inert. Both read from `outlier_detection_impl.cc` rather than assumed. `alwaysEjectOneEndpoint` would be the tidier answer to the second one, but it does not exist at the pinned v1.6.5.

  On `maxEjectionPercent` specifically: it stays at `50` and the comment now says it keeps *at least half* the pool serving, not a majority, since an even pool can lose exactly half. 49 would read safer and is what the sibling charts use, but it rounds the wrong way for the pool this most often applies to — one of the two proxy replicas is 50%, so at 49 nothing could ever be ejected and the whole block would be inert on exactly the routes it is meant to cover.

  Not adding `consecutiveGatewayErrors`, though it would be a reasonable request: it is unreachable rather than merely unset. Envoy's `DEFAULT_ENFORCING_CONSECUTIVE_GATEWAY_FAILURE` is `0`, and Envoy Gateway sets `EnforcingConsecutiveGatewayFailure: 100` only inside the same `if` that sets the threshold, so leaving the field out means the 502/503/504 detector runs and never ejects. Confirmed against a live config dump, where no `consecutive_gateway_failure` field appears at all. That is also what makes the `consecutive5XxErrors: 0` decision below complete rather than half-done — there is no side door by which a proxy 502 can still eject a proxy replica.

  One further default is worth calling out, because it is a behaviour decision rather than a threshold. `consecutive5XxErrors` ships at `0`, which never fires, because ejection judges whatever the gateway connects to and with `oidc.enabled` that is not the component: browser routes resolve to the shared oauth2-proxy Deployment, whose replicas all forward to the same component Service. One failing component pod therefore makes every proxy replica answer `502` alike, and ejecting on that removes a healthy proxy, leaves the failing pod in place, and hands the retry to a proxy that reaches it anyway — at a cost of half the proxy pool, since the default is two replicas. The local-origin detector stays on, because a refused connection always indicts whoever refused it; on a proxied route that means an unreachable proxy replica, which is worth ejecting. Installs that reach component pods directly, with OIDC off or over the mTLS and auth-bypass routes, can raise it in one line.

## Test plan

- [x] `helm template test . --values values-ci.yaml` per `AGENTS.md` — renders; retry present on the global and ZTP upload policies, and no `safe-methods` rules, since OIDC is off in those values.
- [x] With `--set oidc.enabled=true` — all **5** policies render and **9** browser routes carry the `safe-methods` rule (render, ztp, dhcp, temporal-api, temporal-web, ui, nautobot, config-store, mcp).
- [x] Trigger split verified per policy: the three all-method policies carry `connect-failure,refused-stream` and no status codes; the two method-scoped ones add `retriable-status-codes` with `httpStatusCodes: [502]`.
- [x] Toggles: `gateway.retry.safeMethods.enabled=false` removes the rules and both new policies while the original three keep their retry; `gateway.retry.enabled=false` removes everything; `oidc.enabled=false` renders no rules at all; `numRetries=0` still honoured.
- [x] Overrides: `safeMethods.methods=[GET]` and `httpStatusCodes=[502,504]` both render as configured.
- [x] `--set gateway.type=kgateway` renders no Envoy policies and no `safe-methods` rules. (`kgateway` also needs `gateway.createGatewayClass=false` to render at all, which is pre-existing chart validation, unrelated to this change.)
- [x] `helm lint . --values values-ci.yaml` passes. The `temporal.yaml` name-length warnings are pre-existing and unrelated.
- [x] `helm template` with `values-ci.yaml` + `values-observability.yaml` per `AGENTS.md` — renders.
- [x] `kubectl apply --dry-run=server` of all 5 rendered policies and all 24 rendered HTTPRoutes — every object accepted, so the `sectionName` targeting, the method matches and the retry schema validate against a real API server.
- [x] Because that dry run used an Envoy Gateway newer than the pinned v1.6.5, the pinned schemas were checked directly too: `retry.retryOn.{triggers,httpStatusCodes}`, `perRetry.backOff.*` and `targetRefs[].sectionName` all exist in the v1.6.5 `BackendTrafficPolicy` CRD, `retriable-status-codes` is in its trigger enum, and `rules[].name` plus `matches[].method` (`GET`/`HEAD`) exist in the Gateway API v1.4.1 **standard** CRD.
- [x] Passive health check, default off: `healthCheck` absent from all 5 policies with stock values.
- [x] `gateway.passiveHealthCheck.enabled=true`: `healthCheck.passive` present on all 5, with retry and the `[502]` codes on the two method-scoped policies unchanged, so the two features compose rather than displace each other.
- [x] `dig` rather than `default` for every threshold: `consecutive5XxErrors=0` and `splitExternalLocalOriginErrors=false` both render as given instead of being silently rewritten, same reasoning as `numRetries: 0`.
- [x] `gateway.type=kgateway` with the health check forced on still renders no Envoy policies.
- [x] `kubectl apply --dry-run=server` of all 5 policies with the health check on, plus all rendered HTTPRoutes — every object accepted.
- [x] Pinned-schema check for this part too: `consecutiveLocalOriginFailures`, `consecutive5XxErrors`, `interval`, `baseEjectionTime`, `maxEjectionPercent` and `splitExternalLocalOriginErrors` all exist under `healthCheck.passive` in the v1.6.5 `BackendTrafficPolicy` CRD.
- [x] `consecutive5XxErrors: 0` renders on all 5 policies and is accepted by a real API server; raising it to 5 still works as an override; the template's own fallback is 0 too, so deleting the key cannot re-enable it.
- [x] That 0 disables the detector rather than ejecting on the first 5xx was read from Envoy, not assumed: the check is `++consecutive_5xx_ == threshold`, which a pre-incremented counter can never satisfy at 0. Same `==` pattern as the local-origin counter.

**Not covered by an end-to-end test.** I have not driven live traffic through a terminating pod against a v1.6.5 cluster to watch the `502` get retried; the evidence here is schema validation plus the translator source. If you'd rather see the counters move first, I can stand up the pinned versions in kind and post `upstream_rq_retry` before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable gateway retries for connection failures and selected HTTP 502 responses.
  - Added safe-method retry policies for browser routes, limited to supported HTTP methods.
  - Added optional passive health checks with configurable failure thresholds and endpoint ejection settings.
  - Added route-specific retry policies and timeouts for browser services and ZTP uploads.
  - Added configurable retry behavior by HTTP method, status code, and route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

