### PR TITLE
fix(render): stop the device-change fan-out from amplifying and self-heal wedged consumers

### DIFF
--- a/deploy/helm/templates/render-service.yaml
+++ b/deploy/helm/templates/render-service.yaml
@@ -222,6 +222,15 @@ spec:
         ports:
         - name: metrics
           containerPort: 8000
+        - name: health
+          containerPort: 8001
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8001
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          failureThreshold: 4
         resources:
           {{- toYaml .Values.renderService.consumers.nautobot.resources | nindent 10 }}
         volumeMounts:
@@ -333,6 +342,15 @@ spec:
         ports:
         - name: metrics
           containerPort: 8000
+        - name: health
+          containerPort: 8001
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8001
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          failureThreshold: 4
         resources:
           {{- toYaml .Values.renderService.consumers.device.resources | nindent 10 }}
         volumeMounts:

--- a/packages/templates/src/nv_config_manager_templates/filters/__init__.py
+++ b/packages/templates/src/nv_config_manager_templates/filters/__init__.py
@@ -17,3 +17,12 @@
 
 class FilterException(Exception):
     """Exception to be thrown when bad input is supplied to a filter."""
+
+
+class DeviceNotRenderableError(FilterException):
+    """Raised when a device lacks the data needed to select any template set.
+
+    Distinct from FilterException so callers can treat it as "nothing to render
+    yet" rather than a render defect. Subclasses FilterException so existing
+    handlers keep working unchanged.
+    """

--- a/packages/templates/src/nv_config_manager_templates/filters/device.py
+++ b/packages/templates/src/nv_config_manager_templates/filters/device.py
@@ -25,7 +25,7 @@ from nv_config_manager_templates.dataclasses.bgp import BGPLocalConfig, BGPPeer
 from nv_config_manager_templates.dataclasses.consoleport import ConsoleServerPort
 from nv_config_manager_templates.dataclasses.interface import ConnectedDevice, Interface
 from nv_config_manager_templates.dataclasses.vrf import VRF
-from nv_config_manager_templates.filters import FilterException
+from nv_config_manager_templates.filters import DeviceNotRenderableError, FilterException
 from nv_config_manager_templates.filters.ip import gateway as gateway_filter
 
 
@@ -88,11 +88,14 @@ def role(value: DeviceRenderData) -> str:
 
 def desired_firmware(value: DeviceRenderData) -> str:
     """Return the desired firmware image version for this device."""
-    return _required(
-        value.firmware.desired_version,
-        "device.firmware.desired_version",
-        value,
-    )
+    if value.firmware.desired_version is None:
+        # The firmware version selects the template directory, so a device
+        # without one has no template set to render from. That is a device that
+        # is not ready yet, not a broken render.
+        raise DeviceNotRenderableError(
+            f"Device {value.identity.name} has no desired firmware version set."
+        )
+    return value.firmware.desired_version
 
 
 def router_id(value: DeviceRenderData) -> str:

--- a/packages/templates/src/nv_config_manager_templates/render.py
+++ b/packages/templates/src/nv_config_manager_templates/render.py
@@ -41,7 +41,7 @@ import nv_config_manager_templates.filters.device as device_filters
 import nv_config_manager_templates.filters.ip as ip_filters
 import nv_config_manager_templates.filters.location as location_filters
 import nv_config_manager_templates.filters.vault as vault_filters
-from nv_config_manager_templates.filters import FilterException
+from nv_config_manager_templates.filters import DeviceNotRenderableError, FilterException
 
 # Modify this constant as new filter modules are implemented
 FILTER_MODULES = [
@@ -270,7 +270,15 @@ class Renderer:
         """List all entrypoint templates for the given device."""
         platform = self._normalize_string(device_filters.platform(device_data))
         role = self._normalize_string(device_filters.role(device_data))
-        fwver = device_filters.desired_firmware(device_data)
+        try:
+            fwver = device_filters.desired_firmware(device_data)
+        except DeviceNotRenderableError as exc:
+            # The firmware version is only a path component here, so a device
+            # without one matches no entrypoints. Report that as an empty set
+            # rather than failing the whole render: a device awaiting firmware
+            # assignment is a normal state, not a defect.
+            logger.info("No entrypoints for %s/%s: %s", platform, role, exc)
+            return []
 
         path = f"{platform}/{role}/{fwver}/entrypoint/"
         return [

--- a/packages/templates/tests/nv_config_manager_templates/filters/test_device.py
+++ b/packages/templates/tests/nv_config_manager_templates/filters/test_device.py
@@ -42,7 +42,7 @@ from nv_config_manager_dcim import (
 
 from nv_config_manager_templates.dataclasses.interface import Interface
 from nv_config_manager_templates.dataclasses.vrf import VRF
-from nv_config_manager_templates.filters import FilterException
+from nv_config_manager_templates.filters import DeviceNotRenderableError, FilterException
 from nv_config_manager_templates.filters.device import (
     asn,
     attached_vrfs,
@@ -173,12 +173,16 @@ def test_interface_has_tag(public_leaf_data: dict) -> None:
 
 
 def test_desired_firmware_missing(public_leaf_data: dict) -> None:
-    """Missing intended firmware reports a clear filter error."""
+    """Missing intended firmware is reported as not-renderable, not a bad filter input."""
     no_desired_data = public_leaf_data.model_copy(
         update={"firmware": public_leaf_data.firmware.model_copy(update={"desired_version": None})}
     )
 
-    with pytest.raises(FilterException, match="device.firmware.desired_version"):
+    with pytest.raises(DeviceNotRenderableError, match="no desired firmware version set"):
+        desired_firmware(no_desired_data)
+
+    # Still a FilterException so existing callers keep working.
+    with pytest.raises(FilterException):
         desired_firmware(no_desired_data)
 
 

--- a/packages/templates/tests/nv_config_manager_templates/test_render.py
+++ b/packages/templates/tests/nv_config_manager_templates/test_render.py
@@ -150,6 +150,21 @@ def test_missing_site_aggregate_fails_edge_render() -> None:
         renderer.render(template, render_data)
 
 
+def test_missing_intended_firmware_yields_no_entrypoints() -> None:
+    """A device awaiting firmware assignment renders nothing instead of failing."""
+    os.environ["NV_CONFIG_MANAGER_SKIP_VAULT"] = "1"
+
+    with (RENDER_DATA_DIR / "a09-u28-p01-bleaf-01.json").open(encoding="utf-8") as file:
+        render_data = RenderData.from_cache(json.load(file))
+    no_firmware = render_data.device.model_copy(
+        update={
+            "firmware": render_data.device.firmware.model_copy(update={"desired_version": None})
+        }
+    )
+
+    assert Renderer().list_entrypoints(no_firmware) == []
+
+
 def test_renderer_exposes_plugin_extension_data(public_leaf_data, public_location_data) -> None:
     """Plugin filters receive extension data, not provider cache envelope metadata."""
     render_data = RenderData(

--- a/src/nv_config_manager/common/client/config_store.py
+++ b/src/nv_config_manager/common/client/config_store.py
@@ -391,16 +391,21 @@ class ConfigStoreClient(_WhoamiViaRetryClientMixin):
         """
         author_email = f"{user}@{user_domain}"
 
+        # One device-scoped read instead of a GET per file. The per-file endpoint
+        # 404s for anything not yet stored, so a first render of a device (or of a
+        # newly added template) used to emit a 404 per file purely to compute the
+        # diff. The device endpoint returns an empty list instead.
+        existing_content = {
+            str(config["filename"]): str(config["content"])
+            for config in await self.list_device_configs(device_uuid)
+        }
+
         filtered_items = []
         for filename, content in files.items():
             clean_filename = filename.replace(".j2", "")
-            try:
-                existing_file = await self.load_file(device_uuid, clean_filename)
-                if content == existing_file.content:
-                    self.logger.info("No diff for %s/%s", device_uuid, clean_filename)
-                    continue
-            except ConfigStoreFileNotFound:
-                pass
+            if existing_content.get(clean_filename) == content:
+                self.logger.info("No diff for %s/%s", device_uuid, clean_filename)
+                continue
 
             filtered_items.append(
                 {

--- a/src/nv_config_manager/common/nats_admin.py
+++ b/src/nv_config_manager/common/nats_admin.py
@@ -18,7 +18,10 @@ import nats.errors
 from nats.js.errors import APIError
 
 CONSUMER_ACK_WAIT_SECONDS = 360
-CONSUMER_MAX_DELIVER = -1
+# Bounded so that a message which can never win its per-device lock stops
+# circulating. Lock contention naks count as delivery attempts, so this has to
+# stay well above the retry depth a healthy render needs.
+CONSUMER_MAX_DELIVER = 1000
 
 
 def is_nats_permissions_error(exc: Exception) -> bool:

--- a/src/nv_config_manager/render/events/util.py
+++ b/src/nv_config_manager/render/events/util.py
@@ -45,6 +45,14 @@ class DeviceNotEnabledError(Exception):
     """To be raised if a device is not enabled for NVIDIA Config Manager."""
 
 
+# How long a device stays deduped while its render is queued but not yet
+# processed. This has to cover worst-case queue latency: a change to one shared
+# Nautobot object fans out to every attached device, so if the flag expires
+# before the render runs, the next change re-publishes the same device and the
+# queue amplifies by one copy per change.
+QUEUED_FLAG_TTL_SECONDS = 3600
+
+
 def _get_queue_redis_client() -> RedisClient | None:
     """Create a Redis client for queue operations."""
     if is_local_environment():
@@ -75,7 +83,30 @@ async def mark_queued(device_uuid: str, client: RedisClient | None = None) -> No
 
     try:
         queue_key = f"{device_uuid}_queued"
-        await client.setex(queue_key, 60, 1, serialize=False)  # TTL of 60 seconds
+        await client.setex(queue_key, QUEUED_FLAG_TTL_SECONDS, 1, serialize=False)
+    finally:
+        if owned_client:
+            await _close_queue_redis_client(client)
+
+
+async def claim_queued(device_uuid: str, client: RedisClient | None = None) -> bool:
+    """Atomically claim the render queue slot for a device.
+
+    Returns True when the caller won the claim and should publish, False when a
+    render is already queued. Separate ``exists`` and ``setex`` calls let
+    concurrent producers both observe an unset flag and both publish, so the
+    check and the set have to happen in one ``SET NX EX``.
+    """
+    owned_client = client is None
+    client = client or _get_queue_redis_client()
+    if client is None:
+        # Local environment, never dedup
+        return True
+
+    try:
+        queue_key = f"{device_uuid}_queued"
+        claimed = await client.redis.set(queue_key, b"1", ex=QUEUED_FLAG_TTL_SECONDS, nx=True)
+        return bool(claimed)
     finally:
         if owned_client:
             await _close_queue_redis_client(client)
@@ -148,8 +179,9 @@ async def _process_single_device_enqueue(
         None if successful, dict with error details if failed
     """
     try:
-        # Check if device is already queued for rendering
-        if await is_queued(device_uuid, queue_client):
+        # Claim before the Nautobot lookup so that concurrent producers collapse
+        # to a single publish per device rather than one publish per change.
+        if not await claim_queued(device_uuid, queue_client):
             logger.info(
                 "Device %s already has a pending render, skipping duplicate queue request",
                 device_uuid,
@@ -157,13 +189,11 @@ async def _process_single_device_enqueue(
             return None
 
         if not await should_run(device_uuid, dcim_client):
+            await clear_queued(device_uuid, queue_client)
             return {
                 "device_uuid": device_uuid,
                 "error": f"{device_uuid} is not enabled for configuration renders.",
             }
-
-        # Mark device as queued before publishing
-        await mark_queued(device_uuid, queue_client)
 
         # Publish message using provided jetstream connection
         message = {

--- a/src/nv_config_manager/render/pull_consumer.py
+++ b/src/nv_config_manager/render/pull_consumer.py
@@ -21,7 +21,12 @@ import logging
 import os
 import signal
 import ssl
+import threading
+import time
 from asyncio import AbstractEventLoop
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
 
 import nats
 import nats.errors
@@ -128,6 +133,21 @@ class PullConsumer:
         # Must be < FetchMaxWait/2 (default FetchMaxWait=5s, so heartbeat must be < 2.5s)
         self.heartbeat_interval = 1.0
 
+        # Liveness. A broken connection can leave this loop retrying forever
+        # without the process ever exiting, so the only trustworthy evidence
+        # that the consumer still works is a fetch that completes. An idle
+        # queue is healthy; a fetch that never completes is not.
+        #
+        # The budget has to exceed the longest time one message can legitimately
+        # occupy the loop, because the clock is only stamped between fetches. A
+        # message still being worked on past its ack wait is already redelivered
+        # elsewhere, so that is the point where a stalled loop stops being
+        # merely slow.
+        self.liveness_timeout = float(
+            os.getenv("CONSUMER_LIVENESS_TIMEOUT_SECONDS", str(CONSUMER_ACK_WAIT_SECONDS + 240))
+        )
+        self._last_successful_fetch = time.monotonic()
+
     def run(self) -> None:
         """Run the consumer."""
         try:
@@ -172,6 +192,19 @@ class PullConsumer:
         Override this in subclasses to implement custom flow control logic.
         """
         return True
+
+    def _record_successful_fetch(self) -> None:
+        """Note that a fetch completed, whether or not it returned messages."""
+        self._last_successful_fetch = time.monotonic()
+
+    def liveness(self) -> tuple[bool, str]:
+        """Report whether a fetch has completed recently enough."""
+        stalled_for = time.monotonic() - self._last_successful_fetch
+        if stalled_for > self.liveness_timeout:
+            return False, (
+                f"no successful fetch for {stalled_for:.0f}s (limit {self.liveness_timeout:.0f}s)"
+            )
+        return True, f"last successful fetch {stalled_for:.0f}s ago"
 
     async def ack(self, msg: Msg) -> None:
         """Acknowledge a message with resilient error handling."""
@@ -352,12 +385,14 @@ class PullConsumer:
                     # raise an exception after missing heartbeats. Any exception
                     # during fetch indicates we should recreate the consumer.
                     msgs = await pull_subscription.fetch(batch=1, heartbeat=self.heartbeat_interval)
+                    self._record_successful_fetch()
                     if msgs:
                         await self._resilient_message_handler(msgs[0])
                     else:
                         await asyncio.sleep(self.idle_wait)
                 except FetchTimeoutError:
                     # Heartbeats were fine, but no messages were received
+                    self._record_successful_fetch()
                     await asyncio.sleep(self.idle_wait)
                 except Exception as e:
                     # Any exception during fetch (timeouts, heartbeat failures,
@@ -588,22 +623,58 @@ class PullDeviceChangeConsumer(PullConsumer):
             await self.nak(msg, delay=5)
             return
         try:
-            # Clear the queued flag only after successfully acquiring the lock
-            await clear_queued(device_id)
             # Dispatch is now async, so we can await it directly
             await self.dispatcher.nautobot_change_dispatch(data)
+            # Release the dedup slot only once the render is finished. Clearing
+            # at lock acquisition reopens it for the whole duration of the
+            # render, so a change arriving mid-render enqueues a duplicate.
+            await clear_queued(device_id)
             await self.ack(msg)
         except RenderException:
             # No need to redeliver render exceptions, they won't succeed on retry
+            await clear_queued(device_id)
             await self.ack(msg)
         except Exception as e:
             self.logger.error("Error processing device change message: %s", data, exc_info=e)
+            # Leave the dedup slot claimed: the render is still pending until a
+            # redelivery completes it.
             await self.nak(msg)
         finally:
             try:
                 await lock.release()
             except Exception as e:
                 self.logger.error("Error releasing lock for %s", device_id, exc_info=e)
+
+
+def start_liveness_server(consumer: PullConsumer, port: int = 8001) -> ThreadingHTTPServer:
+    """Serve consumer liveness on /healthz.
+
+    Without this the pod stays Running and Ready while the consumer makes no
+    progress, because the retry loop swallows every error and the process never
+    exits. Nothing outside the process can then restart it.
+    """
+
+    class LivenessHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path.rstrip("/") not in ("/healthz", ""):
+                self.send_error(HTTPStatus.NOT_FOUND)
+                return
+            live, detail = consumer.liveness()
+            body = detail.encode()
+            self.send_response(HTTPStatus.OK if live else HTTPStatus.SERVICE_UNAVAILABLE)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+            """Drop per-request logging so probes do not flood the log."""
+
+    server = ThreadingHTTPServer(("", port), LivenessHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
 
 
 def main() -> None:
@@ -622,6 +693,7 @@ def main() -> None:
     else:
         raise NotImplementedError(f"No consumer implemented for {consumer_name}.")
 
+    start_liveness_server(consumer)
     consumer.run()
     get_logger(__name__, category=LogCategory.RENDER_EVENT).info("Exiting...")
 

--- a/src/tests/common/nv_config_manager_config_store/test_config_store_client.py
+++ b/src/tests/common/nv_config_manager_config_store/test_config_store_client.py
@@ -16,6 +16,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 import pytest_asyncio
 
@@ -137,14 +138,31 @@ async def test_whoami_uses_service_root(async_config_store_client):
 
 
 @pytest.mark.asyncio
+async def test_load_file_not_found(async_config_store_client):
+    """Test a 404 from the per-file endpoint maps to ConfigStoreFileNotFound."""
+    mock_session = _mock_retry_client(None)
+    mock_session.get.return_value.raise_for_status = MagicMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=404, message="Not Found"
+        )
+    )
+
+    with patch(
+        "nv_config_manager.common.client.config_store.RetryClient", return_value=mock_session
+    ):
+        with pytest.raises(ConfigStoreFileNotFound):
+            await async_config_store_client.load_file(
+                "123e4567-e89b-12d3-a456-426614174000", "startup.yaml"
+            )
+
+
+@pytest.mark.asyncio
 async def test_persist_files_new(async_config_store_client):
-    """Test persisting new files."""
+    """Test persisting files for a device with nothing stored yet."""
     device_uuid = "123e4567-e89b-12d3-a456-426614174000"
 
-    async def mock_load_file(dev_uuid, filename):
-        raise ConfigStoreFileNotFound(f"File {filename} not found")
-
-    async_config_store_client.load_file = mock_load_file
+    list_configs = AsyncMock(return_value=[])
+    async_config_store_client.list_device_configs = list_configs
 
     mock_session = _mock_retry_client(MOCK_BATCH_POST_RESPONSE)
 
@@ -163,6 +181,34 @@ async def test_persist_files_new(async_config_store_client):
     assert len(config_files) == 1
     assert config_files[0].commit == "6"
     assert config_files[0].filename == "startup.yaml"
+    # A device with no stored configs must be discovered without a per-file GET.
+    list_configs.assert_awaited_once_with(device_uuid)
+
+
+@pytest.mark.asyncio
+async def test_persist_files_skips_unchanged(async_config_store_client):
+    """Test files matching the stored content are not resubmitted."""
+    device_uuid = "123e4567-e89b-12d3-a456-426614174000"
+
+    async_config_store_client.list_device_configs = AsyncMock(
+        return_value=[dict(MOCK_GET_RESPONSE)]
+    )
+
+    mock_session = _mock_retry_client(MOCK_BATCH_POST_RESPONSE)
+
+    with patch(
+        "nv_config_manager.common.client.config_store.RetryClient", return_value=mock_session
+    ):
+        config_files = await async_config_store_client.persist_files(
+            device_uuid=device_uuid,
+            files={"startup.yaml.j2": MOCK_GET_RESPONSE["content"]},
+            commit_message="test commit message",
+            user="testuser",
+            user_domain="config-manager.example.com",
+        )
+
+    assert config_files is None
+    mock_session.post.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/src/tests/common/test_nats_client.py
+++ b/src/tests/common/test_nats_client.py
@@ -22,6 +22,7 @@ from nats.js.api import AckPolicy, DeliverPolicy
 from nats.js.errors import NotFoundError
 
 from nv_config_manager.common.client import DEFAULT_NATS_API_PREFIX, NatsClient, NatsConsumer
+from nv_config_manager.common.nats_admin import CONSUMER_MAX_DELIVER
 
 TEST_SERVER = "nats://nats.example.local:4222"
 
@@ -136,7 +137,7 @@ async def test_consumer_binds_existing_durable_with_configured_api_prefix():
     assert config.deliver_policy == DeliverPolicy.NEW
     assert config.ack_policy == AckPolicy.EXPLICIT
     assert config.ack_wait == 360
-    assert config.max_deliver == -1
+    assert config.max_deliver == CONSUMER_MAX_DELIVER
 
 
 @pytest.mark.asyncio

--- a/src/tests/render/events/test_util.py
+++ b/src/tests/render/events/test_util.py
@@ -21,7 +21,9 @@ import pytest
 
 from nv_config_manager.dcim import RenderDeviceStatus
 from nv_config_manager.render.events.util import (
+    QUEUED_FLAG_TTL_SECONDS,
     DeviceNotEnabledError,
+    claim_queued,
     clear_queued,
     is_queued,
     mark_queued,
@@ -112,11 +114,16 @@ is_aggregate_environment=false
     )
     with patch("nv_config_manager.render.events.util._get_queue_redis_client") as redis_getter:
         redis = MagicMock()
-        redis.exists = AsyncMock(return_value=False)
-        redis.setex = AsyncMock()
+        redis.redis.set = AsyncMock(return_value=True)  # Claim won
+        redis.delete = AsyncMock()
         redis_getter.return_value = redis
 
         await queue_render("test-device", "message", "user", "2024-01-16T21:46:05Z")
+
+        # The claim is a single atomic SET NX EX, not a separate check and set
+        redis.redis.set.assert_awaited_once_with(
+            "test-device_queued", b"1", ex=QUEUED_FLAG_TTL_SECONDS, nx=True
+        )
 
     mock_nats_connection.jetstream.return_value.publish.assert_awaited_once()
     mock_dcim_client.get_render_device_status.assert_awaited_once_with("test-device")
@@ -152,13 +159,16 @@ is_aggregate_environment=false
     mock_nats_connection.jetstream.return_value.publish.side_effect = RuntimeError("NATS error")
     with patch("nv_config_manager.render.events.util._get_queue_redis_client") as redis_getter:
         redis = MagicMock()
-        redis.exists = AsyncMock(return_value=False)
-        redis.setex = AsyncMock()
+        redis.redis.set = AsyncMock(return_value=True)  # Claim won
         redis.delete = AsyncMock()
         redis_getter.return_value = redis
 
         with pytest.raises(Exception, match="NATS error"):
             await queue_render("test-device", "message", "user", "2024-01-16T21:46:05Z")
+
+        redis.redis.set.assert_awaited_once_with(
+            "test-device_queued", b"1", ex=QUEUED_FLAG_TTL_SECONDS, nx=True
+        )
 
     redis.delete.assert_awaited_once_with("test-device_queued")
 
@@ -177,5 +187,25 @@ async def test_redis_deduplication_functions():
         assert await is_queued("device") is True
         await clear_queued("device")
 
-    redis.setex.assert_awaited_once_with("device_queued", 60, 1, serialize=False)
+    redis.setex.assert_awaited_once_with(
+        "device_queued", QUEUED_FLAG_TTL_SECONDS, 1, serialize=False
+    )
     redis.delete.assert_awaited_once_with("device_queued")
+
+
+@pytest.mark.asyncio
+async def test_claim_queued_is_atomic_and_exclusive():
+    """Only the first caller may claim a device, via a single SET NX EX."""
+    with patch("nv_config_manager.render.events.util._get_queue_redis_client") as redis_getter:
+        redis = MagicMock()
+        redis.redis.set = AsyncMock(return_value=True)
+        redis_getter.return_value = redis
+
+        assert await claim_queued("device") is True
+        redis.redis.set.assert_awaited_once_with(
+            "device_queued", b"1", ex=QUEUED_FLAG_TTL_SECONDS, nx=True
+        )
+
+        # A second caller loses the claim while the flag is held
+        redis.redis.set = AsyncMock(return_value=None)
+        assert await claim_queued("device") is False

--- a/src/tests/render/test_pull_consumer.py
+++ b/src/tests/render/test_pull_consumer.py
@@ -15,6 +15,8 @@
 """Tests for the NATS pull consumer module."""
 
 import json
+import urllib.error
+import urllib.request
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nats.errors
@@ -27,6 +29,7 @@ from redis.asyncio.lock import Lock as AsyncRedisLock
 from nv_config_manager.render.events.util import DeviceNotEnabledError
 from nv_config_manager.render.pull_consumer import (
     CONSUMER_ACK_PENDING,
+    CONSUMER_ACK_WAIT_SECONDS,
     CONSUMER_PENDING,
     CONSUMER_REDELIVERED,
     CONSUMER_WAITING,
@@ -34,6 +37,7 @@ from nv_config_manager.render.pull_consumer import (
     PullDCIMConsumer,
     PullDeviceChangeConsumer,
     PullNautobotConsumer,
+    start_liveness_server,
 )
 
 # Test NATS configuration - mock credentials for testing only
@@ -135,6 +139,69 @@ async def test_pull_consumer_can_process_message(custom_ini):
 
     # Default implementation should always return True
     assert await consumer.can_process_message() is True
+
+
+def test_liveness_fails_once_fetches_stop_completing(custom_ini):
+    """A consumer that cannot complete a fetch must report itself unhealthy."""
+    custom_ini(TEST_NATS_CONFIG)
+    consumer = PullConsumer(
+        stream="test_stream",
+        subject="test_subject",
+        queue_suffix="test_queue",
+    )
+
+    live, _ = consumer.liveness()
+    assert live is True
+
+    # A wedged connection leaves the retry loop running but never completes a
+    # fetch, which is the only state that distinguishes it from an idle queue.
+    consumer._last_successful_fetch -= consumer.liveness_timeout + 1
+    live, detail = consumer.liveness()
+    assert live is False
+    assert "no successful fetch" in detail
+
+    # A fetch that returns no messages still proves the connection works
+    consumer._record_successful_fetch()
+    live, _ = consumer.liveness()
+    assert live is True
+
+
+def test_liveness_budget_outlasts_one_slow_message(custom_ini):
+    """A render that is slow but working must not be mistaken for a wedged loop."""
+    custom_ini(TEST_NATS_CONFIG)
+    consumer = PullConsumer(
+        stream="test_stream",
+        subject="test_subject",
+        queue_suffix="test_queue",
+    )
+
+    # The clock is only stamped between fetches, so a single message occupies the
+    # loop for its whole render. A budget below the ack wait would restart the pod
+    # mid-render, and the redelivery would be just as slow.
+    assert consumer.liveness_timeout > CONSUMER_ACK_WAIT_SECONDS
+
+
+def test_liveness_endpoint_returns_503_when_wedged(custom_ini):
+    """The probe endpoint has to fail closed so Kubernetes restarts the pod."""
+    custom_ini(TEST_NATS_CONFIG)
+    consumer = PullConsumer(
+        stream="test_stream",
+        subject="test_subject",
+        queue_suffix="test_queue",
+    )
+    server = start_liveness_server(consumer, port=0)
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/healthz"
+        with urllib.request.urlopen(url, timeout=5) as response:
+            assert response.status == 200
+
+        consumer._last_successful_fetch -= consumer.liveness_timeout + 1
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            urllib.request.urlopen(url, timeout=5)
+        assert excinfo.value.code == 503
+    finally:
+        server.shutdown()
+        server.server_close()
 
 
 def test_render_consumer_metrics_are_labeled_by_fixed_consumer(custom_ini, monkeypatch):


### PR DESCRIPTION
## Problem

A single bulk update to a shared Nautobot object can fan out into a very large backlog of duplicate render events. Once the queue is deep enough, the consumer neither drains it nor recovers on its own, and a wedged consumer keeps reporting `Running` and `Ready` while doing no work at all.

Four distinct defects combined to produce and sustain that.

## 1. Dedup was effectively disabled

`clear_queued` was called at lock acquisition, *before* dispatch:

```python
lock = await create_lock(device_id, blocking=False)
...
await clear_queued(device_id)          # window closes here
await self.dispatcher.nautobot_change_dispatch(data)
```

So the suppression window lasted milliseconds rather than covering the render. Because a render that fails on missing data fails immediately, **the faster it failed the faster dedup was defeated** — a positive feedback loop where failing renders accelerate the fan-out causing the failures.

Clearing now happens once the render finishes. On the generic-exception path the slot is deliberately left claimed, because the render really is still pending until a redelivery completes it.

## 2. The dedup claim was not atomic

`is_queued` (EXISTS) followed by `mark_queued` (SETEX) let concurrent producers all observe an unset flag and all publish. With `queue_render_batch` at `max_concurrency=20` across multiple replicas that's likely, not theoretical. Replaced with a single `SET NX EX` in `claim_queued`, publishing only when the claim is won.

TTL also goes from 60s to 1h. A 60-second window can expire mid-render, and any device touched more than once a minute got a fresh publish regardless.

## 3. Redelivery was unbounded

`CONSUMER_MAX_DELIVER = -1` meant a message that can never win its per-device lock circulated forever. This matters more than it looks because lock-contention `nak`s count as delivery attempts. Bounded at 1000 — well above the retry depth a healthy render needs.

Worth flagging for reviewers: `_ensure_consumer_exists` only *warns* when an existing durable's config differs from these constants, it never corrects it. Changing the constant will not touch consumers that already exist; those need an operator reset (`reset_consumer_request` describes it).

## 4. A wedged consumer could never be restarted

The retry loop catches every exception and the process never exits, so nothing outside the process could restart it, and a consumer could stay broken indefinitely with no probes present. Adds `/healthz` on port 8001 reporting whether a fetch has completed within `CONSUMER_LIVENESS_TIMEOUT_SECONDS`, plus a `livenessProbe` on both consumer deployments.

An idle queue counts as healthy: `_record_successful_fetch()` fires on `FetchTimeoutError` too, since a timeout means heartbeats were fine and there was simply nothing to do. Only a fetch that never *completes* marks the pod unhealthy.

The default budget is derived from `CONSUMER_ACK_WAIT_SECONDS` rather than being a flat 120s. The liveness clock is only stamped between fetches, so a single slow render occupies the loop for its whole duration; a budget below the ack wait would restart the pod mid-render and the redelivery would be just as slow. Past the ack wait the message is already being redelivered elsewhere, which is the point where a stalled loop stops being merely slow.

## 5. Missing intended-firmware is no longer a render failure

`desired_firmware` raises the new `DeviceNotRenderableError` (subclassing `FilterException`, so existing handlers are unaffected), and `list_entrypoints` treats it as an empty entrypoint set. The firmware version is only a path component in `{platform}/{role}/{fwver}/entrypoint/`, so a device awaiting firmware assignment legitimately matches no templates — `execute_render` already handles the empty case with "No entrypoint templates matched". This stops devices pending firmware assignment counting as `RenderException`s and makes the processed-vs-failed counters meaningful again.

## Test plan

- [x] `pytest src/tests/render src/tests/common` — 317 passed, 4 skipped
- [x] `pytest components/network-templates/tests` — 108 passed
- [x] `ruff check` and `ruff format --check` clean on all changed files
- [x] Full `src/tests` suite — 1613 passed; the one failure (`test_kea_dhcp_confgen.py::test_kea_config_valid`) needs Docker and is unrelated
- [ ] Verify `/healthz` returns 503 on a deliberately wedged consumer before rollout
- [ ] After deploy, confirm `nv_config_manager_nautobot_change_messages_processed_total` becomes non-zero

## Not covered here

The NATS WebSocket transport is a contributing root cause and is *not* fixed by this PR. `nats-py`'s `WebSocketTransport.readline()` only handles `WSMsgType.CLOSED` and returns `data.data` unconditionally, so a `WSMsgType.ERROR` hands the protocol parser a `WebSocketError` object and raises `TypeError`; `drain()` also dequeues before awaiting `send_bytes`, silently dropping a message on every teardown. Clients reached over a WebSocket proxy can therefore tear down repeatedly and, in the worst case, stop reconnecting entirely. The practical remedy is deployment-side configuration of `[nats] server` and belongs with the deployment manifests rather than here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added health checks for consumer services, reporting service readiness through HTTP status responses.
  - Added safeguards to prevent duplicate queued renders during concurrent processing.
  - Devices without sufficient firmware information are now skipped cleanly during rendering.

- **Bug Fixes**
  - Unchanged configuration files are no longer resubmitted unnecessarily.
  - Messages that repeatedly fail delivery are now capped to prevent indefinite retries.
  - Improved render-event handling after successful and failed processing.

- **Tests**
  - Expanded coverage for health checks, queue claiming, configuration persistence, retry limits, and non-renderable devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->