### PR TITLE
fix(ci): resolve promotion source from pipeline API

### DIFF
--- a/.gitlab/ci/promote-test-envs-child.yml
+++ b/.gitlab/ci/promote-test-envs-child.yml
@@ -5,6 +5,9 @@
 stages:
   - deploy
 
+workflow:
+  name: "Promote PR #${NVCM_PROMOTE_PR} to ${NVCM_PROMOTE_ENV}"
+
 include:
   # Import only the shared image pins, not common.yml's workflow or full stage
   # list, so top-level and child pipelines cannot drift independently.

--- a/.gitlab/ci/scripts/tests/validate_promote_request_test.sh
+++ b/.gitlab/ci/scripts/tests/validate_promote_request_test.sh
@@ -16,7 +16,7 @@ main_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 curl() {
     local args=("$@") output_file="" has_job_token=false
     local has_https_proto=false has_https_redirect_proto=false
-    local i arg
+    local pipeline_name="" i arg
     for ((i = 0; i < ${#args[@]}; i++)); do
         arg="${args[$i]}"
         if [[ "$arg" == "JOB-TOKEN: job-token" ]]; then
@@ -27,6 +27,8 @@ curl() {
             has_https_proto=true
         elif [[ "$arg" == "--proto-redir" && "${args[$((i + 1))]}" == "=https" ]]; then
             has_https_redirect_proto=true
+        elif [[ "$arg" == name=* ]]; then
+            pipeline_name="${arg#name=}"
         fi
     done
     local url="${!#}"
@@ -36,8 +38,9 @@ curl() {
     fi
     case "$url" in
         */api/v4/job)
-            printf '{"source":"%s","pipeline":{"id":%s,"ref":"main"},"user":{"id":%s}}\n' \
-                "${MOCK_CURRENT_SOURCE}" "${MOCK_CURRENT_PIPELINE_ID}" "${MOCK_CURRENT_USER_ID}"
+            # The mirror's GET /job response omits source.
+            printf '{"pipeline":{"id":%s,"ref":"%s"},"user":{"id":%s}}\n' \
+                "${MOCK_CURRENT_PIPELINE_ID}" "${MOCK_CURRENT_JOB_REF}" "${MOCK_CURRENT_USER_ID}"
             ;;
         */projects/7/pipelines\?ref=*)
             printf '[{"id":100,"ref":"pull-request/123","sha":"%s","source":"push"}]\n' \
@@ -62,7 +65,16 @@ curl() {
                 "$main_sha"
             ;;
         */projects/7/pipelines/300/metadata)
+            [[ "$pipeline_name" == "Promote PR #123 (${pr_sha:0:8})" ]] || return 96
             printf '{}\n'
+            ;;
+        */projects/7/pipelines/300)
+            printf '{"ref":"%s","sha":"%s","status":"running","source":"%s"}\n' \
+                "${MOCK_CURRENT_PIPELINE_REF}" "$main_sha" "${MOCK_CURRENT_SOURCE}"
+            ;;
+        */projects/7/pipelines/400)
+            printf '{"ref":"%s","sha":"%s","status":"running","source":"%s"}\n' \
+                "${MOCK_CURRENT_PIPELINE_REF}" "$main_sha" "${MOCK_CURRENT_SOURCE}"
             ;;
         */projects/7/jobs/202/artifacts/promote-request.env)
             [[ "$has_job_token" == true && "$has_https_proto" == true && -n "$output_file" ]] || return 97
@@ -119,7 +131,9 @@ run_source_validator() (
          | .checkout_sha = $checkout_sha
          | .user_id = $user_id' \
         "$webhook_fixture" > "$payload_file"
-    export MOCK_CURRENT_SOURCE=trigger MOCK_CURRENT_PIPELINE_ID=300 MOCK_CURRENT_USER_ID=7
+    export MOCK_CURRENT_SOURCE="${TEST_CURRENT_SOURCE:-trigger}" MOCK_CURRENT_PIPELINE_ID=300 MOCK_CURRENT_USER_ID=7
+    export MOCK_CURRENT_JOB_REF="${TEST_CURRENT_JOB_REF:-main}"
+    export MOCK_CURRENT_PIPELINE_REF="${TEST_CURRENT_PIPELINE_REF:-main}"
     export MOCK_BUILD_USER_ID="${TEST_BUILD_USER_ID:-7}"
     export MOCK_BRANCH_SHA="${TEST_BRANCH_SHA:-$pr_sha}"
     export CI_JOB_TOKEN=job-token CI_API_V4_URL="${TEST_CI_API_V4_URL:-https://gitlab.example/api/v4}" CI_PROJECT_ID=7
@@ -131,7 +145,9 @@ run_source_validator() (
 )
 
 run_final_validator() (
-    export MOCK_CURRENT_SOURCE=parent_pipeline MOCK_CURRENT_PIPELINE_ID=400 MOCK_CURRENT_USER_ID=42
+    export MOCK_CURRENT_SOURCE="${TEST_CURRENT_SOURCE:-parent_pipeline}" MOCK_CURRENT_PIPELINE_ID=400 MOCK_CURRENT_USER_ID=42
+    export MOCK_CURRENT_JOB_REF="${TEST_CURRENT_JOB_REF:-main}"
+    export MOCK_CURRENT_PIPELINE_REF="${TEST_CURRENT_PIPELINE_REF:-main}"
     export CI_JOB_TOKEN=job-token CI_API_V4_URL="${TEST_CI_API_V4_URL:-https://gitlab.example/api/v4}" CI_PROJECT_ID=7
     export NVCM_MIRROR_API_TOKEN=read-token
     export NVCM_PROMOTE_PR=123 NVCM_PROMOTE_PR_SHA="$pr_sha"
@@ -167,6 +183,8 @@ run_source_validator
 run_final_validator
 TEST_ARTIFACT_DIRECT=true run_final_validator
 TEST_CI_API_V4_URL=http://gitlab.example/api/v4 assert_source_rejected "CI_API_V4_URL must use HTTPS"
+TEST_CURRENT_SOURCE=web assert_source_rejected "pipeline source 'web' is not a push webhook trigger"
+TEST_CURRENT_PIPELINE_REF=other assert_source_rejected "current job and pipeline refs do not match"
 TEST_OBJECT_KIND=pipeline assert_source_rejected "webhook event is not a push"
 TEST_PROJECT_ID=8 assert_source_rejected "webhook project does not match"
 TEST_REF=refs/heads/main assert_source_rejected "is not refs/heads/pull-request/<number>"
@@ -174,6 +192,8 @@ TEST_AFTER=cccccccccccccccccccccccccccccccccccccccc assert_source_rejected "afte
 TEST_BUILD_USER_ID=8 assert_source_rejected "build pipeline user does not match"
 TEST_BRANCH_SHA=cccccccccccccccccccccccccccccccccccccccc assert_source_rejected "moved to"
 TEST_CI_API_V4_URL=http://gitlab.example/api/v4 assert_final_rejected "CI_API_V4_URL must use HTTPS"
+TEST_CURRENT_SOURCE=push assert_final_rejected "pipeline source 'push' is not a PR promotion child pipeline"
+TEST_CURRENT_PIPELINE_REF=other assert_final_rejected "current job and pipeline refs do not match"
 TEST_ARTIFACT_REDIRECT_URL=http://artifacts.example/promote-request.env assert_final_rejected "artifact redirect must use HTTPS"
 TEST_VERIFIED_PR=999 assert_final_rejected "verified request PR does not match"
 TEST_BRIDGE_NAME=promote-to-test01 assert_final_rejected "source trigger job"

--- a/.gitlab/ci/scripts/validate_promote_request.sh
+++ b/.gitlab/ci/scripts/validate_promote_request.sh
@@ -32,10 +32,18 @@ api_get() {
 # /job is authenticated by this job's short-lived token, so its pipeline
 # metadata cannot be redirected by overriding a predefined CI variable.
 current_job_json="$(curl -fsS --max-time 30 -H "JOB-TOKEN: ${CI_JOB_TOKEN}" "${CI_API_V4_URL}/job")"
-request_source="$(printf '%s' "$current_job_json" | jq -r '.source // empty')"
 current_ref="$(printf '%s' "$current_job_json" | jq -r '.pipeline.ref // .ref // empty')"
 current_pipeline_id="$(printf '%s' "$current_job_json" | jq -r '.pipeline.id // empty')"
 current_user_id="$(printf '%s' "$current_job_json" | jq -r '.user.id // empty')"
+[[ "$current_pipeline_id" =~ ^[0-9]+$ ]] || fail "current child pipeline id is missing"
+
+# Some GitLab versions omit source from GET /job. Resolve it from the current
+# pipeline id reported by that authenticated endpoint instead.
+current_pipeline_json="$(api_get "${api}/pipelines/${current_pipeline_id}")"
+request_source="$(printf '%s' "$current_pipeline_json" | jq -r '.source // empty')"
+pipeline_ref="$(printf '%s' "$current_pipeline_json" | jq -r '.ref // empty')"
+[[ "$pipeline_ref" == "$current_ref" ]] \
+    || fail "current job and pipeline refs do not match"
 
 project_json="$(api_get "$api")"
 default_branch="$(printf '%s' "$project_json" | jq -r '.default_branch // empty')"
@@ -45,7 +53,6 @@ default_branch="$(printf '%s' "$project_json" | jq -r '.default_branch // empty'
 
 [[ "$request_source" == "parent_pipeline" ]] \
     || fail "pipeline source '${request_source:-unknown}' is not a PR promotion child pipeline"
-[[ "$current_pipeline_id" =~ ^[0-9]+$ ]] || fail "current child pipeline id is missing"
 
 for key in NVCM_PROMOTE_SOURCE_PIPELINE_ID NVCM_PROMOTE_SOURCE_REF NVCM_PROMOTE_SOURCE_SHA; do
     [[ -n "${!key:-}" ]] || fail "${key} is required for a button-triggered promotion"

--- a/.gitlab/ci/scripts/validate_promote_source_pipeline.sh
+++ b/.gitlab/ci/scripts/validate_promote_source_pipeline.sh
@@ -33,9 +33,17 @@ api_get() {
 # /job is authenticated by this job's short-lived token, so its source/ref
 # cannot be redirected by overriding predefined CI variables.
 current_job_json="$(curl -fsS --max-time 30 -H "JOB-TOKEN: ${CI_JOB_TOKEN}" "${CI_API_V4_URL}/job")"
-request_source="$(printf '%s' "$current_job_json" | jq -r '.source // empty')"
 current_ref="$(printf '%s' "$current_job_json" | jq -r '.pipeline.ref // .ref // empty')"
 request_pipeline_id="$(printf '%s' "$current_job_json" | jq -r '.pipeline.id // empty')"
+[[ "$request_pipeline_id" =~ ^[0-9]+$ ]] || fail "request pipeline id is missing"
+
+# Some GitLab versions omit source from GET /job. Resolve it from the current
+# pipeline id reported by that authenticated endpoint instead.
+current_pipeline_json="$(api_get "${api}/pipelines/${request_pipeline_id}")"
+request_source="$(printf '%s' "$current_pipeline_json" | jq -r '.source // empty')"
+pipeline_ref="$(printf '%s' "$current_pipeline_json" | jq -r '.ref // empty')"
+[[ "$pipeline_ref" == "$current_ref" ]] \
+    || fail "current job and pipeline refs do not match"
 
 project_json="$(api_get "$api")"
 default_branch="$(printf '%s' "$project_json" | jq -r '.default_branch // empty')"
@@ -44,7 +52,6 @@ default_branch="$(printf '%s' "$project_json" | jq -r '.default_branch // empty'
     || fail "promotion request runs on '${current_ref:-unknown}', expected '${default_branch}'"
 [[ "$request_source" == "trigger" ]] \
     || fail "pipeline source '${request_source:-unknown}' is not a push webhook trigger"
-[[ "$request_pipeline_id" =~ ^[0-9]+$ ]] || fail "request pipeline id is missing"
 
 payload="$(<"$TRIGGER_PAYLOAD")"
 object_kind="$(printf '%s' "$payload" | jq -r '.object_kind // empty')"
@@ -67,7 +74,8 @@ pr_ref="${payload_ref#refs/heads/}"
 # Make the automatically-created pipeline easy to locate in GitLab. Naming is
 # best-effort and has no role in authorization.
 if ! curl -fsS --max-time 30 --request PUT -H "JOB-TOKEN: ${CI_JOB_TOKEN}" \
-    -F "name=Promote PR #${pr_num}" "${api}/pipelines/${request_pipeline_id}/metadata" >/dev/null; then
+    -F "name=Promote PR #${pr_num} (${payload_sha:0:8})" \
+    "${api}/pipelines/${request_pipeline_id}/metadata" >/dev/null; then
     echo "WARN: could not name request pipeline ${request_pipeline_id}" >&2
 fi
 


### PR DESCRIPTION
## Description

- Fix promotion validation on the mirror GitLab version, where `GET /job` omits the pipeline source.
- Resolve the source from the current pipeline API using the pipeline ID authenticated by the job token.
- Name request pipelines with the PR number and SHA, and child pipelines with the PR number and target environment.
- Cover both authorization paths and the request-pipeline label with regression tests.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

`bash .gitlab/ci/scripts/tests/validate_promote_request_test.sh`

Kind was not run because this changes only GitLab metadata validation, pipeline labels, and their mocked shell tests.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promotion workflows now display the pull request and target environment in child-pipeline names.

* **Bug Fixes**
  * Promotion validation now more reliably verifies pipeline sources and matching refs.
  * Invalid pipeline sources, mismatched refs, and missing or invalid pipeline identifiers are correctly rejected.
  * Pipeline metadata is retrieved consistently through the pipeline API for improved validation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->