### PR TITLE
fix(helm): avoid CNPG PodMonitor ownership collisions

### DIFF
--- a/.github/scripts/check-cnpg-podmonitors.py
+++ b/.github/scripts/check-cnpg-podmonitors.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Check the rendered relationship between CNPG Clusters and PodMonitors."""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+Document = dict[str, Any]
+
+
+def nested(document: Document, *keys: str) -> Any:
+    """Return a nested value, or None when the path does not exist."""
+    value: Any = document
+    for key in keys:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(key)
+    return value
+
+
+def check_render(path: Path) -> list[str]:
+    """Return ownership and label errors from one Helm render."""
+    with path.open(encoding="utf-8") as stream:
+        documents = [
+            document for document in yaml.safe_load_all(stream) if isinstance(document, dict)
+        ]
+
+    clusters = [
+        document
+        for document in documents
+        if document.get("kind") == "Cluster"
+        and str(document.get("apiVersion", "")).startswith("postgresql.cnpg.io/")
+    ]
+    monitors = [
+        document
+        for document in documents
+        if document.get("kind") == "PodMonitor"
+        and isinstance(
+            nested(document, "spec", "selector", "matchLabels", "cnpg.io/cluster"),
+            str,
+        )
+    ]
+    cluster_names = [nested(cluster, "metadata", "name") for cluster in clusters]
+    selected_cluster_names = [
+        nested(monitor, "spec", "selector", "matchLabels", "cnpg.io/cluster")
+        for monitor in monitors
+    ]
+    raw_monitor_names = [nested(monitor, "metadata", "name") for monitor in monitors]
+    operator_monitored_clusters = [
+        nested(cluster, "metadata", "name")
+        for cluster in clusters
+        if nested(cluster, "spec", "monitoring", "enablePodMonitor") is True
+    ]
+
+    errors: list[str] = []
+    if not clusters:
+        errors.append("no CNPG Clusters rendered")
+    if operator_monitored_clusters:
+        errors.append(
+            "operator-managed PodMonitors must remain disabled for chart-monitored "
+            f"CNPG Clusters: {', '.join(map(str, operator_monitored_clusters))}"
+        )
+    cluster_counts = Counter(cluster_names)
+    selector_counts = Counter(selected_cluster_names)
+    if cluster_counts != selector_counts:
+        missing = sorted((cluster_counts - selector_counts).elements(), key=str)
+        unexpected = sorted((selector_counts - cluster_counts).elements(), key=str)
+        errors.append(
+            "CNPG Cluster/PodMonitor selectors differ "
+            f"(missing: {missing or 'none'}; unexpected: {unexpected or 'none'}); "
+            "check monitoring.podMonitors.cnpg.enabled"
+        )
+    invalid_name_documents = [
+        index
+        for index, name in enumerate(raw_monitor_names, start=1)
+        if not isinstance(name, str) or not name
+    ]
+    if invalid_name_documents:
+        errors.append(
+            "chart-owned CNPG PodMonitor metadata.name is missing or invalid in document(s): "
+            + ", ".join(map(str, invalid_name_documents))
+        )
+    monitor_names = [name for name in raw_monitor_names if isinstance(name, str) and name]
+    if len(set(monitor_names)) != len(monitor_names):
+        errors.append("chart-owned CNPG PodMonitor names are not unique")
+    if collisions := sorted(set(cluster_names).intersection(monitor_names)):
+        errors.append(f"PodMonitor names collide with CNPG Clusters: {', '.join(collisions)}")
+    overlong_names = sorted(name for name in monitor_names if len(name) > 63)
+    if overlong_names:
+        errors.append(f"PodMonitor names exceed 63 characters: {', '.join(overlong_names)}")
+
+    print(f"{path}: {len(clusters)} CNPG Clusters, {len(monitors)} CNPG PodMonitors")
+    return errors
+
+
+def main(arguments: list[str]) -> int:
+    """Validate each rendered manifest provided on the command line."""
+    if len(arguments) < 2:
+        print(f"usage: {arguments[0]} RENDERED_MANIFEST [...]", file=sys.stderr)
+        return 2
+
+    try:
+        failures = [
+            f"{path}: {error}"
+            for argument in arguments[1:]
+            for path in [Path(argument)]
+            for error in check_render(path)
+        ]
+    except (OSError, yaml.YAMLError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    for failure in failures:
+        print(f"ERROR: {failure}", file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Sorted list check (keep-sorted)
         run: make sort-check
       - run: uv sync --frozen
-      - run: uv run ruff format --check src/ packages plugins/dcim/nautobot-2x
-      - run: uv run ruff check src/ packages plugins/dcim/nautobot-2x
-      - run: uv run ty check src/nv_config_manager/ packages/dcim/src packages/workflows
-      - run: uv run mypy src/nv_config_manager packages/dcim/src packages/workflows --no-incremental
+      - run: uv run ruff format --check src/ packages plugins/dcim/nautobot-2x .github/scripts/check-cnpg-podmonitors.py
+      - run: uv run ruff check src/ packages plugins/dcim/nautobot-2x .github/scripts/check-cnpg-podmonitors.py
+      - run: uv run ty check src/nv_config_manager/ packages/dcim/src packages/workflows .github/scripts/check-cnpg-podmonitors.py
+      - run: uv run mypy src/nv_config_manager packages/dcim/src packages/workflows .github/scripts/check-cnpg-podmonitors.py --no-incremental
       - name: Installer lint
         working-directory: installer
         run: |
@@ -265,10 +265,31 @@ jobs:
           persist-credentials: false
       - name: Setup proxy cache
         uses: *setup_proxy_cache
+      - uses: *actions_setup_python
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Helm
         run: |
-          curl --retry 3 --retry-delay 5 --retry-connrefused -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | tar -xz
+          HELM_ARCHIVE="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          # Official v3.15.3 Linux AMD64 release checksum. Update this value
+          # together with HELM_VERSION.
+          HELM_SHA256=ad871aecb0c9fd96aa6702f6b79e87556c8998c2e714a4959bf71ee31282ac9c
+          curl --retry 3 --retry-delay 5 --retry-connrefused -fsSLO \
+            "https://get.helm.sh/${HELM_ARCHIVE}"
+          curl --retry 3 --retry-delay 5 --retry-connrefused -fsSLO \
+            "https://get.helm.sh/${HELM_ARCHIVE}.sha256sum"
+          grep -Fqx "${HELM_SHA256}  ${HELM_ARCHIVE}" "${HELM_ARCHIVE}.sha256sum"
+          sha256sum -c "${HELM_ARCHIVE}.sha256sum"
+          tar -xzf "$HELM_ARCHIVE"
           sudo mv linux-amd64/helm /usr/local/bin/helm
+      - name: Install YAML parser from internal package cache
+        run: |
+          # PyYAML 6.0.3 cp313 manylinux2014 x86_64 wheel. Update this hash
+          # when PYTHON_VERSION or the Helm runner architecture changes.
+          PYYAML_SHA256=0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6
+          python -m pip install --disable-pip-version-check --no-deps \
+            --only-binary=:all: --require-hashes \
+            -r <(printf 'PyYAML==6.0.3 --hash=sha256:%s\n' "$PYYAML_SHA256")
       - name: Build chart dependencies
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
@@ -277,6 +298,19 @@ jobs:
           helm dependency build deploy/helm/
       - run: helm lint deploy/helm/ --values deploy/helm/values-ci.yaml
       - run: helm template test deploy/helm/ --values deploy/helm/values-ci.yaml >/tmp/nvcm-helm.yaml
+      - name: CNPG PodMonitor ownership render
+        run: |
+          # A CloudNativePG operator may own/delete a PodMonitor whose name is
+          # identical to its Cluster. Chart-owned monitors must use distinct,
+          # release-scoped names or ArgoCD will wait forever for deleted CRs.
+          # Exercise the fullname truncation path. Each monitor must retain a
+          # cluster-specific identity even when the release name is very long.
+          long_release_name="$(printf 'r%.0s' {1..53})"
+          helm template "$long_release_name" deploy/helm/ \
+            --values deploy/helm/values-ci.yaml >/tmp/nvcm-helm-long-release.yaml
+          python .github/scripts/check-cnpg-podmonitors.py \
+            /tmp/nvcm-helm.yaml \
+            /tmp/nvcm-helm-long-release.yaml
       - name: Bundled NATS without Nautobot render
         run: |
           helm template test deploy/helm/ \

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1197,6 +1197,24 @@ Result depends on configuration:
 {{- end }}
 
 {{/*
+Generate a chart-owned CNPG PodMonitor name.
+
+Short names remain readable. If the release + cluster name exceeds the DNS
+label limit, reserve space for a hash of the complete identity so truncation
+cannot collapse monitors for different releases or clusters onto one name.
+*/}}
+{{- define "nv-config-manager.cnpgPodMonitorName" -}}
+{{- $fullname := include "nv-config-manager.fullname" .root -}}
+{{- $name := printf "%s-cnpg-%s" $fullname .clusterName -}}
+{{- if gt (len $name) 63 -}}
+{{- $hash := sha256sum (printf "%s/%s" $fullname .clusterName) | trunc 10 -}}
+{{- printf "%s-%s" ($name | trunc 52 | trimSuffix "-") $hash -}}
+{{- else -}}
+{{- $name -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Address of the Prometheus this release deploys, for KEDA's render-autoscaling
 trigger -- empty unless that in-cluster Prometheus is actually what KEDA will
 query.

--- a/deploy/helm/templates/monitoring.yaml
+++ b/deploy/helm/templates/monitoring.yaml
@@ -794,11 +794,16 @@ spec:
 {{- range $clusterKey := .Values.cnpg.clusterList }}
 {{- $config := index $.Values.cnpg $clusterKey }}
 {{- if $config.enabled }}
+{{- $podMonitorName := include "nv-config-manager.cnpgPodMonitorName" (dict "root" $ "clusterName" $config.clusterName) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ $config.clusterName }}
+  # This chart deliberately leaves Cluster.spec.monitoring.enablePodMonitor
+  # disabled. CloudNativePG may still delete a same-name PodMonitor it does not
+  # own, so keep chart-owned monitors release-scoped. Upstream diagnosis:
+  # https://github.com/cloudnative-pg/cloudnative-pg/issues/6109
+  name: {{ $podMonitorName }}
   namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" $ | nindent 4 }}
@@ -829,11 +834,12 @@ spec:
 {{- /* Nautobot CNPG cluster — same enable conditions as cnpg-clusters.yaml */}}
 {{- $nautobotConfig := .Values.cnpg.nautobot }}
 {{- if or $nautobotConfig.enabled (and .Values.nautobot.enabled .Values.externalServices.nautobot.local) }}
+{{- $nautobotPodMonitorName := include "nv-config-manager.cnpgPodMonitorName" (dict "root" . "clusterName" $nautobotConfig.clusterName) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ $nautobotConfig.clusterName }}
+  name: {{ $nautobotPodMonitorName }}
   namespace: {{ $namespace }}
   labels:
     {{- include "nv-config-manager.labels" . | nindent 4 }}


### PR DESCRIPTION
## Description

- Give chart-managed CloudNativePG `PodMonitor` resources release-scoped names
  so they no longer share names with `Cluster` resources and get deleted by
  the operator ([cloudnative-pg#6109](https://github.com/cloudnative-pg/cloudnative-pg/issues/6109)).
- Add a focused Helm render regression check for normal and long release names.
  It verifies one monitor per database cluster, unique non-colliding names, and
  the 63-character Kubernetes name limit.
- Verify the pinned Helm release archive against its official checksum before
  extracting or installing it in CI.

## Validation

<!-- List the commands, manual checks, or screenshots used to validate the change. -->

- [ ] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

Kind integration was not run because this is a monitoring-resource metadata
change and the external operator ownership loop is not reproduced by that
suite. Local validation passed:

```text
helm lint deploy/helm --values deploy/helm/values-ci.yaml
helm template test deploy/helm --values deploy/helm/values-ci.yaml
check-cnpg-podmonitors.py against normal and long-release renders
negative render with an overlong PodMonitor name
official Helm v3.15.3 Linux AMD64 archive and checksum artifact verification
```

The kind integration test is manual due to taking ~30 min to complete. Ready pull requests from
configured trustees auto-sync when every commit is GitHub `Verified`. Other pull requests,
including draft pull requests, require an authorized maintainer to approve the exact current
commit. Approval must be repeated after the pull request is updated.

For a pull request that requires approval, an authorized maintainer first comments:

```text
/ok to test <sha>
```

After copy-pr-bot has synced the current commit, start the suite with:

```text
/kind test
```

As a fallback, run Actions -> Kind Integration -> Run workflow against the copy-pr-bot generated
`pull-request/<PR_NUMBER>` branch. Use the default `test_path` for the full suite, or narrow it
only while debugging.

The completed workflow updates this PR description with its conclusion and exact run URL.

Passing Kind Integration run, if not automatically reported:
<!-- kind-integration-result:start -->
<!-- Paste the workflow run URL here only if the Kind result was not automatically updated. -->
<!-- kind-integration-result:end -->

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs,
      docs screenshots, or Helm/rendered outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * CloudNativePG monitoring resources now use chart-owned, release-scoped names.
  * Monitor names remain unique and comply with Kubernetes’ 63-character limit, including for long release or cluster names.
  * Monitoring resource replacement and deletion now follow the associated chart-managed resource.

* **Validation**
  * Added automated checks for monitor naming, ownership, selector coverage, collisions, and length limits.
  * Extended CI validation to cover standard and long release-name scenarios, including Helm archive integrity and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->