### PR TITLE
ztp os upgrade initial

### DIFF
--- a/components/nautobot/nv_config_manager_jobs/data/config_contexts.yaml
+++ b/components/nautobot/nv_config_manager_jobs/data/config_contexts.yaml
@@ -21,7 +21,7 @@
   deployment_types: [all]
 
 - name: NVIDIA Config Manager DHCP Custom Options
-  description: Custom DHCP option definitions for KEA (cumulus-provision-url)
+  description: Custom DHCP option definitions for KEA (cumulus-provision-url and Junos option 43)
   weight: 1000
   is_active: true
   schema: nv-config-manager-site-dhcp-option-def
@@ -35,4 +35,66 @@
           space: dhcp4
           encapsulate: ""
           record-types: ""
+        - code: 0
+          name: image-file-name
+          type: string
+          array: false
+          space: vendor-encapsulated-options-space
+          encapsulate: ""
+          record-types: ""
+        - code: 1
+          name: config-file-name
+          type: string
+          array: false
+          space: vendor-encapsulated-options-space
+          encapsulate: ""
+          record-types: ""
+        - code: 2
+          name: image-file-type
+          type: string
+          array: false
+          space: vendor-encapsulated-options-space
+          encapsulate: ""
+          record-types: ""
+        - code: 3
+          name: transfer-mode
+          type: string
+          array: false
+          space: vendor-encapsulated-options-space
+          encapsulate: ""
+          record-types: ""
+        - code: 4
+          name: alt-image-file-name
+          type: string
+          array: false
+          space: vendor-encapsulated-options-space
+          encapsulate: ""
+          record-types: ""
+        - code: 5
+          name: http-port
+          type: string
+          array: false
+          space: vendor-encapsulated-options-space
+          encapsulate: ""
+          record-types: ""
+  deployment_types: [all]
+
+- name: Juniper Junos ZTP DHCP Options
+  description: DHCP option 43 URLs for Junos HTTP ZTP and OS upgrade
+  weight: 1000
+  is_active: true
+  platforms:
+    - Juniper Junos
+  data:
+    dhcp:
+      options:
+        interface_names:
+          fxp0: &juniper_ztp_reservation
+            reservation_options:
+              transfer-mode: http
+              image-file-name: http://{{ ztp_server }}/v1/device/{{ device_id }}/firmware
+              config-file-name: http://{{ ztp_server }}/v1/device/{{ device_id }}/config/full-config
+          em0: *juniper_ztp_reservation
+          vme: *juniper_ztp_reservation
+          "re0:mgmt-0": *juniper_ztp_reservation
   deployment_types: [all]

--- a/components/nautobot/tests/test_load_bootstrap_data.py
+++ b/components/nautobot/tests/test_load_bootstrap_data.py
@@ -705,6 +705,45 @@ class TestLoadConfigContexts:
 
         assert firmware_contexts == []
 
+    def test_bundled_dhcp_option_defs_include_junos_option_43(self):
+        data_path = Path(__file__).resolve().parents[1] / "nv_config_manager_jobs/data/config_contexts.yaml"
+        with data_path.open() as f:
+            config_contexts = yaml.safe_load(f)
+
+        option_context = next(
+            context for context in config_contexts if context["name"] == "NVIDIA Config Manager DHCP Custom Options"
+        )
+        option_names = {entry["name"] for entry in option_context["data"]["Dhcp4"]["option-def"]}
+        assert "cumulus-provision-url" in option_names
+        assert {
+            "image-file-name",
+            "config-file-name",
+            "image-file-type",
+            "transfer-mode",
+            "alt-image-file-name",
+            "http-port",
+        } <= option_names
+
+    def test_bundled_juniper_ztp_context_targets_junos_and_full_config(self):
+        data_path = Path(__file__).resolve().parents[1] / "nv_config_manager_jobs/data/config_contexts.yaml"
+        with data_path.open() as f:
+            config_contexts = yaml.safe_load(f)
+
+        ztp_context = next(
+            context for context in config_contexts if context["name"] == "Juniper Junos ZTP DHCP Options"
+        )
+        assert ztp_context["platforms"] == ["Juniper Junos"]
+        reservation = ztp_context["data"]["dhcp"]["options"]["interface_names"]["fxp0"]["reservation_options"]
+        assert reservation["transfer-mode"] == "http"
+        assert "/firmware" in reservation["image-file-name"]
+        assert "/config/full-config" in reservation["config-file-name"]
+        assert set(ztp_context["data"]["dhcp"]["options"]["interface_names"]) == {
+            "fxp0",
+            "em0",
+            "vme",
+            "re0:mgmt-0",
+        }
+
     def test_creates_config_context_with_roles_and_platforms(self, tmp_path):
         mod = _import_module()
         from nautobot.dcim.models import Platform

--- a/docs/dhcp/nautobot-modeling.mdx
+++ b/docs/dhcp/nautobot-modeling.mdx
@@ -377,9 +377,14 @@ Junos factory ZTP reads DHCP option 43, not `cumulus-provision-url`. The bundled
         }
       }
     }
+  },
+  "ztp": {
+    "ipv4": ["10.1.200.10", "10.1.200.11"]
   }
 }
 ```
+
+`{{ ztp_server }}` is rendered from the merged `ztp.ipv4` (or `ztp.ipv6`) list. Put that list in this context, or in another context that applies to the same device (typically a site-level context). Config generation fails if a reservation uses `{{ ztp_server }}` and no list is present.
 
 Custom option-def entries for those names must use Kea space `vendor-encapsulated-options-space` so they pack into DHCP option 43. The bundled `NVIDIA Config Manager DHCP Custom Options` context defines them.
 

--- a/docs/dhcp/nautobot-modeling.mdx
+++ b/docs/dhcp/nautobot-modeling.mdx
@@ -260,6 +260,7 @@ DHCP options applied to **individual reservations** only. These appear in the re
 **Common use cases**:
 
 - Boot scripts for ZTP: `cumulus-provision-url`, `boot-file-name`
+- Junos HTTP ZTP: `transfer-mode`, `image-file-name`, `config-file-name` (DHCP option 43 suboptions)
 - Device-specific settings: `hostname`, `domain-name`
 
 **Jinja2 variables**:
@@ -357,6 +358,32 @@ This config context:
 - Adds ZTP boot script URL to reservations on `eth0`
 - Sets DNS servers for the entire subnet
 - Enables global and in-subnet reservations
+
+### Example: Juniper Junos Switch
+
+Junos factory ZTP reads DHCP option 43, not `cumulus-provision-url`. The bundled `Juniper Junos ZTP DHCP Options` context targets platform `Juniper Junos` and applies these reservation options on common management interface names (`fxp0`, `em0`, `vme`, `re0:mgmt-0`):
+
+```json
+{
+  "dhcp": {
+    "options": {
+      "interface_names": {
+        "fxp0": {
+          "reservation_options": {
+            "transfer-mode": "http",
+            "image-file-name": "http://{{ ztp_server }}/v1/device/{{ device_id }}/firmware",
+            "config-file-name": "http://{{ ztp_server }}/v1/device/{{ device_id }}/config/full-config"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Custom option-def entries for those names must use Kea space `vendor-encapsulated-options-space` so they pack into DHCP option 43. The bundled `NVIDIA Config Manager DHCP Custom Options` context defines them.
+
+`config-file-name` points at the intended `full-config` file. Supply that file through operator or plugin templates; a missing file returns 404 from the ZTP API. Add other management interface names in a site context if needed.
 
 ## Flags
 

--- a/docs/network-ztp/configuration.mdx
+++ b/docs/network-ztp/configuration.mdx
@@ -21,11 +21,27 @@ Before configuring devices for ZTP, ensure:
 
 ### DHCP Configuration
 
-Configure your DHCP server to provide the ZTP boot file URL in the `boot-file-name` option:
+How the DHCP server tells a device where to fetch ZTP artifacts depends on the NOS:
+
+**Cumulus Linux** — `cumulus-provision-url` (and often `boot-file-name`) pointing at the boot script:
 
 ```text
-option boot-file-name "http://ztp.example.com/v1/device/{device_uuid}/boot-script";
+option cumulus-provision-url "http://ztp.example.com/v1/device/{device_uuid}/boot-script";
 ```
+
+**NV-OS** — `boot-file-name` pointing at `ztp.json`:
+
+```text
+option boot-file-name "http://ztp.example.com/v1/device/{device_uuid}/config/ztp.json";
+```
+
+**Juniper Junos** — DHCP option 43 (vendor-encapsulated) with HTTP transfer-mode. The bundled platform context sets:
+
+- `transfer-mode`: `http`
+- `image-file-name`: `http://ztp.example.com/v1/device/{device_uuid}/firmware`
+- `config-file-name`: `http://ztp.example.com/v1/device/{device_uuid}/config/full-config`
+
+`full-config` is the intended Junos configuration rendered by operator or plugin templates. The ZTP API does not synthesize a placeholder file.
 
 Replace `ztp.example.com` with your ZTP server URL and `{device_uuid}` with the device UUID from the device management system.
 
@@ -98,7 +114,10 @@ curl https://ztp.example.com/v1/device/{device_uuid}/config/{configlet}
 
 Common configuration file names:
 
-- `boot-script`: Initial boot script
+- `boot-script`: Cumulus Linux initial boot script
+- `ztp.json`: NV-OS ZTP sequence
+- `full-config`: Junos hierarchical configuration (operator- or plugin-rendered)
+- `startup.yaml`: Cumulus / NV-OS intended configuration
 - `system.cfg`: System configuration
 - `interfaces.cfg`: Interface configuration
 

--- a/docs/temporal/workflows/switch-os-upgrade.mdx
+++ b/docs/temporal/workflows/switch-os-upgrade.mdx
@@ -4,7 +4,7 @@ sidebar-title: Switch OS Upgrade
 position: 10
 ---
 
-Upgrades the operating system on network switches with automated backup, deployment, and validation procedures.
+Upgrades the operating system on Cumulus Linux and Juniper Junos switches with automated backup, deployment, and validation procedures.
 
 <Note>
 This workflow does not support NVLink and NVLink Switches. See the [NVLink Switch Firmware Upgrade](nvlink-switch-firmware-upgrade.mdx) workflow for details on NVLink upgrades.

--- a/docs/user-guides/switch-os-upgrade/index.mdx
+++ b/docs/user-guides/switch-os-upgrade/index.mdx
@@ -81,17 +81,17 @@ The workflow returns `True` on full success, `False` on early-exit branches (no-
 After the workflow reports success, confirm:
 
 - **All four stages green** on the Config Manager run page (or `approve_upgrade` green and downstream UNREACHABLE for the short-circuit paths).
-- **`nv show platform`** on the device reports the intended firmware version.
-- **Nautobot device status** is back to Provisioned (or Active), and the device responds to a ZTP-completion verification command (`/etc/os-release`, or your environment's equivalent).
+- **Running image matches the intended version.** On Cumulus Linux, `nv show platform` (and `/etc/os-release`) report the target release. On Junos, `show version` reports the target Junos version and NETCONF is reachable.
+- **Nautobot device status** is back to Provisioned (or Active).
 - **A pre-upgrade backup** is in the Config Store, tagged with the commit SHA the workflow used.
 
 ## Rollback
 
-Cumulus Linux does not have a native one-shot OS rollback. The recovery options are:
+Neither Cumulus Linux nor Junos has a one-shot OS-image rollback in this workflow. Recovery options:
 
 - **Set the intended firmware back to the previous version in Nautobot**, re-render via the [Render Service](../../render/index.mdx), and re-run Switch OS Upgrade. The workflow will install the older image and reboot the device back onto it.
 - **Reprovision the device** via [Device Reprovision](../reprovision/index.mdx). The reprovision flow factory-resets and re-runs ZTP with whatever intended firmware is currently set in Nautobot — useful when the post-upgrade device state is unrecoverable.
-- **Use the pre-upgrade backup** from the Config Store to restore configuration after a successful rollback to the prior firmware.
+- **Use the pre-upgrade backup** from the Config Store to restore configuration after a successful rollback to the prior firmware. On Junos, numbered config rollback (`rollback 1`) restores configuration only; it does not revert the OS image.
 
 ## Common issues
 

--- a/docs/user-guides/switch-os-upgrade/index.mdx
+++ b/docs/user-guides/switch-os-upgrade/index.mdx
@@ -91,7 +91,7 @@ Neither Cumulus Linux nor Junos has a one-shot OS-image rollback in this workflo
 
 - **Set the intended firmware back to the previous version in Nautobot**, re-render via the [Render Service](../../render/index.mdx), and re-run Switch OS Upgrade. The workflow will install the older image and reboot the device back onto it.
 - **Reprovision the device** via [Device Reprovision](../reprovision/index.mdx). The reprovision flow factory-resets and re-runs ZTP with whatever intended firmware is currently set in Nautobot — useful when the post-upgrade device state is unrecoverable.
-- **Use the pre-upgrade backup** from the Config Store to restore configuration after a successful rollback to the prior firmware. On Junos, numbered config rollback (`rollback 1`) restores configuration only; it does not revert the OS image.
+- **Use the pre-upgrade backup** from the Config Store to restore configuration after a successful rollback to the prior firmware. On Junos, numbered config rollback (`rollback 1`) loads the previous configuration into the candidate configuration. Validate and commit it to activate the configuration; this changes configuration only and does not revert the OS image.
 
 ## Common issues
 

--- a/docs/user-guides/switch-os-upgrade/index.mdx
+++ b/docs/user-guides/switch-os-upgrade/index.mdx
@@ -4,7 +4,7 @@ sidebar-title: Switch OS Upgrade
 position: 10
 ---
 
-The Switch OS Upgrade workflow upgrades a single Cumulus Linux switch to a new firmware version. It computes the version delta against the device's intended firmware in Nautobot, pauses for a human to approve the upgrade, backs up the current configuration, updates device-context state, drives the image install + reboot + ZTP cycle, and validates that the device came back on the right version. Multiple short-circuit paths exit safely when no work is required.
+The Switch OS Upgrade workflow upgrades a single Cumulus Linux or Juniper Junos switch to a new firmware version. It computes the version delta against the device's intended firmware in Nautobot, pauses for a human to approve the upgrade, backs up the current configuration, updates device-context state, drives the image install + reboot + ZTP cycle, and validates that the device came back on the right version. Multiple short-circuit paths exit safely when no work is required.
 
 <Note>
 The workflow uses the selected DCIM provider's normalized firmware-intent and
@@ -24,9 +24,10 @@ Before running, complete the pre-work that drives the upgrade. The workflow does
 Also confirm:
 
 - **Device exists in Nautobot** with a current intended configuration in the [Config Store](../../config-store/index.mdx).
-- **Device is on a supported platform** — Cumulus Linux only. Other platforms (NVOS for NVLink, vendor OSes) are rejected at runtime.
-- **Firmware image is uploaded** to the ZTP service for the target Cumulus Linux version and the device's platform. See [Upload Images to the ZTP Server](../../network-ztp/upload-images.mdx) for the upload procedure.
-- **Device is reachable** and credentials are current. The upgrade flow drives image install over the management network and waits for the device to ZTP back into Provisioned state.
+- **Device is on a supported platform** — Cumulus Linux or Juniper Junos. NV-OS (NVLink) is rejected at runtime; use [NVLink Switch Firmware Upgrade](../nvlink-switch-firmware-upgrade/index.mdx) instead.
+- **Firmware image is uploaded** to the ZTP service for the target OS version and the device's platform. See [Upload Images to the ZTP Server](../../network-ztp/upload-images.mdx) for the upload procedure.
+- **Juniper Junos:** operator- or plugin-supplied templates must render `full-config` into the intended config store. After factory reset the device fetches that file and the firmware image through DHCP option 43 (HTTP). There is no bundled Junos template tree.
+- **Device is reachable** and credentials are current. The upgrade flow drives image install over the management network and waits for the device to ZTP back into a reachable state.
 - **Approval to take the device offline.** The upgrade triggers a reboot — plan a maintenance window appropriate for the device's role in the fabric.
 
 ## Running the workflow
@@ -62,11 +63,11 @@ The workflow runs four stages in order. Only `approve_upgrade` requires approval
 
 1. **`update_device_configuration` — Refresh device context for the upgrade.**
 
-   Calls `validate_rendered_image_change` (6-minute start-to-close timeout, 2-minute heartbeat) to ensure the rendered configuration is consistent with the upgrade target, and updates Config Manager's internal state to track the new firmware.
+   Calls `validate_rendered_image_change` (6-minute start-to-close timeout, 2-minute heartbeat) to ensure upgrade artifacts match the target, and updates Config Manager's internal state to track the new firmware. Cumulus checks `VERSION_ID=` in the rendered `boot-script`. Junos checks that the image is on the ZTP server and that `full-config` exists in the intended config store.
 
 1. **`perform_upgrade` — Install the image and wait for the device to come back.**
 
-   Pushes the image to the device via the ZTP service and reboots. Two long-poll activities then wait for the device to converge:
+   Pushes the image to the device via the ZTP service and reboots. Cumulus uses NVUE factory-default; Junos uses `request system zeroize`. Two long-poll activities then wait for the device to converge:
 
    - `poll_image` — 35-minute timeout (30 + 5 buffer), 3-minute heartbeat. If the post-reboot image does not match the intended firmware, raises `ApplicationError`.
    - `poll_ztp_status` — 15-minute timeout (10 + 5 buffer). If ZTP does not complete in that window, raises `ApplicationError`.

--- a/src/nv_config_manager/dhcp/kea_dhcp_confgen.py
+++ b/src/nv_config_manager/dhcp/kea_dhcp_confgen.py
@@ -43,6 +43,15 @@ class DhcpConfigGenerationError(Exception):
     """DHCP Configuration Generation Error."""
 
 
+_DHCP4_OPTION_SPACE = "dhcp4"
+SiteOptionDefs = dict[str, dict[str, Any]]
+
+
+def _site_option_defs(site_dhcp_options: list[dict[str, Any]]) -> SiteOptionDefs:
+    """Index site option-def entries by option name."""
+    return {opt["name"]: opt for opt in site_dhcp_options}
+
+
 def _normalize_reservation_id(reservation_id: str) -> str:
     try:
         return str(macaddress.MAC(reservation_id))
@@ -213,7 +222,7 @@ def _filter_pool_reservation_overlaps(subnet_data: dict[str, Any]) -> None:
 def _process_subnet_reservations(
     subnet_data: dict[str, Any],
     dhcp_contexts: dict[str, dict[str, Any]],
-    site_option_codes: dict[str, int],
+    site_option_codes: SiteOptionDefs,
     options: dict[str, Any],
     config: dict[str, Any],
     reservations: list[dict[str, Any]],
@@ -247,7 +256,7 @@ def _process_subnet_reservations(
 def _process_option_candidates(
     subnet_data: dict[str, Any],
     dhcp_contexts: dict[str, dict[str, Any]],
-    site_option_codes: dict[str, int],
+    site_option_codes: SiteOptionDefs,
     options: dict[str, Any],
     config: dict[str, Any],
     conflicts: list[str],
@@ -286,7 +295,7 @@ def _process_option_candidates(
 def _build_subnet_config(
     subnet_data: dict[str, Any],
     options: dict[str, Any],
-    site_option_codes: dict[str, int],
+    site_option_codes: SiteOptionDefs,
     subnet_option_reservations: list[dict[str, Any]],
     config: dict[str, Any],
 ) -> dict[str, Any]:
@@ -333,7 +342,7 @@ async def _generate_automatic_dhcp_subnets_and_reservations(
     for subnet_data in dhcp_subnets:
         options: dict[str, Any] = {}
         config: dict[str, Any] = {}
-        site_option_codes = {opt["name"]: opt["code"] for opt in site_dhcp_options}
+        site_option_codes = _site_option_defs(site_dhcp_options)
 
         _filter_pool_reservation_overlaps(subnet_data)
         _process_subnet_reservations(
@@ -437,15 +446,23 @@ def _merge_options_and_config(
 
 def _format_options_for_kea(
     reservation_options: dict[str, str],
-    site_option_codes: dict[str, int],
+    site_option_codes: SiteOptionDefs,
 ) -> list[dict[str, Any]]:
     """Convert reservation_options dict to Kea option-data format."""
-    return [
-        {"name": opt, "data": value, "code": site_option_codes[opt]}
-        if opt in site_option_codes
-        else {"name": opt, "data": value}
-        for opt, value in reservation_options.items()
-    ]
+    option_data: list[dict[str, Any]] = []
+    for opt, value in reservation_options.items():
+        entry: dict[str, Any] = {"name": opt, "data": value}
+        option_def = site_option_codes.get(opt)
+        if option_def is None:
+            option_data.append(entry)
+            continue
+        if "code" in option_def:
+            entry["code"] = option_def["code"]
+        space = option_def.get("space")
+        if space and space != _DHCP4_OPTION_SPACE:
+            entry["space"] = space
+        option_data.append(entry)
+    return option_data
 
 
 def _add_reservation_identifier(

--- a/src/nv_config_manager/temporal/client/device.py
+++ b/src/nv_config_manager/temporal/client/device.py
@@ -2711,6 +2711,25 @@ class JuniperConnection(NetworkConnection):
         except (KeyError, IndexError, TypeError, ValueError) as error:
             raise NetworkDeviceException(f"Unable to determine uptime on {self._host}.") from error
 
+    def execute_ztp(self) -> None:
+        """Factory-reset the device so it re-runs Junos DHCP/HTTP ZTP."""
+        device = self._get_device()
+        try:
+            device.rpc.request_system_zeroize()
+        except (RpcError, ConnectError):
+            # Zeroize tears down NETCONF as the device reboots; that is success.
+            logger.info(
+                "NETCONF session ended after zeroize on %s; treating as success",
+                self._host,
+            )
+        finally:
+            self.close()
+
+    def get_ztp_status(self) -> str:
+        """Return success when the device is reachable after ZTP."""
+        self.get_running_image()
+        return "success"
+
     def _get_lldp_neighbor_entries(self) -> list[dict[str, Any]]:
         """Return raw lldp-neighbor-information entries from the device."""
         data = self._rpc("get-lldp-neighbors-information")

--- a/src/nv_config_manager/temporal/client/device.py
+++ b/src/nv_config_manager/temporal/client/device.py
@@ -2716,7 +2716,7 @@ class JuniperConnection(NetworkConnection):
         device = self._get_device()
         try:
             device.rpc.request_system_zeroize()
-        except (RpcError, ConnectError):
+        except ConnectError:
             # Zeroize tears down NETCONF as the device reboots; that is success.
             logger.info(
                 "NETCONF session ended after zeroize on %s; treating as success",

--- a/src/nv_config_manager/temporal/ngc/activities/render.py
+++ b/src/nv_config_manager/temporal/ngc/activities/render.py
@@ -21,9 +21,16 @@ from pydantic import BaseModel, Field
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from nv_config_manager.common.client.config_store import ConfigStoreClient, ConfigStoreFileNotFound
 from nv_config_manager.common.client.render import FileCommit
-from nv_config_manager.common.config import ConfigStoreType, config_store_client, render_client
+from nv_config_manager.common.config import (
+    ConfigStoreType,
+    config_store_client,
+    get_storage_client,
+    render_client,
+)
 from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData, Platform
+from nv_config_manager.ztp.storage import ObjectStorageClient, ObjectStorageNotFoundException
 
 
 class ExecuteRenderInput(BaseModel):
@@ -91,44 +98,90 @@ class ValidateRenderedPasswordChangeInput(BaseModel):
     desired_password_string: str
 
 
+_IMAGE_RENDER_POLL_TIMEOUT = timedelta(minutes=5)
+_IMAGE_RENDER_POLL_INTERVAL_SECONDS = 30
+_JUNIPER_INTENDED_CONFIG_FILE = "full-config"
+
+
 # Temporary hack until we can get proper mTLS certificates issued
 # for communication between the render service and the temporal service
 @activity.defn
 async def validate_rendered_image_change(
     activity_input: ValidateRenderedImageChangeInput,
 ) -> bool:
-    """Validate the rendered image change.
+    """Validate that upgrade artifacts for the target image are in place."""
+    platform = activity_input.device_data.platform
+    if platform == Platform.CUMULUS_LINUX:
+        return await _validate_cumulus_boot_script_image(activity_input)
+    if platform == Platform.JUNIPER_JUNOS:
+        return await _validate_juniper_upgrade_artifacts(activity_input)
+    raise NotImplementedError(f"Platform {platform} not supported")
 
-    Polls the file content every 30 seconds for up to 5 minutes to check for the desired image version.
-    Raises ApplicationError if the timeout is reached.
-    """
+
+def _heartbeat_render_poll(start_time: datetime) -> None:
+    elapsed_minutes = (datetime.now() - start_time).total_seconds() / 60
+    activity.heartbeat(f"Validating render ({elapsed_minutes:.0f}m)")
+
+
+async def _validate_cumulus_boot_script_image(
+    activity_input: ValidateRenderedImageChangeInput,
+) -> bool:
+    """Poll until the boot-script names the desired Cumulus VERSION_ID."""
     client = config_store_client(ConfigStoreType.INTENDED)
-    boot_script = None
-    if activity_input.device_data.platform == Platform.CUMULUS_LINUX:
-        boot_script = "boot-script"
-
-    if not boot_script:
-        raise NotImplementedError(f"Platform {activity_input.device_data.platform} not supported")
-
+    desired = activity_input.desired_image
     start_time = datetime.now()
-    timeout = timedelta(minutes=5)
-    poll_interval = 30  # seconds
-
     async with client:
-        while datetime.now() - start_time < timeout:
-            # Send heartbeat with progress information
-            elapsed_minutes = (datetime.now() - start_time).total_seconds() / 60
-            activity.heartbeat(f"Validating render ({elapsed_minutes:.0f}m)")
-
+        while datetime.now() - start_time < _IMAGE_RENDER_POLL_TIMEOUT:
+            _heartbeat_render_poll(start_time)
             config_file = await client.load_file(
-                device_uuid=activity_input.device_data.id, filename=boot_script
+                device_uuid=activity_input.device_data.id, filename="boot-script"
             )
-            if f"VERSION_ID={activity_input.desired_image}" in config_file.content:
+            if f"VERSION_ID={desired}" in config_file.content:
                 return True
-            await asyncio.sleep(poll_interval)
-
+            await asyncio.sleep(_IMAGE_RENDER_POLL_INTERVAL_SECONDS)
     raise ApplicationError(
-        f"Timeout waiting for image version {activity_input.desired_image} to be present in boot script"
+        f"Timeout waiting for image version {desired} to be present in boot script"
+    )
+
+
+async def _juniper_firmware_present(
+    storage_client: ObjectStorageClient, platform: str, desired: str
+) -> bool:
+    try:
+        await storage_client.get_firmware_checksum(platform, desired)
+        return True
+    except ObjectStorageNotFoundException:
+        return False
+
+
+async def _juniper_full_config_present(config_client: ConfigStoreClient, device_id: str) -> bool:
+    try:
+        await config_client.load_file(device_uuid=device_id, filename=_JUNIPER_INTENDED_CONFIG_FILE)
+        return True
+    except ConfigStoreFileNotFound:
+        return False
+
+
+async def _validate_juniper_upgrade_artifacts(
+    activity_input: ValidateRenderedImageChangeInput,
+) -> bool:
+    """Poll until the Junos image is on the ZTP server and full-config is rendered."""
+    desired = activity_input.desired_image
+    device_id = activity_input.device_data.id
+    platform = str(activity_input.device_data.platform)
+    config_client = config_store_client(ConfigStoreType.INTENDED)
+    storage_client = get_storage_client()
+    start_time = datetime.now()
+    async with config_client, storage_client:
+        while datetime.now() - start_time < _IMAGE_RENDER_POLL_TIMEOUT:
+            _heartbeat_render_poll(start_time)
+            firmware_ready = await _juniper_firmware_present(storage_client, platform, desired)
+            config_ready = await _juniper_full_config_present(config_client, device_id)
+            if firmware_ready and config_ready:
+                return True
+            await asyncio.sleep(_IMAGE_RENDER_POLL_INTERVAL_SECONDS)
+    raise ApplicationError(
+        f"Timeout waiting for Juniper firmware {desired} and full-config for device {device_id}"
     )
 
 

--- a/src/nv_config_manager/temporal/ngc/workflows/os_upgrade.py
+++ b/src/nv_config_manager/temporal/ngc/workflows/os_upgrade.py
@@ -69,7 +69,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
     non_retryable_error_types=["FirmwareUpgradeException"],
 )
 
-SUPPORTED_PLATFORMS = [Platform.CUMULUS_LINUX]
+SUPPORTED_PLATFORMS = [Platform.CUMULUS_LINUX, Platform.JUNIPER_JUNOS]
 
 
 class SwitchOSUpgradeInput(BaseModel):

--- a/src/tests/dhcp/test_kea_dhcp_confgen.py
+++ b/src/tests/dhcp/test_kea_dhcp_confgen.py
@@ -26,6 +26,7 @@ from testcontainers.core.container import DockerContainer
 from nv_config_manager.dhcp.kea import KeaClient
 from nv_config_manager.dhcp.kea_dhcp_confgen import (
     DhcpConfigGenerationError,
+    _format_options_for_kea,
     generate_config,
     inject_lease_db_config,
 )
@@ -1450,6 +1451,45 @@ async def test_override_router_option_error():
             MockRedisClient(),
             version=4,
         )
+
+
+def test_format_options_for_kea_includes_vendor_space():
+    """Option 43 suboptions carry space so Kea does not emit them as dhcp4."""
+    site_option_defs = {
+        "cumulus-provision-url": {
+            "name": "cumulus-provision-url",
+            "code": 239,
+            "space": "dhcp4",
+        },
+        "config-file-name": {
+            "name": "config-file-name",
+            "code": 1,
+            "space": "vendor-encapsulated-options-space",
+        },
+        "transfer-mode": {
+            "name": "transfer-mode",
+            "code": 3,
+            "space": "vendor-encapsulated-options-space",
+        },
+    }
+
+    option_data = _format_options_for_kea(
+        {
+            "cumulus-provision-url": "http://ztp.example/boot-script",
+            "transfer-mode": "http",
+            "config-file-name": "http://ztp.example/config/full-config",
+            "hostname": "switch-01",
+        },
+        site_option_defs,
+    )
+
+    by_name = {entry["name"]: entry for entry in option_data}
+    assert by_name["cumulus-provision-url"]["code"] == 239
+    assert "space" not in by_name["cumulus-provision-url"]
+    assert by_name["transfer-mode"]["space"] == "vendor-encapsulated-options-space"
+    assert by_name["transfer-mode"]["code"] == 3
+    assert by_name["config-file-name"]["space"] == "vendor-encapsulated-options-space"
+    assert "code" not in by_name["hostname"]
 
 
 @pytest.mark.asyncio

--- a/src/tests/temporal/clients/test_device.py
+++ b/src/tests/temporal/clients/test_device.py
@@ -564,6 +564,34 @@ def test_get_configuration_text_keeps_secrets_raw(juniper_conn):
     assert '"$6$abcDE12$secretHash"' in text
 
 
+def test_execute_ztp_issues_zeroize_and_closes(juniper_conn):
+    """execute_ztp issues request-system-zeroize and closes the NETCONF session."""
+    device = MagicMock()
+    juniper_conn._device = device
+    with patch.object(juniper_conn, "_get_device", return_value=device):
+        juniper_conn.execute_ztp()
+    device.rpc.request_system_zeroize.assert_called_once_with()
+    device.close.assert_called_once()
+    assert juniper_conn._device is None
+
+
+def test_execute_ztp_treats_dropped_session_as_success(juniper_conn):
+    """A dropped NETCONF session during zeroize is treated as success."""
+    device = MagicMock()
+    device.rpc.request_system_zeroize.side_effect = ConnectError("session closed")
+    juniper_conn._device = device
+    with patch.object(juniper_conn, "_get_device", return_value=device):
+        juniper_conn.execute_ztp()
+    device.close.assert_called_once()
+    assert juniper_conn._device is None
+
+
+def test_get_ztp_status_returns_success_when_image_readable(juniper_conn):
+    """get_ztp_status is success once the device answers with a running image."""
+    with patch.object(juniper_conn, "get_running_image", return_value="24.4R2-S3.7-EVO"):
+        assert juniper_conn.get_ztp_status() == "success"
+
+
 def test_get_hostname_and_running_image_use_facts(juniper_conn):
     """Hostname and running image come from PyEZ facts."""
     device = MagicMock()

--- a/src/tests/temporal/ngc/activities/test_os.py
+++ b/src/tests/temporal/ngc/activities/test_os.py
@@ -16,7 +16,7 @@
 
 import json
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 import responses
@@ -24,6 +24,7 @@ from nv_config_manager_dcim.workflow_models import OSImageVersions
 from temporalio.exceptions import ApplicationError
 from temporalio.testing import ActivityEnvironment
 
+from nv_config_manager.common.client import ConfigStoreFileNotFound
 from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData, Platform
 from nv_config_manager.temporal.ngc.activities.os import (
     ExecuteZTPInput,
@@ -51,6 +52,7 @@ from nv_config_manager.temporal.ngc.activities.render import (
     ValidateRenderedImageChangeInput,
     validate_rendered_image_change,
 )
+from nv_config_manager.ztp.storage import ObjectStorageNotFoundException
 
 
 @pytest.fixture
@@ -691,3 +693,169 @@ async def test_validate_rendered_image_change_unsupported_platform():
         )
 
     assert "Platform arista-eos not supported" in str(exc_info.value)
+
+
+@pytest.fixture
+def juniper_device_data():
+    """Juniper device used by image-render validation tests."""
+    return NetworkDeviceData(
+        id="juniper-device",
+        name="juniper-device",
+        platform=Platform.JUNIPER_JUNOS,
+        role="wan",
+        site="test_site",
+        device_type="mx204",
+        primary_ip4="192.0.2.10",
+        primary_ip6=None,
+    )
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.ngc.activities.render.asyncio.sleep", new_callable=AsyncMock)
+@patch("nv_config_manager.temporal.ngc.activities.render.activity.heartbeat")
+async def test_validate_rendered_image_change_juniper_success(
+    mock_heartbeat, mock_sleep, juniper_device_data
+):
+    """Juniper validation succeeds when firmware and full-config are both present."""
+    mock_file = MagicMock()
+    mock_config_client = AsyncMock()
+    mock_config_client.__aenter__ = AsyncMock(return_value=mock_config_client)
+    mock_config_client.__aexit__ = AsyncMock(return_value=None)
+    mock_config_client.load_file = AsyncMock(return_value=mock_file)
+
+    mock_storage_client = AsyncMock()
+    mock_storage_client.__aenter__ = AsyncMock(return_value=mock_storage_client)
+    mock_storage_client.__aexit__ = AsyncMock(return_value=None)
+    mock_storage_client.get_firmware_checksum = AsyncMock(return_value="abc123")
+
+    with (
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.config_store_client",
+            return_value=mock_config_client,
+        ),
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.get_storage_client",
+            return_value=mock_storage_client,
+        ),
+        patch("nv_config_manager.temporal.ngc.activities.render.datetime") as mock_datetime,
+    ):
+        mock_now = MagicMock()
+        mock_now.__sub__ = MagicMock(return_value=timedelta(seconds=0))
+        mock_datetime.now.return_value = mock_now
+
+        result = await validate_rendered_image_change(
+            ValidateRenderedImageChangeInput(
+                device_data=juniper_device_data, desired_image="24.4R2"
+            )
+        )
+
+    assert result is True
+    mock_storage_client.get_firmware_checksum.assert_called_once_with("juniper-junos", "24.4R2")
+    mock_config_client.load_file.assert_called_once_with(
+        device_uuid="juniper-device", filename="full-config"
+    )
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.ngc.activities.render.asyncio.sleep", new_callable=AsyncMock)
+@patch("nv_config_manager.temporal.ngc.activities.render.activity.heartbeat")
+async def test_validate_rendered_image_change_juniper_timeout(
+    mock_heartbeat, mock_sleep, juniper_device_data
+):
+    """Juniper validation times out when firmware is missing from ZTP storage."""
+    mock_file = MagicMock()
+    mock_config_client = AsyncMock()
+    mock_config_client.__aenter__ = AsyncMock(return_value=mock_config_client)
+    mock_config_client.__aexit__ = AsyncMock(return_value=None)
+    mock_config_client.load_file = AsyncMock(return_value=mock_file)
+
+    mock_storage_client = AsyncMock()
+    mock_storage_client.__aenter__ = AsyncMock(return_value=mock_storage_client)
+    mock_storage_client.__aexit__ = AsyncMock(return_value=None)
+    mock_storage_client.get_firmware_checksum = AsyncMock(
+        side_effect=ObjectStorageNotFoundException("missing")
+    )
+
+    start_time = datetime.now()
+    timeout = timedelta(minutes=5)
+
+    with (
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.config_store_client",
+            return_value=mock_config_client,
+        ),
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.get_storage_client",
+            return_value=mock_storage_client,
+        ),
+        patch("nv_config_manager.temporal.ngc.activities.render.datetime") as mock_datetime,
+    ):
+        call_count = 0
+
+        def mock_now():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return start_time
+            return start_time + timeout + timedelta(seconds=1)
+
+        mock_datetime.now.side_effect = mock_now
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await validate_rendered_image_change(
+                ValidateRenderedImageChangeInput(
+                    device_data=juniper_device_data, desired_image="24.4R2"
+                )
+            )
+
+    assert "Timeout waiting for Juniper firmware 24.4R2" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@patch("nv_config_manager.temporal.ngc.activities.render.asyncio.sleep", new_callable=AsyncMock)
+@patch("nv_config_manager.temporal.ngc.activities.render.activity.heartbeat")
+async def test_validate_rendered_image_change_juniper_waits_for_full_config(
+    mock_heartbeat, mock_sleep, juniper_device_data
+):
+    """Missing full-config is treated as not-ready, not as a hard error."""
+    mock_config_client = AsyncMock()
+    mock_config_client.__aenter__ = AsyncMock(return_value=mock_config_client)
+    mock_config_client.__aexit__ = AsyncMock(return_value=None)
+    mock_config_client.load_file = AsyncMock(side_effect=ConfigStoreFileNotFound("missing"))
+
+    mock_storage_client = AsyncMock()
+    mock_storage_client.__aenter__ = AsyncMock(return_value=mock_storage_client)
+    mock_storage_client.__aexit__ = AsyncMock(return_value=None)
+    mock_storage_client.get_firmware_checksum = AsyncMock(return_value="abc123")
+
+    start_time = datetime.now()
+    timeout = timedelta(minutes=5)
+
+    with (
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.config_store_client",
+            return_value=mock_config_client,
+        ),
+        patch(
+            "nv_config_manager.temporal.ngc.activities.render.get_storage_client",
+            return_value=mock_storage_client,
+        ),
+        patch("nv_config_manager.temporal.ngc.activities.render.datetime") as mock_datetime,
+    ):
+        call_count = 0
+
+        def mock_now():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return start_time
+            return start_time + timeout + timedelta(seconds=1)
+
+        mock_datetime.now.side_effect = mock_now
+
+        with pytest.raises(ApplicationError, match="full-config"):
+            await validate_rendered_image_change(
+                ValidateRenderedImageChangeInput(
+                    device_data=juniper_device_data, desired_image="24.4R2"
+                )
+            )

--- a/src/tests/temporal/ngc/workflows/test_switch_os_upgrade_workflow.py
+++ b/src/tests/temporal/ngc/workflows/test_switch_os_upgrade_workflow.py
@@ -26,7 +26,7 @@ from temporalio.client import Client, WorkflowHandle
 from temporalio.common import RetryPolicy
 from temporalio.worker import Worker
 
-from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData
+from nv_config_manager.temporal.common.mixins.device import NetworkDeviceData, Platform
 from nv_config_manager.temporal.ngc.activities.backup import (
     PersistConfigBackupInput,
     RecordBackupConfigManagerPluginInput,
@@ -51,6 +51,7 @@ from nv_config_manager.temporal.ngc.activities.os import (
 from nv_config_manager.temporal.ngc.activities.render import ValidateRenderedImageChangeInput
 from nv_config_manager.temporal.ngc.workflows.backup import BackupWorkflow
 from nv_config_manager.temporal.ngc.workflows.os_upgrade import (
+    SUPPORTED_PLATFORMS,
     SwitchOSUpgradeInput,
     SwitchOSUpgradeWorkflow,
 )
@@ -58,6 +59,12 @@ from nv_config_manager.temporal.ngc.workflows.os_upgrade import (
 # Test-specific retry policy and timeout
 TEST_RETRY_POLICY = RetryPolicy(maximum_attempts=1)
 TEST_TIMEOUT = timedelta(seconds=10)
+
+
+def test_supported_platforms_include_juniper_junos():
+    """Switch OS Upgrade accepts Juniper Junos in addition to Cumulus Linux."""
+    assert Platform.CUMULUS_LINUX in SUPPORTED_PLATFORMS
+    assert Platform.JUNIPER_JUNOS in SUPPORTED_PLATFORMS
 
 
 @activity.defn(name="get_network_device")


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of the change. Reference issues with "closes #1234" when applicable. -->

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
Kind integration completed with **success** for [`c887360`](https://github.com/dsx-ai-factory/nv-config-manager/commit/c8873609ec952d0e86e91006e9af24b1e11fb36d) in [this workflow run](https://github.com/dsx-ai-factory/nv-config-manager/actions/runs/33118486841).
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Juniper Junos support for zero-touch provisioning and switch OS upgrades.
  * Added Junos DHCP option 43 settings for firmware, configuration, image type, transfer mode, and HTTP delivery.
  * Added validation that Junos firmware and full configuration files are available before upgrades.

* **Bug Fixes**
  * Improved handling of vendor-specific DHCP option spaces and codes.
  * ZTP now treats expected connection loss during device reboot as successful.

* **Documentation**
  * Updated Junos provisioning, DHCP, and upgrade guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->