### PR TITLE
docs: fix Nautobot app repository links and link upstream Nautobot project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest stable release](https://img.shields.io/github/v/release/dsx-ai-factory/nv-config-manager?display_name=tag&label=stable&sort=semver)](https://github.com/dsx-ai-factory/nv-config-manager/releases/latest)
 [![Latest release candidate](https://img.shields.io/github/v/tag/dsx-ai-factory/nv-config-manager?filter=*-rc.*&label=rc&sort=date&color=orange)](https://github.com/dsx-ai-factory/nv-config-manager/tags)
 
-NVIDIA Config Manager (NVCM) is an open-source network automation and configuration management platform for large-scale datacenter operations. It combines a pluggable DCIM provider, event-driven rendering, ZTP, DHCP, workflow automation, and configuration storage behind a single Helm deployment. Nautobot is the bundled reference provider and default deployment, not a core-service dependency.
+NVIDIA Config Manager (NVCM) is an open-source network automation and configuration management platform for large-scale datacenter operations. It combines a pluggable DCIM provider, event-driven rendering, ZTP, DHCP, workflow automation, and configuration storage behind a single Helm deployment. [Nautobot](https://github.com/nautobot/nautobot) is the bundled reference provider and default deployment, not a core-service dependency.
 
 NVCM is currently in Developer Preview and is not recommended for production use.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -189,10 +189,10 @@ The following packages are dependencies of the Nautobot component (`components/n
 | Package | License | URL |
 |---------|---------|-----|
 | nautobot | Apache-2.0 | https://github.com/nautobot/nautobot |
-| nautobot-fsus | Apache-2.0 | https://github.com/nautobot/nautobot-app-fsus |
+| nautobot-fsus | Apache-2.0 | https://github.com/NVIDIA/nautobot-app-fsus |
 | nautobot-firewall-models | Apache-2.0 | https://github.com/nautobot/nautobot-app-firewall-models |
 | nautobot-design-builder | Apache-2.0 | https://github.com/nautobot/nautobot-app-design-builder |
-| nautobot-bgp-models | Apache-2.0 | https://github.com/nautobot/nautobot-plugin-bgp-models |
+| nautobot-bgp-models | Apache-2.0 | https://github.com/nautobot/nautobot-app-bgp-models |
 | pyasn1 | BSD-2-Clause | https://github.com/pyasn1/pyasn1 |
 
 ---

--- a/docs/nautobot/index.mdx
+++ b/docs/nautobot/index.mdx
@@ -10,7 +10,7 @@ The pages in this section walk you through the core concepts and objects you wil
 
 ## What is Nautobot, and Why Does Config Manager Use It?
 
-Nautobot is a network source of truth and network automation platform. In the Config Manager ecosystem, Nautobot serves as the central repository for all information about your network infrastructure:
+[Nautobot](https://docs.nautobot.com/) is a network source of truth and network automation platform. In the Config Manager ecosystem, Nautobot serves as the central repository for all information about your network infrastructure:
 
 - **Physical Infrastructure**: What equipment you have (switches, servers), where it is located (datacenters, racks), and how it is connected (cables, interfaces)
 - **Logical Configuration**: IP addresses, VLANs, routing information, and device roles

--- a/docs/nautobot/nautobot-integration.mdx
+++ b/docs/nautobot/nautobot-integration.mdx
@@ -23,10 +23,10 @@ The Config Manager Nautobot image enables the following Nautobot apps in `nautob
 | :----------- | :---------- |
 | `nv_config_manager` | Config Manager-specific models, jobs, and integration points |
 | `nautobot_fsus` | Field-serviceable unit tracking |
-| `nautobot_firewall_models` | Firewall and security policy data models |
-| `nautobot_design_builder` | Design and job framework used by bootstrap and custom data-loading flows |
+| [`nautobot_firewall_models`](https://github.com/nautobot/nautobot-app-firewall-models) | Firewall and security policy data models |
+| [`nautobot_design_builder`](https://github.com/nautobot/nautobot-app-design-builder) | Design and job framework used by bootstrap and custom data-loading flows |
 | `nautobot_nvdatamodels` | NVIDIA-specific data models |
-| `nautobot_bgp_models` | BGP data models |
+| [`nautobot_bgp_models`](https://github.com/nautobot/nautobot-app-bgp-models) | BGP data models |
 | `nautobot_app_overlays` | Overlay network data models |
 
 The image also includes the `nautobot-broker-nats` package for Nautobot event broker integration. That package is not listed in `PLUGINS`; it is registered by the Nautobot configuration when NATS is configured.


### PR DESCRIPTION
  ## Description

  Docs-only change. Fixes two incorrect repository URLs in `THIRD_PARTY_LICENSES.md` and adds upstream links for the Nautobot
  project and the community Nautobot apps it bundles.

  **Corrections in `THIRD_PARTY_LICENSES.md`:**

  - `nautobot-fsus` pointed at `github.com/nautobot/nautobot-app-fsus`, which does not exist (404). The app is published by NVIDIA at `github.com/NVIDIA/nautobot-app-fsus`.
  - `nautobot-bgp-models` pointed at the old `nautobot-plugin-bgp-models` name. The repository has been renamed to
  `nautobot-app-bgp-models`; the old URL redirects today but the entry now uses the canonical name.

  **New links:**

  - `docs/nautobot/nautobot-integration.mdx`: the three community apps in the apps table (`nautobot_firewall_models`,
  `nautobot_design_builder`, `nautobot_bgp_models`) now link to their upstream repositories under the `nautobot` GitHub
  organization. NVIDIA-authored and in-repo apps are left as plain text.
  - `docs/nautobot/index.mdx`: the first mention of Nautobot in "What is Nautobot" links to the upstream documentation at
  docs.nautobot.com.
  - `README.md`: "Nautobot is the bundled reference provider" links to the upstream project repository.

  Disclosure: I work at Network to Code, the company that maintains Nautobot and the three community apps linked above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links to the Nautobot GitHub repository and official documentation.
  * Updated integration documentation with repository links for supported Nautobot applications.
  * Corrected the repository URL listed for the `nautobot-app-bgp-models` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->