### PR TITLE
fix(config-store): avoid per-file 404s when computing render diffs

### DIFF
--- a/src/nv_config_manager/common/client/config_store.py
+++ b/src/nv_config_manager/common/client/config_store.py
@@ -391,16 +391,21 @@ class ConfigStoreClient(_WhoamiViaRetryClientMixin):
         """
         author_email = f"{user}@{user_domain}"
 
+        # One device-scoped read instead of a GET per file. The per-file endpoint
+        # 404s for anything not yet stored, so a first render of a device (or of a
+        # newly added template) used to emit a 404 per file purely to compute the
+        # diff. The device endpoint returns an empty list instead.
+        existing_content = {
+            str(config["filename"]): str(config["content"])
+            for config in await self.list_device_configs(device_uuid)
+        }
+
         filtered_items = []
         for filename, content in files.items():
             clean_filename = filename.replace(".j2", "")
-            try:
-                existing_file = await self.load_file(device_uuid, clean_filename)
-                if content == existing_file.content:
-                    self.logger.info("No diff for %s/%s", device_uuid, clean_filename)
-                    continue
-            except ConfigStoreFileNotFound:
-                pass
+            if existing_content.get(clean_filename) == content:
+                self.logger.info("No diff for %s/%s", device_uuid, clean_filename)
+                continue
 
             filtered_items.append(
                 {

--- a/src/tests/common/nv_config_manager_config_store/test_config_store_client.py
+++ b/src/tests/common/nv_config_manager_config_store/test_config_store_client.py
@@ -16,6 +16,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 import pytest_asyncio
 
@@ -137,14 +138,31 @@ async def test_whoami_uses_service_root(async_config_store_client):
 
 
 @pytest.mark.asyncio
+async def test_load_file_not_found(async_config_store_client):
+    """Test a 404 from the per-file endpoint maps to ConfigStoreFileNotFound."""
+    mock_session = _mock_retry_client(None)
+    mock_session.get.return_value.raise_for_status = MagicMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=404, message="Not Found"
+        )
+    )
+
+    with patch(
+        "nv_config_manager.common.client.config_store.RetryClient", return_value=mock_session
+    ):
+        with pytest.raises(ConfigStoreFileNotFound):
+            await async_config_store_client.load_file(
+                "123e4567-e89b-12d3-a456-426614174000", "startup.yaml"
+            )
+
+
+@pytest.mark.asyncio
 async def test_persist_files_new(async_config_store_client):
-    """Test persisting new files."""
+    """Test persisting files for a device with nothing stored yet."""
     device_uuid = "123e4567-e89b-12d3-a456-426614174000"
 
-    async def mock_load_file(dev_uuid, filename):
-        raise ConfigStoreFileNotFound(f"File {filename} not found")
-
-    async_config_store_client.load_file = mock_load_file
+    list_configs = AsyncMock(return_value=[])
+    async_config_store_client.list_device_configs = list_configs
 
     mock_session = _mock_retry_client(MOCK_BATCH_POST_RESPONSE)
 
@@ -163,6 +181,34 @@ async def test_persist_files_new(async_config_store_client):
     assert len(config_files) == 1
     assert config_files[0].commit == "6"
     assert config_files[0].filename == "startup.yaml"
+    # A device with no stored configs must be discovered without a per-file GET.
+    list_configs.assert_awaited_once_with(device_uuid)
+
+
+@pytest.mark.asyncio
+async def test_persist_files_skips_unchanged(async_config_store_client):
+    """Test files matching the stored content are not resubmitted."""
+    device_uuid = "123e4567-e89b-12d3-a456-426614174000"
+
+    async_config_store_client.list_device_configs = AsyncMock(
+        return_value=[dict(MOCK_GET_RESPONSE)]
+    )
+
+    mock_session = _mock_retry_client(MOCK_BATCH_POST_RESPONSE)
+
+    with patch(
+        "nv_config_manager.common.client.config_store.RetryClient", return_value=mock_session
+    ):
+        config_files = await async_config_store_client.persist_files(
+            device_uuid=device_uuid,
+            files={"startup.yaml.j2": MOCK_GET_RESPONSE["content"]},
+            commit_message="test commit message",
+            user="testuser",
+            user_domain="config-manager.example.com",
+        )
+
+    assert config_files is None
+    mock_session.post.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`persist_files` did a `GET /v1/config/{uuid}/{filename}` per rendered file to decide whether content had changed. That endpoint 404s for anything not yet stored, so the diff check itself generated 404s:

- a device's **first render** emitted one 404 per file it produced;
- **adding or renaming an entrypoint template** emitted one 404 per device across the fleet, once the template updater re-rendered every stale device.

Render treats these as expected misses (`except ConfigStoreFileNotFound: pass`), so they were invisible in render's logs while still counting against the config-store SLO — which matches the pattern we saw in iad03: elevated 404s on a small number of config filenames with no render errors.

This reads the device-scoped endpoint `GET /v1/config/device/{uuid}` once instead. It returns an empty list rather than a 404 when a device has nothing stored, and it already carries full `content`, so the comparison happens locally against a throwaway `dict[str, str]`. Round trips drop from N to one.

No API or schema change; this is client-side only.

## Notes for review

- `file_type` scoping is preserved. `list_device_configs` defaults its `file_type` argument to a sentinel that `_file_type_params` resolves to `self.file_type`, so the plain call stays scoped to `intended`/`backup` matching the client.
- Filename is a safe dict key here because `get_all_device_configs` returns one row per `(filename, file_type)` at max version, so within a single `file_type` there are no collisions.
- `.get(...) == content` replaces the try/except: a missing filename yields `None`, which never equals a config string, so the file falls through to being written — the same outcome the `except ConfigStoreFileNotFound: pass` produced.
- Bandwidth is a wash. `load_file` already returned full content per file, so this transfers the same bytes in one response. It does hold one device's files in memory simultaneously rather than one at a time; `persist_files` only ever handles a single device per call.
- **Behavior change worth noting:** a config-store outage now fails the render at the list call rather than at the first per-file GET. Both failed before, a few lines later, and retry handling for 429/5xx is unchanged — but the logged message becomes "Failed to list configs" instead of "Failed to load startup.yaml".

## Test plan

- [x] `uv run pytest src/tests/common src/tests/config_store src/tests/render` — 363 passed, 4 skipped
- [x] `uv run ruff check` / `ruff format --check` / `uv run mypy` on both changed files
- [x] `test_persist_files_new` rewritten — it asserted the old mechanism directly by monkeypatching `load_file` to raise; now mocks `list_device_configs` and asserts exactly one device-scoped call
- [x] `test_persist_files_skips_unchanged` added — covers the no-diff path (previously uncovered, and the behavior most at risk from this rewrite) plus `.j2` stripping
- [x] `test_load_file_not_found` added — `load_file`'s 404 mapping had no coverage and is still live for ZTP and the deploy activities
- [ ] Confirm the 404 rate on `nv_config_manager_config_store_http_requests_total` drops after deploy, particularly around the next template version bump

## Related

Does not address the other two items from the SLO investigation: the ZTP `device_http_requests` counter is dead (calls `.labels()` without `.inc()`), and `monitoring.groupFastApiStatusCodes: true` collapses 403 and 404 into `status="4xx"` so SPIFFE ACL denials can't be separated from missing configs in the SLI.