### PR TITLE
fix(ci): Hide Pulse and airgapped jobs from special pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,10 +4,18 @@ include:
   - local: .gitlab/ci/lint.yml
   - local: .gitlab/ci/build.yml
   - local: .gitlab/ci/test.yml
+  # Secret-free pull-request builds and protected test-env promote pipelines
+  # have deliberately narrow job sets. Do not include unrelated Pulse or
+  # airgapped jobs (including their tracking/manual placeholders) in them.
   - local: .gitlab/ci/pulse.yml
+    rules: &exclude-special-pipeline-fragments
+      - if: $CI_COMMIT_BRANCH =~ /^pull-request\// || (($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $NVCM_PROMOTE_ENV =~ /^(test|test01)$/)
+        when: never
+      - when: always
   - local: .gitlab/ci/sonar.yml
   - local: .gitlab/ci/deploy.yml
   - local: .gitlab/ci/release.yml
   - local: .gitlab/ci/airgapped.yml
+    rules: *exclude-special-pipeline-fragments
   - local: .gitlab/ci/pr-build.yml
   - local: .gitlab/ci/promote-test-envs.yml


### PR DESCRIPTION
## Description

Exclude the Pulse and airgapped CI fragments from the test promotion pipelines. These are not needed.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run. No point, internal gitlab config only.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.
