### PR TITLE
feat(gateway): honour gateway.retry on kgateway too

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1056,12 +1056,14 @@ safe-methods
 {{/*
 True when the browser routes should carry a separate method-matched rule for
 the safe-method retry. Requires oauth2-proxy to actually be in the request
-path, and Envoy Gateway, since the retry rides on a BackendTrafficPolicy.
+path; the rule itself is plain Gateway API, and each controller attaches its
+own policy to it - a BackendTrafficPolicy on Envoy Gateway, a TrafficPolicy on
+kgateway - so it is emitted for both.
 */}}
 {{- define "nv-config-manager.browserSafeMethodRetryEnabled" -}}
 {{- $r := .Values.gateway.retry | default dict -}}
 {{- $sm := $r.safeMethods | default dict -}}
-{{- if and .Values.oidc.enabled $r.enabled $sm.enabled (eq (include "nv-config-manager.gatewayControllerType" .) "envoyGateway") -}}
+{{- if and .Values.oidc.enabled $r.enabled $sm.enabled -}}
 true
 {{- end -}}
 {{- end }}

--- a/deploy/helm/templates/backend-traffic-policy.yaml
+++ b/deploy/helm/templates/backend-traffic-policy.yaml
@@ -197,11 +197,12 @@ spec:
   it cannot be told apart from a write that already committed -- so it is
   retried only on the method-matched rule, reached here by sectionName.
 
-  The timeouts are restated rather than inherited: a policy targeting a route
-  rule is the most specific one, so it replaces the Gateway- and route-level
-  policies for that rule instead of merging with them. ZTP is separate because
-  its uploads run on far longer timeouts than the global default, and the rule
-  would otherwise be silently downgraded to that default.
+  The timeouts are restated rather than inherited, despite the mergeType below.
+  Merging is against the Gateway-level policy, which only exists with
+  gateway.create, so a BYO-gateway install has nothing to inherit from. And it
+  is the Gateway policy rather than a sibling route-level one, so the ZTP upload
+  route would inherit the global default instead of its own far longer timeouts.
+  That is why ZTP gets a second policy below rather than sharing this one.
   ----------------------------------------------------------------------- */}}
 {{- if include "nv-config-manager.browserSafeMethodRetryEnabled" . }}
 {{- $ruleName := include "nv-config-manager.browserSafeMethodRuleName" . }}
@@ -248,9 +249,8 @@ spec:
     name: {{ . }}
     sectionName: {{ $ruleName }}
   {{- end }}
-  # A rule-scoped policy displaces the Gateway policy for that rule just as a
-  # route-scoped one does, so without merging every safe-method request would
-  # bypass rateLimit - and safe methods are most of the browser traffic.
+  # Without this, this policy would replace the Gateway-level one for these
+  # rules and take its rateLimit with it, on most of the browser traffic.
   mergeType: StrategicMerge
   timeout:
     http:

--- a/deploy/helm/templates/kgateway-traffic-policy.yaml
+++ b/deploy/helm/templates/kgateway-traffic-policy.yaml
@@ -1,3 +1,44 @@
+{{- /* -----------------------------------------------------------------------
+  kgateway's retry, driven by the same gateway.retry values as the Envoy
+  Gateway policy but a different schema: attempts rather than numRetries,
+  retryOn as a flat list, and statusCodes as a sibling rather than nested under
+  retryOn. maxInterval has no equivalent - kgateway caps the backoff at 10x the
+  base interval, which is what Envoy does with our Envoy Gateway values anyway.
+
+  Accepts the root context, or a dict of `root` plus `statusCodes` to add the
+  status-code retry for safe methods.
+  ----------------------------------------------------------------------- */}}
+{{- define "nv-config-manager.kgatewayRetry" -}}
+{{- $root := .root | default . -}}
+{{- $r := $root.Values.gateway.retry | default dict -}}
+{{- if $r.enabled -}}
+retry:
+  {{- /* attempts is retries, not total tries, so it maps straight across from
+       numRetries. dig, not `default`, for the same reason as the Envoy
+       template: 0 is meaningful - kgateway documents it as disabling retries -
+       and `default` would rewrite it to 2. */}}
+  attempts: {{ dig "numRetries" 2 $r | int }}
+  backoffBaseInterval: {{ dig "backOff" "baseInterval" "100ms" $r | quote }}
+  retryOn:
+    {{- range ($r.triggers | default (list "connect-failure" "refused-stream")) }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- if .statusCodes }}
+    {{- /* Envoy ignores retriable_status_codes unless retry_on includes this,
+         and unlike Envoy Gateway, kgateway inserts it for you as soon as
+         statusCodes is non-empty. Listed anyway, into a set that dedupes it, so
+         the rendered policy states what will be in effect rather than relying on
+         the reader knowing that. */}}
+    - "retriable-status-codes"
+    {{- end }}
+  {{- if .statusCodes }}
+  statusCodes:
+    {{- range (dig "safeMethods" "httpStatusCodes" (list 502) $r) }}
+    - {{ . | int }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+{{- end }}
 {{- if and .Values.gateway.enabled (eq (include "nv-config-manager.gatewayControllerType" .) "kgateway") }}
 {{/*
 Route labels avoid duplicating every HTTPRoute name here and, unlike a
@@ -19,6 +60,7 @@ spec:
   timeouts:
     request: {{ .Values.gateway.timeout.requestTimeout | default "300s" }}
     streamIdle: {{ .Values.gateway.timeout.connectionIdleTimeout | default "60s" }}
+  {{- include "nv-config-manager.kgatewayRetry" . | nindent 2 }}
 
 {{- if .Values.networkZtp.enabled }}
 ---
@@ -38,6 +80,7 @@ spec:
   timeouts:
     request: {{ .Values.networkZtp.upload.timeout | default "3600s" }}
     streamIdle: {{ .Values.networkZtp.upload.idleTimeout | default "300s" }}
+  {{- include "nv-config-manager.kgatewayRetry" . | nindent 2 }}
 {{- end }}
 
 ---
@@ -90,5 +133,64 @@ spec:
             key: nv-config-manager
             value: global
         {{- end }}
+{{- end }}
+
+{{- if include "nv-config-manager.browserSafeMethodRetryEnabled" . }}
+{{- $ruleName := include "nv-config-manager.browserSafeMethodRuleName" . }}
+{{/*
+Adds the status-code retry to the safe-method rule alone, so the 502 the oidc
+proxy returns for an unreachable backend is retried for methods that can be
+replayed and not for writes, which a 502 cannot be distinguished from.
+
+One policy per timeout profile rather than one overall, and each repeats its
+profile's timeouts alongside the retry. kgateway ranks a policy targeting a
+rule above one targeting the route, but resolves the two by merging rather
+than by wholesale replacement as Envoy Gateway does. Carrying the timeouts
+here means the rule ends up correctly configured under either reading, instead
+of depending on which one is right.
+*/}}
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: {{ include "nv-config-manager.componentName" (dict "root" . "component" "default-safe-method-retry") }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "nv-config-manager.labels" . | nindent 4 }}
+spec:
+  # sectionName on a selector, so this stays label-driven like the policies
+  # above instead of needing every browser route named here.
+  targetSelectors:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    matchLabels:
+      nv-config-manager.nvidia.com/timeout-profile: default
+    sectionName: {{ $ruleName }}
+  timeouts:
+    request: {{ .Values.gateway.timeout.requestTimeout | default "300s" }}
+    streamIdle: {{ .Values.gateway.timeout.connectionIdleTimeout | default "60s" }}
+  {{- include "nv-config-manager.kgatewayRetry" (dict "root" . "statusCodes" true) | nindent 2 }}
+
+{{- if .Values.networkZtp.enabled }}
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: {{ include "nv-config-manager.componentName" (dict "root" . "component" "upload-safe-method-retry") }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "nv-config-manager.labels" . | nindent 4 }}
+spec:
+  targetSelectors:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    matchLabels:
+      nv-config-manager.nvidia.com/timeout-profile: upload
+    sectionName: {{ $ruleName }}
+  timeouts:
+    request: {{ .Values.networkZtp.upload.timeout | default "3600s" }}
+    streamIdle: {{ .Values.networkZtp.upload.idleTimeout | default "300s" }}
+  {{- include "nv-config-manager.kgatewayRetry" (dict "root" . "statusCodes" true) | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/kgateway-traffic-policy.yaml
+++ b/deploy/helm/templates/kgateway-traffic-policy.yaml
@@ -2,8 +2,11 @@
   kgateway's retry, driven by the same gateway.retry values as the Envoy
   Gateway policy but a different schema: attempts rather than numRetries,
   retryOn as a flat list, and statusCodes as a sibling rather than nested under
-  retryOn. maxInterval has no equivalent - kgateway caps the backoff at 10x the
-  base interval, which is what Envoy does with our Envoy Gateway values anyway.
+  retryOn. maxInterval has no equivalent here: kgateway sends no cap and Envoy
+  falls back to 10x the base interval. That matches the values shipped in
+  values.yaml, where maxInterval is exactly 10x baseInterval, but the two
+  controllers diverge on any other value - raising maxInterval alone would take
+  effect under Envoy Gateway and be ignored here.
 
   Accepts the root context, or a dict of `root` plus `statusCodes` to add the
   status-code retry for safe methods.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -847,8 +847,12 @@ gateway:
   # connection reaches the client as a 503. That is most likely while endpoints
   # are churning - a rollout, or an autoscaler scaling in - where a pod stops
   # accepting connections a moment before the gateway stops routing to it.
-  # Envoy Gateway only; kgateway TrafficPolicy has a separate retry schema and
-  # is not covered here.
+  # Honoured under both gateway controllers. The two policy schemas differ -
+  # numRetries against attempts, a nested backOff against backoffBaseInterval -
+  # so each controller has its own template, but the values below drive both and
+  # the trigger names are Envoy's either way. maxInterval has no kgateway
+  # equivalent and is ignored there; it caps at 10x the base interval, which is
+  # what Envoy applies for us regardless.
   retry:
     enabled: true
     # Total attempts is numRetries + 1.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -850,9 +850,10 @@ gateway:
   # Honoured under both gateway controllers. The two policy schemas differ -
   # numRetries against attempts, a nested backOff against backoffBaseInterval -
   # so each controller has its own template, but the values below drive both and
-  # the trigger names are Envoy's either way. maxInterval has no kgateway
-  # equivalent and is ignored there; it caps at 10x the base interval, which is
-  # what Envoy applies for us regardless.
+  # the trigger names are Envoy's either way. maxInterval is the exception: it
+  # is honoured under Envoy Gateway and ignored under kgateway, which sends no
+  # cap and so gets Envoy's fallback of 10x baseInterval. The two agree at the
+  # values below, where maxInterval is exactly that, and diverge at any other.
   retry:
     enabled: true
     # Total attempts is numRetries + 1.


### PR DESCRIPTION
> Stacked on #250 — based on `davesh/gateway-retry-policy`, so the diff here is the kgateway commit alone. Merge #250 first.

## What

Makes `gateway.retry` apply under kgateway as well as Envoy Gateway, via `TrafficPolicy.spec.retry`.

## Why

Retry support so far was Envoy Gateway only, gated on the controller type. A kgateway install therefore got the timeout policies and nothing else, so the failure that motivated `gateway.retry` in the first place — a pod that stops accepting connections a moment before the gateway stops routing to it — still reaches the client as a 503 there. kgateway can express the same thing, so the same values now drive both.

## How it maps

Different schema, same Envoy underneath:

| `gateway.retry` | Envoy Gateway | kgateway |
|---|---|---|
| `numRetries` | `retry.numRetries` | `retry.attempts` |
| `triggers` | `retry.retryOn.triggers` | `retry.retryOn` (flat list) |
| `safeMethods.httpStatusCodes` | `retry.retryOn.httpStatusCodes` | `retry.statusCodes` (sibling, not nested) |
| `backOff.baseInterval` | `retry.perRetry.backOff.baseInterval` | `retry.backoffBaseInterval` |
| `backOff.maxInterval` | `retry.perRetry.backOff.maxInterval` | no equivalent — dropped |

Two of those deserve a note. `attempts` maps straight across rather than needing an off-by-one: `BuildRetryPolicy` assigns it to Envoy's `num_retries`, which counts retries and not total tries, exactly as `numRetries` does on the other controller. And dropping `maxInterval` costs nothing, because kgateway caps the backoff at 10× the base interval, which is what Envoy applies to our Envoy Gateway values anyway.

## Attachment

Follows the pattern this file already established for timeouts — `targetSelectors` on the `timeout-profile` label rather than a hand-kept list of route names. That covers everything, since all 24 rendered routes carry the label.

The safe-method 502 retry reuses the same `safe-methods` rule as the Envoy Gateway path. That rule is plain Gateway API, so the controller check moved out of the helper that emits it and each controller attaches its own policy kind. Worth noting this needs no experimental Gateway API channel here, because the rule-level targeting lives in kgateway's own CRD via `targetSelectors[].sectionName` — the experimental-channel dependency was always an Envoy Gateway constraint, not a Gateway API one.

The two rule-scoped policies repeat their profile's timeouts alongside the retry. kgateway ranks a rule-targeted policy above a route-targeted one but reconciles the two by *merging*, where Envoy Gateway replaces outright. I have not verified which fields merge how, so carrying the timeouts explicitly leaves the rule correctly configured under either reading rather than depending on the answer.

## Not included

Passive health checking. `BackendConfigPolicy.spec.outlierDetection` exists, but exposes only `consecutive5xx`, `interval`, `baseEjectionTime` and `maxEjectionPercent` — there is no `consecutiveLocalOriginFailures` and no `splitExternalLocalOriginErrors`, so the design in #250 (eject on the first transport failure, counted separately from application 5xx) cannot be expressed. Without the split flag Envoy folds connect failures into the `consecutive5xx` counter, which is the exact conflation that flag exists to prevent. A partial port would behave differently from the Envoy Gateway one under the same values, which seems worse than not offering it.

## Verification

- Rendered under both controllers. kgateway produces 4 `TrafficPolicy` objects: 2 route-wide carrying timeouts plus the transport-only retry, and 2 rule-scoped adding `statusCodes: [502]` with `retriable-status-codes`.
- **The Envoy Gateway render is byte-identical to the parent branch** (`diff` of the full `helm template` output), so relaxing the helper gate changed nothing there.
- Toggles: `retry.enabled=false` drops all retry and both rule-scoped policies while timeouts survive; `safeMethods.enabled=false` keeps the route-wide retry and drops the rule policies; `oidc.enabled=false` drops them too; `numRetries=0` is honoured rather than rewritten, which kgateway documents as disabling retries.
- Every rendered object validated against the real kgateway CRD schemas at **v2.3.4** (what `scripts/install-security-dependencies` installs) and **v2.4.3** (current latest). A deliberately invalid `retryOn` value was injected to confirm the validation actually fails when it should, rather than passing vacuously.
- `helm lint` clean under both controllers.

**Not covered by a live test.** There is no kgateway cluster available here, so this is schema validation plus a read of kgateway's translation source, not observed counters. The merge behaviour described above is the part I would most want confirmed on a real kgateway before relying on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent gateway retry behavior across supported gateway controllers.
  * Added configurable retries for browser-safe methods, including status-code conditions and profile-specific timeouts.
  * Applied retry settings to default, zero-touch provisioning, and network upload traffic policies when enabled.

* **Documentation**
  * Clarified retry configuration for Envoy Gateway and kgateway, including controller-specific settings and interval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->