### PR TITLE
fix(ci): recover rewritten webhook PR ref

### DIFF
--- a/.gitlab/ci/scripts/tests/validate_promote_request_test.sh
+++ b/.gitlab/ci/scripts/tests/validate_promote_request_test.sh
@@ -42,13 +42,21 @@ curl() {
             printf '{"pipeline":{"id":%s,"ref":"%s"},"user":{"id":%s}}\n' \
                 "${MOCK_CURRENT_PIPELINE_ID}" "${MOCK_CURRENT_JOB_REF}" "${MOCK_CURRENT_USER_ID}"
             ;;
-        */projects/7/pipelines\?sha=*)
+        */projects/7/pipelines\?sha=*\&page=1)
             if [[ "${MOCK_AMBIGUOUS_BUILD_REFS}" == true ]]; then
                 printf '[{"id":100,"ref":"pull-request/123","sha":"%s","source":"push"},{"id":101,"ref":"pull-request/456","sha":"%s","source":"push"}]\n' \
                     "$pr_sha" "$pr_sha"
             else
                 printf '[{"id":100,"ref":"%s","sha":"%s","source":"push"}]\n' \
                     "${MOCK_BUILD_REF}" "$pr_sha"
+            fi
+            ;;
+        */projects/7/pipelines\?sha=*\&page=2)
+            if [[ "${MOCK_SECOND_PIPELINE_PAGE}" == true ]]; then
+                printf '[{"id":200,"ref":"pull-request/456","sha":"%s","source":"push"}]\n' \
+                    "$pr_sha"
+            else
+                printf '[]\n'
             fi
             ;;
         */projects/7/pipelines/100)
@@ -142,6 +150,7 @@ run_source_validator() (
     export MOCK_BUILD_USER_ID="${TEST_BUILD_USER_ID:-7}"
     export MOCK_BUILD_REF="${TEST_BUILD_REF:-pull-request/123}"
     export MOCK_AMBIGUOUS_BUILD_REFS="${TEST_AMBIGUOUS_BUILD_REFS:-false}"
+    export MOCK_SECOND_PIPELINE_PAGE="${TEST_SECOND_PIPELINE_PAGE:-false}"
     export MOCK_BRANCH_SHA="${TEST_BRANCH_SHA:-$pr_sha}"
     export CI_JOB_TOKEN=job-token CI_API_V4_URL="${TEST_CI_API_V4_URL:-https://gitlab.example/api/v4}" CI_PROJECT_ID=7
     export NVCM_MIRROR_API_TOKEN=read-token TRIGGER_PAYLOAD="$payload_file"
@@ -198,6 +207,7 @@ TEST_OBJECT_KIND=pipeline assert_source_rejected "webhook event is not a push"
 TEST_PROJECT_ID=8 assert_source_rejected "webhook project does not match"
 TEST_REF=refs/heads/main assert_source_rejected "is not a PR ref or GitLab-rewritten default branch"
 TEST_REF=main TEST_AMBIGUOUS_BUILD_REFS=true assert_source_rejected "matches multiple pull-request refs"
+TEST_REF=main TEST_SECOND_PIPELINE_PAGE=true assert_source_rejected "lookup spans more than one page"
 TEST_AFTER=cccccccccccccccccccccccccccccccccccccccc assert_source_rejected "after/checkout SHA mismatch"
 TEST_BUILD_USER_ID=8 assert_source_rejected "build pipeline user does not match"
 TEST_BRANCH_SHA=cccccccccccccccccccccccccccccccccccccccc assert_source_rejected "moved to"

--- a/.gitlab/ci/scripts/tests/validate_promote_request_test.sh
+++ b/.gitlab/ci/scripts/tests/validate_promote_request_test.sh
@@ -42,13 +42,18 @@ curl() {
             printf '{"pipeline":{"id":%s,"ref":"%s"},"user":{"id":%s}}\n' \
                 "${MOCK_CURRENT_PIPELINE_ID}" "${MOCK_CURRENT_JOB_REF}" "${MOCK_CURRENT_USER_ID}"
             ;;
-        */projects/7/pipelines\?ref=*)
-            printf '[{"id":100,"ref":"pull-request/123","sha":"%s","source":"push"}]\n' \
-                "$pr_sha"
+        */projects/7/pipelines\?sha=*)
+            if [[ "${MOCK_AMBIGUOUS_BUILD_REFS}" == true ]]; then
+                printf '[{"id":100,"ref":"pull-request/123","sha":"%s","source":"push"},{"id":101,"ref":"pull-request/456","sha":"%s","source":"push"}]\n' \
+                    "$pr_sha" "$pr_sha"
+            else
+                printf '[{"id":100,"ref":"%s","sha":"%s","source":"push"}]\n' \
+                    "${MOCK_BUILD_REF}" "$pr_sha"
+            fi
             ;;
         */projects/7/pipelines/100)
-            printf '{"ref":"pull-request/123","sha":"%s","status":"success","source":"push","user":{"id":7}}\n' \
-                "$pr_sha" \
+            printf '{"ref":"%s","sha":"%s","status":"success","source":"push","user":{"id":7}}\n' \
+                "${MOCK_BUILD_REF}" "$pr_sha" \
                 | jq --arg status "${MOCK_BUILD_STATUS:-running}" \
                     --argjson user_id "${MOCK_BUILD_USER_ID:-7}" \
                     '.status = $status | .user.id = $user_id'
@@ -135,6 +140,8 @@ run_source_validator() (
     export MOCK_CURRENT_JOB_REF="${TEST_CURRENT_JOB_REF:-main}"
     export MOCK_CURRENT_PIPELINE_REF="${TEST_CURRENT_PIPELINE_REF:-main}"
     export MOCK_BUILD_USER_ID="${TEST_BUILD_USER_ID:-7}"
+    export MOCK_BUILD_REF="${TEST_BUILD_REF:-pull-request/123}"
+    export MOCK_AMBIGUOUS_BUILD_REFS="${TEST_AMBIGUOUS_BUILD_REFS:-false}"
     export MOCK_BRANCH_SHA="${TEST_BRANCH_SHA:-$pr_sha}"
     export CI_JOB_TOKEN=job-token CI_API_V4_URL="${TEST_CI_API_V4_URL:-https://gitlab.example/api/v4}" CI_PROJECT_ID=7
     export NVCM_MIRROR_API_TOKEN=read-token TRIGGER_PAYLOAD="$payload_file"
@@ -180,6 +187,8 @@ assert_source_rejected() {
 }
 
 run_source_validator
+TEST_AMBIGUOUS_BUILD_REFS=true run_source_validator
+TEST_REF=main run_source_validator
 run_final_validator
 TEST_ARTIFACT_DIRECT=true run_final_validator
 TEST_CI_API_V4_URL=http://gitlab.example/api/v4 assert_source_rejected "CI_API_V4_URL must use HTTPS"
@@ -187,7 +196,8 @@ TEST_CURRENT_SOURCE=web assert_source_rejected "pipeline source 'web' is not a p
 TEST_CURRENT_PIPELINE_REF=other assert_source_rejected "current job and pipeline refs do not match"
 TEST_OBJECT_KIND=pipeline assert_source_rejected "webhook event is not a push"
 TEST_PROJECT_ID=8 assert_source_rejected "webhook project does not match"
-TEST_REF=refs/heads/main assert_source_rejected "is not refs/heads/pull-request/<number>"
+TEST_REF=refs/heads/main assert_source_rejected "is not a PR ref or GitLab-rewritten default branch"
+TEST_REF=main TEST_AMBIGUOUS_BUILD_REFS=true assert_source_rejected "matches multiple pull-request refs"
 TEST_AFTER=cccccccccccccccccccccccccccccccccccccccc assert_source_rejected "after/checkout SHA mismatch"
 TEST_BUILD_USER_ID=8 assert_source_rejected "build pipeline user does not match"
 TEST_BRANCH_SHA=cccccccccccccccccccccccccccccccccccccccc assert_source_rejected "moved to"

--- a/.gitlab/ci/scripts/validate_promote_source_pipeline.sh
+++ b/.gitlab/ci/scripts/validate_promote_source_pipeline.sh
@@ -63,21 +63,41 @@ payload_user_id="$(printf '%s' "$payload" | jq -r '.user_id // empty')"
 
 [[ "$object_kind" == "push" ]] || fail "webhook event is not a push"
 [[ "$payload_project_id" == "$CI_PROJECT_ID" ]] || fail "webhook project does not match this project"
-[[ "$payload_ref" =~ ^refs/heads/pull-request/([0-9]+)$ ]] \
-    || fail "webhook ref '${payload_ref}' is not refs/heads/pull-request/<number>"
-pr_num="${BASH_REMATCH[1]}"
-pr_ref="${payload_ref#refs/heads/}"
+expected_pr_ref=""
+if [[ "$payload_ref" =~ ^refs/heads/pull-request/[0-9]+$ ]]; then
+    expected_pr_ref="${payload_ref#refs/heads/}"
+elif [[ "$payload_ref" != "$default_branch" ]]; then
+    fail "webhook ref '${payload_ref}' is not a PR ref or GitLab-rewritten default branch"
+fi
 [[ "$payload_sha" =~ ^[0-9a-f]{40}$ ]] || fail "webhook SHA is not a full lowercase Git SHA"
 [[ "$payload_after" == "$payload_sha" ]] || fail "webhook after/checkout SHA mismatch"
 [[ "$payload_user_id" =~ ^[0-9]+$ ]] || fail "webhook user id is missing or invalid"
 
-# Make the automatically-created pipeline easy to locate in GitLab. Naming is
-# best-effort and has no role in authorization.
-if ! curl -fsS --max-time 30 --request PUT -H "JOB-TOKEN: ${CI_JOB_TOKEN}" \
-    -F "name=Promote PR #${pr_num} (${payload_sha:0:8})" \
-    "${api}/pipelines/${request_pipeline_id}/metadata" >/dev/null; then
-    echo "WARN: could not name request pipeline ${request_pipeline_id}" >&2
-fi
+create_deadline=$((SECONDS + create_timeout))
+build_pipeline_id=""
+pr_ref=""
+while [[ -z "$build_pipeline_id" ]]; do
+    # GitLab 17.4 replaces the webhook ref in TRIGGER_PAYLOAD with the trigger
+    # URL's target ref. Recover the PR ref from the push pipeline bound to the
+    # webhook SHA, and reject ambiguous matches instead of guessing.
+    pipelines_json="$(api_get "${api}/pipelines?sha=${payload_sha}&source=push&order_by=id&sort=desc&per_page=100")"
+    matching_pipelines="$(printf '%s' "$pipelines_json" \
+        | jq -c --arg expected_ref "$expected_pr_ref" --arg sha "$payload_sha" \
+            '[.[] | select(.sha == $sha and .source == "push"
+                and ((.ref // "") | test("^pull-request/[0-9]+$"))
+                and ($expected_ref == "" or .ref == $expected_ref))]')"
+    matching_ref_count="$(printf '%s' "$matching_pipelines" | jq -r '[.[].ref] | unique | length')"
+    (( matching_ref_count <= 1 )) \
+        || fail "webhook SHA matches multiple pull-request refs"
+    build_pipeline_id="$(printf '%s' "$matching_pipelines" | jq -r 'sort_by(.id) | last | .id // empty')"
+    pr_ref="$(printf '%s' "$matching_pipelines" | jq -r 'sort_by(.id) | last | .ref // empty')"
+    [[ -n "$build_pipeline_id" ]] && break
+    (( SECONDS < create_deadline )) || fail "no PR build pipeline appeared within ${create_timeout}s"
+    sleep "$poll_interval"
+done
+[[ "$build_pipeline_id" =~ ^[0-9]+$ ]] || fail "build pipeline id is invalid"
+[[ "$pr_ref" =~ ^pull-request/([0-9]+)$ ]] || fail "build pipeline PR ref is invalid"
+pr_num="${BASH_REMATCH[1]}"
 
 encoded_ref="$(printf '%s' "$pr_ref" | jq -sRr @uri)"
 assert_current_branch_head() {
@@ -87,20 +107,7 @@ assert_current_branch_head() {
     [[ "$branch_sha" == "$payload_sha" ]] \
         || fail "${pr_ref} moved to '${branch_sha:-unknown}' before its promotion request was ready"
 }
-
-create_deadline=$((SECONDS + create_timeout))
-build_pipeline_id=""
-while [[ -z "$build_pipeline_id" ]]; do
-    assert_current_branch_head
-    pipelines_json="$(api_get "${api}/pipelines?ref=${encoded_ref}&sha=${payload_sha}&source=push&order_by=id&sort=desc&per_page=20")"
-    build_pipeline_id="$(printf '%s' "$pipelines_json" \
-        | jq -r --arg ref "$pr_ref" --arg sha "$payload_sha" \
-            '[.[] | select(.ref == $ref and .sha == $sha and .source == "push")] | sort_by(.id) | last | .id // empty')"
-    [[ -n "$build_pipeline_id" ]] && break
-    (( SECONDS < create_deadline )) || fail "no PR build pipeline appeared within ${create_timeout}s"
-    sleep "$poll_interval"
-done
-[[ "$build_pipeline_id" =~ ^[0-9]+$ ]] || fail "build pipeline id is invalid"
+assert_current_branch_head
 
 build_pipeline_json="$(api_get "${api}/pipelines/${build_pipeline_id}")"
 build_ref="$(printf '%s' "$build_pipeline_json" | jq -r '.ref // empty')"
@@ -113,6 +120,14 @@ build_user_id="$(printf '%s' "$build_pipeline_json" | jq -r '.user.id // empty')
 [[ "$build_user_id" == "$payload_user_id" ]] \
     || fail "build pipeline user does not match the mirror-push webhook user"
 assert_current_branch_head
+
+# Make the automatically-created pipeline easy to locate in GitLab. Naming is
+# best-effort and has no role in authorization.
+if ! curl -fsS --max-time 30 --request PUT -H "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+    -F "name=Promote PR #${pr_num} (${payload_sha:0:8})" \
+    "${api}/pipelines/${request_pipeline_id}/metadata" >/dev/null; then
+    echo "WARN: could not name request pipeline ${request_pipeline_id}" >&2
+fi
 
 {
     echo "VERIFIED_PROMOTE_PR=${pr_num}"

--- a/.gitlab/ci/scripts/validate_promote_source_pipeline.sh
+++ b/.gitlab/ci/scripts/validate_promote_source_pipeline.sh
@@ -80,7 +80,12 @@ while [[ -z "$build_pipeline_id" ]]; do
     # GitLab 17.4 replaces the webhook ref in TRIGGER_PAYLOAD with the trigger
     # URL's target ref. Recover the PR ref from the push pipeline bound to the
     # webhook SHA, and reject ambiguous matches instead of guessing.
-    pipelines_json="$(api_get "${api}/pipelines?sha=${payload_sha}&source=push&order_by=id&sort=desc&per_page=100")"
+    pipelines_query="${api}/pipelines?sha=${payload_sha}&source=push&order_by=id&sort=desc&per_page=100"
+    pipelines_json="$(api_get "${pipelines_query}&page=1")"
+    next_page_json="$(api_get "${pipelines_query}&page=2")"
+    next_page_count="$(printf '%s' "$next_page_json" | jq -r 'length')"
+    (( next_page_count == 0 )) \
+        || fail "webhook SHA pipeline lookup spans more than one page"
     matching_pipelines="$(printf '%s' "$pipelines_json" \
         | jq -c --arg expected_ref "$expected_pr_ref" --arg sha "$payload_sha" \
             '[.[] | select(.sha == $sha and .source == "push"


### PR DESCRIPTION
## Description

- Handle GitLab 17.4 rewriting the webhook payload ref to the trigger target (`main`).
- Recover the PR ref from the GitLab-verified push pipeline at the webhook SHA.
- Preserve the original PR ref when GitLab supplies it and reject ambiguous matches.
- Add regression coverage for both payload shapes and ambiguity handling.

## Validation

- [x] Standard CI passes.
- [x] Kind integration passes, or this PR explains why it was not run.

`bash .gitlab/ci/scripts/tests/validate_promote_request_test.sh`

Kind was not run because this changes only GitLab webhook metadata validation and its mocked shell tests.

## Checklist

- [x] I am familiar with the contributing guidelines in `CONTRIBUTING.md`.
- [x] Commits are signed off for DCO compliance.
- [x] New or existing tests cover these changes, or the PR explains why tests are not needed.
- [x] Documentation is updated for user-facing behavior changes.
- [x] Generated artifacts are updated when applicable, such as OpenAPI specs, docs screenshots, or Helm/rendered outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved promotion validation for pull request references and GitLab-rewritten default-branch references.
  * Build pipelines are matched using the webhook commit and push source.
  * Ambiguous pull request matches are rejected instead of being accepted incorrectly.
  * Validation now safely handles paginated pipeline results and rejects conflicting matches.
  * Branch-head checks run at the correct stage of validation.
  * Pipeline status is monitored until the validation timeout, with improved coverage for default-branch and ambiguous-reference scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->