### PR TITLE
fix(ci): scan current OAuth2 Proxy image

### DIFF
--- a/.gitlab/ci/pulse.yml
+++ b/.gitlab/ci/pulse.yml
@@ -128,7 +128,7 @@ include:
           PULSE_IMAGE_NAME:
             - oauth2-proxy
           PULSE_EXTERNAL_IMAGE:
-            - quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
+            - quay.io/oauth2-proxy/oauth2-proxy:v7.15.4
           PULSE_CONTAINER_SCANNER_PLATFORM:
             - linux/amd64
             - linux/arm64


### PR DESCRIPTION
## Description

Update the Pulse external-image matrix to scan OAuth2 Proxy `v7.15.4`, matching the version shipped by the Helm and installer defaults after #254.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run. Not run because this changes only the external image selected by the Pulse scan matrix.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes. No user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs. No generated artifacts are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OAuth2 Proxy image used in automated security scanning to a newer patch version.
  * Improves access to the latest fixes and maintenance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->