### PR TITLE
fix: update Nautobot security dependencies

### DIFF
--- a/components/nautobot/pyproject.toml
+++ b/components/nautobot/pyproject.toml
@@ -37,8 +37,11 @@ dependencies = [
     # Security: Fix Pillow decompression-bomb bypasses
     # (GHSA-5x94-69rx-g8h2, GHSA-phj9-mv4w-65pm, GHSA-45hq-cxwh-f6vc, GHSA-8v84-f9pq-wr9x)
     "pillow>=12.3.0",
-    # Security: Fix DoS via unbounded recursion (GHSA-jr27-m4p2-rc6r, GHSA-63vm-454h-vhhq)
-    "pyasn1>=0.6.3",
+    # Security: Fix pyasn1 resource-exhaustion issues
+    # (GHSA-jr27-m4p2-rc6r, GHSA-63vm-454h-vhhq, GHSA-hm4w-wwcw-mr6r, GHSA-8ppf-4f7h-5ppj)
+    "pyasn1>=0.6.4",
+    # Security: Fix selector-parser ReDoS issues (GHSA-836r-79rf-4m37, GHSA-2wc2-fm75-p42x)
+    "soupsieve>=2.8.4",
     # Multi-provider JWT validation (external IdPs, Azure AD, SPIFFE JWT-SVIDs)
     # cryptography is already a transitive dep of nautobot but pin for JWKS key support
     "PyJWT[crypto]>=2.13.0",

--- a/components/nautobot/uv.lock
+++ b/components/nautobot/uv.lock
@@ -1226,6 +1226,7 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pynacl" },
     { name = "requests" },
+    { name = "soupsieve" },
     { name = "urllib3" },
 ]
 
@@ -1255,10 +1256,11 @@ requires-dist = [
     { name = "nautobot-nv-config-manager", directory = "nautobot-nv-config-manager" },
     { name = "nautobot-nvdatamodels", specifier = ">=0.17.0" },
     { name = "pillow", specifier = ">=12.3.0" },
-    { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0" },
     { name = "pynacl", specifier = ">=1.6.2" },
     { name = "requests", specifier = ">=2.33.0" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -1476,11 +1478,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -1969,11 +1971,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.1"
+version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/23/adf3796d740536d63a6fbda113d07e60c734b6ed5d3058d1e47fc0495e47/soupsieve-2.8.1.tar.gz", hash = "sha256:4cf733bc50fa805f5df4b8ef4740fc0e0fa6218cf3006269afd3f9d6d80fd350", size = 117856, upload-time = "2025-12-18T13:50:34.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/f3/b67d6ea49ca9154453b6d70b34ea22f3996b9fa55da105a79d8732227adc/soupsieve-2.8.1-py3-none-any.whl", hash = "sha256:a11fe2a6f3d76ab3cf2de04eb339c1be5b506a8a47f2ceb6d139803177f85434", size = 36710, upload-time = "2025-12-18T13:50:33.267Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Raise the Nautobot deployment security floors for `pyasn1` and `soupsieve`, then refresh the component lockfile. The resolved versions move from `pyasn1` 0.6.3 to 0.6.4 and from `soupsieve` 2.8.1 to 2.9.2, clearing the four Pulse STOP findings for GHSA-hm4w-wwcw-mr6r, GHSA-8ppf-4f7h-5ppj, GHSA-836r-79rf-4m37, and GHSA-2wc2-fm75-p42x.

## Validation

- `cd components/nautobot && uv sync --frozen`
- `cd components/nautobot && uv lock --check`
- `cd components/nautobot && uv run ruff format --check nv_config_manager_auth nv_config_manager_jobs nautobot_config.py`
- `cd components/nautobot && uv run ruff check nv_config_manager_auth nv_config_manager_jobs nautobot_config.py`
- `cd components/nautobot && uv run pytest tests/ -n auto --cov=nv_config_manager_auth --cov=nv_config_manager_jobs --cov-report=term` (251 passed)

- [ ] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run. Not run because this is a dependency-floor and lockfile-only change with no runtime behavior changes.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. Not applicable; there are no user-facing changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs. The affected `uv.lock` is updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated supporting components to incorporate the latest security and compatibility improvements.
* **Maintenance**
  * Improved package requirements to support more reliable application behavior and safer processing of encoded data and HTML content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->